### PR TITLE
Add order management tools

### DIFF
--- a/app/api/orders/[order_id]/cancel/route.ts
+++ b/app/api/orders/[order_id]/cancel/route.ts
@@ -3,8 +3,7 @@ export async function POST(
   context: { params: { order_id: string } }
 ) {
   try {
-    const { params } = context;
-    const { order_id } = await params;
+    const { order_id } = context.params;
     // Simulate order cancellation
     return new Response(
       JSON.stringify({ message: `Order ${order_id} cancelled successfully` }),

--- a/app/api/orders/[order_id]/create_refund/route.ts
+++ b/app/api/orders/[order_id]/create_refund/route.ts
@@ -1,9 +1,9 @@
 export async function POST(
   request: Request,
-  { params }: { params: { order_id: string } }
+  context: { params: { order_id: string } }
 ) {
   try {
-    const { order_id } = params;
+    const { order_id } = context.params;
     const { amount, reason } = await request.json();
     // Simulate refund creation
     return new Response(

--- a/app/api/orders/[order_id]/create_return/route.ts
+++ b/app/api/orders/[order_id]/create_return/route.ts
@@ -1,9 +1,9 @@
 export async function POST(
   request: Request,
-  { params }: { params: { order_id: string } }
+  context: { params: { order_id: string } }
 ) {
   try {
-    const { order_id } = params;
+    const { order_id } = context.params;
     const { product_ids } = await request.json();
     // Simulate return initiation
     return new Response(

--- a/app/api/orders/[order_id]/route.ts
+++ b/app/api/orders/[order_id]/route.ts
@@ -2,10 +2,10 @@ import { DEMO_ORDERS } from "@/config/demoData";
 
 export async function GET(
   request: Request,
-  { params }: { params: { order_id: string } }
+  context: { params: { order_id: string } }
 ) {
   try {
-    const { order_id } = params;
+    const { order_id } = context.params;
     const order = DEMO_ORDERS.find((order) => order.id === order_id);
     if (!order) {
       return new Response(JSON.stringify({ error: "Order not found" }), {

--- a/app/api/orders/[order_id]/send_replacement/route.ts
+++ b/app/api/orders/[order_id]/send_replacement/route.ts
@@ -1,9 +1,9 @@
 export async function POST(
   request: Request,
-  { params }: { params: { order_id: string } }
+  context: { params: { order_id: string } }
 ) {
   try {
-    const { order_id } = params;
+    const { order_id } = context.params;
     const { product_id } = await request.json();
     // Simulate sending a replacement
     return new Response(

--- a/config/functions.ts
+++ b/config/functions.ts
@@ -59,8 +59,107 @@ export const submit_warranty_claim = async ({
   }
 };
 
+export const get_order = async ({ order_id }: { order_id: string }) => {
+  try {
+    const res = await fetch(`/api/orders/${order_id}`).then((res) => res.json());
+    return res;
+  } catch (error) {
+    console.error(error);
+    return { error: "Failed to retrieve order" };
+  }
+};
+
+export const cancel_order = async ({ order_id }: { order_id: string }) => {
+  try {
+    const res = await fetch(`/api/orders/${order_id}/cancel`, {
+      method: "POST",
+    }).then((res) => res.json());
+    return res;
+  } catch (error) {
+    console.error(error);
+    return { error: "Failed to cancel order" };
+  }
+};
+
+export const create_return = async ({
+  order_id,
+  product_ids,
+}: {
+  order_id: string;
+  product_ids: string[];
+}) => {
+  try {
+    const res = await fetch(`/api/orders/${order_id}/create_return`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ product_ids }),
+    }).then((res) => res.json());
+    return res;
+  } catch (error) {
+    console.error(error);
+    return { error: "Failed to create return" };
+  }
+};
+
+export const create_refund = async ({
+  order_id,
+  amount,
+  reason,
+}: {
+  order_id: string;
+  amount: number;
+  reason: string;
+}) => {
+  try {
+    const res = await fetch(`/api/orders/${order_id}/create_refund`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ amount, reason }),
+    }).then((res) => res.json());
+    return res;
+  } catch (error) {
+    console.error(error);
+    return { error: "Failed to create refund" };
+  }
+};
+
+export const create_complaint = async ({
+  user_id,
+  type,
+  details,
+  order_id,
+}: {
+  user_id: string;
+  type: string;
+  details: string;
+  order_id?: string;
+}) => {
+  try {
+    const res = await fetch(`/api/complaints/create`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ user_id, type, details, order_id }),
+    }).then((res) => res.json());
+    return res;
+  } catch (error) {
+    console.error(error);
+    return { error: "Failed to create complaint" };
+  }
+};
+
 export const functionsMap = {
   schedule_service_visit,
   request_product_manual,
   submit_warranty_claim,
+  get_order,
+  cancel_order,
+  create_return,
+  create_refund,
+  create_complaint,
 };

--- a/config/tools-list.ts
+++ b/config/tools-list.ts
@@ -45,10 +45,83 @@ export const toolsList = [
       },
     },
   },
+  {
+    name: "get_order",
+    parameters: {
+      order_id: {
+        type: "string",
+        description: "Order ID to retrieve",
+      },
+    },
+  },
+  {
+    name: "cancel_order",
+    parameters: {
+      order_id: {
+        type: "string",
+        description: "Order ID to cancel",
+      },
+    },
+  },
+  {
+    name: "create_return",
+    parameters: {
+      order_id: {
+        type: "string",
+        description: "Order ID for the return",
+      },
+      product_ids: {
+        type: "array",
+        description: "List of product IDs to return",
+      },
+    },
+  },
+  {
+    name: "create_refund",
+    parameters: {
+      order_id: {
+        type: "string",
+        description: "Order ID for the refund",
+      },
+      amount: {
+        type: "number",
+        description: "Refund amount",
+      },
+      reason: {
+        type: "string",
+        description: "Reason for the refund",
+      },
+    },
+  },
+  {
+    name: "create_complaint",
+    parameters: {
+      user_id: {
+        type: "string",
+        description: "ID of the complaining user",
+      },
+      type: {
+        type: "string",
+        description: "Complaint category",
+      },
+      details: {
+        type: "string",
+        description: "Complaint details",
+      },
+      order_id: {
+        type: "string",
+        description: "Related order ID if any",
+      },
+    },
+  },
 ];
 
 // Tools that will need to be confirmed by the human representative before execution
 export const agentTools = [
   "schedule_service_visit",
   "submit_warranty_claim",
+  "cancel_order",
+  "create_return",
+  "create_refund",
+  "create_complaint",
 ];


### PR DESCRIPTION
## Summary
- implement tools for order and complaint management
- update available tool list and agent tools
- fix cancel order route
- revert to using `context` param in order API routes

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68644ec897e88333b20390099e81b62c