### PR TITLE
Update tools to industrial automation

### DIFF
--- a/app/api/product_manuals/[product_id]/route.ts
+++ b/app/api/product_manuals/[product_id]/route.ts
@@ -1,0 +1,18 @@
+export async function GET(
+  request: Request,
+  { params }: { params: { product_id: string } }
+) {
+  try {
+    const { product_id } = params;
+    return new Response(
+      JSON.stringify({
+        product_id,
+        manual_url: `/manuals/${product_id}.pdf`,
+      }),
+      { status: 200 }
+    );
+  } catch (error) {
+    console.error("Error fetching product manual:", error);
+    return new Response("Error fetching product manual", { status: 500 });
+  }
+}

--- a/app/api/service_visits/schedule/route.ts
+++ b/app/api/service_visits/schedule/route.ts
@@ -1,0 +1,15 @@
+export async function POST(request: Request) {
+  try {
+    const { equipment_id, preferred_date, issue_description } = await request.json();
+    return new Response(
+      JSON.stringify({
+        message: `Service visit scheduled for equipment ${equipment_id} on ${preferred_date}`,
+        issue_description,
+      }),
+      { status: 200 }
+    );
+  } catch (error) {
+    console.error("Error scheduling service visit:", error);
+    return new Response("Error scheduling service visit", { status: 500 });
+  }
+}

--- a/app/api/warranty_claims/submit/route.ts
+++ b/app/api/warranty_claims/submit/route.ts
@@ -1,0 +1,16 @@
+export async function POST(request: Request) {
+  try {
+    const { product_id, purchase_date, issue } = await request.json();
+    return new Response(
+      JSON.stringify({
+        message: `Warranty claim submitted for product ${product_id}`,
+        purchase_date,
+        issue,
+      }),
+      { status: 200 }
+    );
+  } catch (error) {
+    console.error("Error submitting warranty claim:", error);
+    return new Response("Error submitting warranty claim", { status: 500 });
+  }
+}

--- a/config/constants.ts
+++ b/config/constants.ts
@@ -4,11 +4,11 @@ export const MODEL = "gpt-4o";
 
 // Developer prompt for the assistant
 export const DEVELOPER_PROMPT = `
-You are an assistant helping a customer service representative named ${AGENT_NAME}.
-You are helping customers with their queries. Respond as if you were ${AGENT_NAME}.
+You are an assistant helping a technical support representative named ${AGENT_NAME}.
+The company provides industrial electrical automation equipment. Respond as if you were ${AGENT_NAME}.
 
 If the customer has general queries, search the knowledge base to find a relevant answer.
-If the customer doesn't provide a specific order ID, fetch their order history using the get_order_history tool. 
+Use “request_product_manual” when a customer needs documentation, “schedule_service_visit” for on-site support and “submit_warranty_claim” for faulty hardware under warranty.
 
 If there is a need to take action, use the tools at your disposal to help fulfill the request or suggest actions to the customer service representative.
 Some actions will require validation from the customer service representative, so don't assume that the action has been taken. Wait for an assistant message saying the action has been executed to confirm anything to the user.
@@ -19,7 +19,7 @@ Be attentive to what happens after to communicate the outcome to the customer.
 
 // Initial message that will be displayed in the chat
 export const INITIAL_MESSAGE = `
-Hi, I'm ${AGENT_NAME}, your support representative. How can I help you today?
+Hi, I'm ${AGENT_NAME} from the industrial automation support team. How can I assist you with your equipment today?
 `;
 
 // Replace with the vector store ID you get after initializing the vector store

--- a/config/functions.ts
+++ b/config/functions.ts
@@ -1,239 +1,66 @@
 // Functions mapping to tool calls
-// Define one function per tool call - each tool call should have a matching function
-// Parameters for a tool call are passed as an object to the corresponding function
+// Define one function per tool. Parameters for a tool call are passed as an object
 
-export const get_order = async ({ order_id }: { order_id: string }) => {
+export const schedule_service_visit = async ({
+  equipment_id,
+  preferred_date,
+  issue_description,
+}: {
+  equipment_id: string;
+  preferred_date: string;
+  issue_description: string;
+}) => {
   try {
-    const res = await fetch(`/api/orders/${order_id}`).then((res) =>
-      res.json()
-    );
-    return res;
-  } catch (error) {
-    console.error(error);
-    return { error: "Failed to get order" };
-  }
-};
-
-export const get_order_history = async ({ user_id }: { user_id: string }) => {
-  try {
-    const res = await fetch(`/api/users/${user_id}/order_history`).then((res) =>
-      res.json()
-    );
-    return res;
-  } catch (error) {
-    console.error(error);
-    return { error: "Failed to get order history" };
-  }
-};
-
-export const cancel_order = async ({ order_id }: { order_id: string }) => {
-  try {
-    const res = await fetch(`/api/orders/${order_id}/cancel`, {
+    const res = await fetch(`/api/service_visits/schedule`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
       },
+      body: JSON.stringify({ equipment_id, preferred_date, issue_description }),
     }).then((res) => res.json());
     return res;
   } catch (error) {
     console.error(error);
-    return { error: "Failed to cancel order" };
+    return { error: "Failed to schedule service visit" };
   }
 };
 
-export const reset_password = async ({ user_id }: { user_id: string }) => {
+export const request_product_manual = async ({ product_id }: { product_id: string }) => {
   try {
-    const res = await fetch(`/api/users/${user_id}/reset_password`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({}),
-    }).then((res) => res.json());
+    const res = await fetch(`/api/product_manuals/${product_id}`).then((res) => res.json());
     return res;
   } catch (error) {
     console.error(error);
-    return { error: "Failed to reset password" };
+    return { error: "Failed to fetch product manual" };
   }
 };
 
-export const send_replacement = async ({
+export const submit_warranty_claim = async ({
   product_id,
-  order_id,
+  purchase_date,
+  issue,
 }: {
   product_id: string;
-  order_id: string;
+  purchase_date: string;
+  issue: string;
 }) => {
   try {
-    const res = await fetch(`/api/orders/${order_id}/send_replacement`, {
+    const res = await fetch(`/api/warranty_claims/submit`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ product_id }),
+      body: JSON.stringify({ product_id, purchase_date, issue }),
     }).then((res) => res.json());
     return res;
   } catch (error) {
     console.error(error);
-    return { error: "Failed to send replacement" };
-  }
-};
-
-export const create_refund = async ({
-  order_id,
-  amount,
-  reason,
-}: {
-  order_id: string;
-  amount: number;
-  reason: string;
-}) => {
-  try {
-    const res = await fetch(`/api/orders/${order_id}/create_refund`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ amount, reason }),
-    }).then((res) => res.json());
-    return res;
-  } catch (error) {
-    console.error(error);
-    return { error: "Failed to create refund" };
-  }
-};
-
-export const issue_voucher = async ({
-  user_id,
-  amount,
-  reason,
-}: {
-  user_id: string;
-  reason: string;
-  amount: number;
-}) => {
-  try {
-    const res = await fetch(`/api/vouchers/create`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ user_id, reason, amount }),
-    }).then((res) => res.json());
-    return res;
-  } catch (error) {
-    console.error(error);
-    return { error: "Failed to issue voucher" };
-  }
-};
-
-export const create_return = async ({
-  order_id,
-  product_ids,
-}: {
-  order_id: string;
-  product_ids: string[];
-}) => {
-  try {
-    const res = await fetch(`/api/orders/${order_id}/create_return`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ product_ids }),
-    }).then((res) => res.json());
-    return res;
-  } catch (error) {
-    console.error(error);
-    return { error: "Failed to create return" };
-  }
-};
-
-export const create_complaint = async ({
-  user_id,
-  type,
-  details,
-  order_id,
-}: {
-  user_id: string;
-  type: string;
-  details: string;
-  order_id: string;
-}) => {
-  try {
-    const res = await fetch(`/api/complaints/create`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ user_id, type, details, order_id }),
-    }).then((res) => res.json());
-    return res;
-  } catch (error) {
-    console.error(error);
-    return { error: "Failed to create complaint" };
-  }
-};
-
-export const create_ticket = async ({
-  user_id,
-  type,
-  details,
-  order_id,
-}: {
-  user_id: string;
-  type: string;
-  details: string;
-  order_id: string;
-}) => {
-  try {
-    const res = await fetch(`/api/tickets/create`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ user_id, type, details, order_id }),
-    }).then((res) => res.json());
-    return res;
-  } catch (error) {
-    console.error(error);
-    return { error: "Failed to create ticket" };
-  }
-};
-
-export const update_info = async ({
-  user_id,
-  info,
-}: {
-  user_id: string;
-  info: { field: string; value: string };
-}) => {
-  try {
-    const res = await fetch(`/api/users/${user_id}/update_info`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ info }),
-    }).then((res) => res.json());
-    return res;
-  } catch (error) {
-    console.error(error);
-    return { error: "Failed to update info" };
+    return { error: "Failed to submit warranty claim" };
   }
 };
 
 export const functionsMap = {
-  get_order: get_order,
-  get_order_history: get_order_history,
-  cancel_order: cancel_order,
-  reset_password: reset_password,
-  send_replacement: send_replacement,
-  create_refund: create_refund,
-  issue_voucher: issue_voucher,
-  create_return: create_return,
-  create_complaint: create_complaint,
-  update_info: update_info,
-  create_ticket: create_ticket,
-  // add more functions as needed
+  schedule_service_visit,
+  request_product_manual,
+  submit_warranty_claim,
 };

--- a/config/tools-list.ts
+++ b/config/tools-list.ts
@@ -1,191 +1,54 @@
 // List of tools available to the agent
 // No need to include the top-level wrapper object as it is added in lib/tools/tools.ts
-// More information on function calling: https://platform.openai.com/docs/guides/function-calling
 
 export const toolsList = [
   {
-    name: "get_order",
+    name: "schedule_service_visit",
     parameters: {
-      order_id: {
+      equipment_id: {
         type: "string",
-        description: "Order ID to get details for",
+        description: "ID of the equipment that requires service",
+      },
+      preferred_date: {
+        type: "string",
+        description: "Preferred date for the visit",
+      },
+      issue_description: {
+        type: "string",
+        description: "Description of the issue",
       },
     },
   },
   {
-    name: "get_order_history",
-    parameters: {
-      user_id: {
-        type: "string",
-        description: "User ID to get order history for",
-      },
-    },
-  },
-  {
-    name: "cancel_order",
-    parameters: {
-      order_id: {
-        type: "string",
-        description: "Order ID to cancel",
-      },
-    },
-  },
-  {
-    name: "reset_password",
-    parameters: {
-      user_id: {
-        type: "string",
-        description: "User ID to send password reset email to",
-      },
-    },
-  },
-  {
-    name: "send_replacement",
+    name: "request_product_manual",
     parameters: {
       product_id: {
         type: "string",
-        description: "Product ID to send replacement for",
-      },
-      order_id: {
-        type: "string",
-        description: "Order ID to send replacement for",
+        description: "Product ID to retrieve the manual for",
       },
     },
   },
   {
-    name: "create_refund",
+    name: "submit_warranty_claim",
     parameters: {
-      order_id: {
+      product_id: {
         type: "string",
-        description: "Order ID to create refund for",
+        description: "Product ID for the warranty claim",
       },
-      amount: {
-        type: "number",
-        description: "Amount to refund",
-      },
-      reason: {
+      purchase_date: {
         type: "string",
-        description: "Reason for refund",
+        description: "Date of purchase",
+      },
+      issue: {
+        type: "string",
+        description: "Description of the problem",
       },
     },
   },
-  {
-    name: "issue_voucher",
-    parameters: {
-      user_id: {
-        type: "string",
-        description: "User ID to issue voucher for",
-      },
-      amount: {
-        type: "number",
-        description: "Amount to issue voucher for",
-      },
-      reason: {
-        type: "string",
-        description: "Reason for issuing voucher",
-      },
-    },
-  },
-  {
-    name: "create_return",
-    parameters: {
-      order_id: {
-        type: "string",
-        description: "Order ID to create return for",
-      },
-      product_ids: {
-        type: "array",
-        description: "Product IDs to create return for",
-        items: {
-          type: "string",
-        },
-      },
-    },
-  },
-  {
-    name: "create_complaint",
-    parameters: {
-      user_id: {
-        type: "string",
-        description: "User ID to create complaint for",
-      },
-      type: {
-        type: "string",
-        description: "Type of complaint",
-        enum: ["product_quality", "order_delay", "delivery_issues", "other"],
-      },
-      details: {
-        type: "string",
-        description: "Details of the complaint",
-      },
-      order_id: {
-        type: "string",
-        description:
-          "Order ID linked to the complaint, N/A if not linked to an order",
-      },
-    },
-  },
-  {
-    name: "create_ticket",
-    parameters: {
-      user_id: {
-        type: "string",
-        description: "User ID to create ticket for",
-      },
-      type: {
-        type: "string",
-        description: "Type of ticket",
-        enum: ["bug_reported", "damaged_product", "other"],
-      },
-      details: {
-        type: "string",
-        description: "Details of the ticket",
-      },
-      order_id: {
-        type: "string",
-        description:
-          "Order ID linked to the ticket, N/A if not linked to an order",
-      },
-    },
-  },
-  {
-    name: "update_info",
-    parameters: {
-      user_id: {
-        type: "string",
-        description: "User ID to update information for",
-      },
-      info: {
-        type: "object",
-        description: "Information to update",
-        properties: {
-          field: {
-            type: "string",
-            description: "Field to update",
-            enum: ["email", "phone", "address", "name"],
-          },
-          value: {
-            type: "string",
-            description: "Value to update",
-          },
-        },
-        additionalProperties: false,
-        required: ["field", "value"],
-      },
-    },
-  },
-  // add more tools as needed
 ];
 
 // Tools that will need to be confirmed by the human representative before execution
-// Ex: "get_order" and "create_ticket" are low-risk so they can be automatically executed
 export const agentTools = [
-  "cancel_order",
-  "reset_password",
-  "send_replacement",
-  "create_refund",
-  "issue_voucher",
-  "create_return",
-  "create_complaint",
-  "update_info",
+  "schedule_service_visit",
+  "submit_warranty_claim",
 ];


### PR DESCRIPTION
## Summary
- revamp tool list for industrial automation tasks
- add new API endpoints for service visits, manuals and warranty claims
- update function map and handlers
- mark sensitive tools requiring human confirmation
- rewrite prompts for the industrial automation domain

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686439c9b1d48333827a5ce7140bd9cd