### PR TITLE
Add project and offers API endpoints

### DIFF
--- a/app/api/projects/outstanding/route.ts
+++ b/app/api/projects/outstanding/route.ts
@@ -1,0 +1,10 @@
+import { OUTSTANDING_PROJECTS } from "@/config/demoData";
+
+export async function GET() {
+  try {
+    return new Response(JSON.stringify(OUTSTANDING_PROJECTS), { status: 200 });
+  } catch (error) {
+    console.error("Error retrieving outstanding projects:", error);
+    return new Response("Error retrieving outstanding projects", { status: 500 });
+  }
+}

--- a/app/api/special_offers/route.ts
+++ b/app/api/special_offers/route.ts
@@ -1,0 +1,10 @@
+import { SPECIAL_OFFERS } from "@/config/demoData";
+
+export async function GET() {
+  try {
+    return new Response(JSON.stringify(SPECIAL_OFFERS), { status: 200 });
+  } catch (error) {
+    console.error("Error retrieving special offers:", error);
+    return new Response("Error retrieving special offers", { status: 500 });
+  }
+}

--- a/config/demoData.ts
+++ b/config/demoData.ts
@@ -155,3 +155,29 @@ export const DEMO_ORDERS = [
     ],
   },
 ];
+
+export const OUTSTANDING_PROJECTS = [
+  {
+    id: "PROJ001",
+    description: "Install new conveyor system",
+    due_date: "2024-06-30",
+  },
+  {
+    id: "PROJ002",
+    description: "Upgrade control software",
+    due_date: "2024-07-15",
+  },
+];
+
+export const SPECIAL_OFFERS = [
+  {
+    id: "OFF001",
+    title: "10% off PLC maintenance",
+    details: "Valid until 2024-07-31",
+  },
+  {
+    id: "OFF002",
+    title: "Free shipping on orders over $500",
+    details: "Valid this month",
+  },
+];

--- a/config/functions.ts
+++ b/config/functions.ts
@@ -152,6 +152,26 @@ export const create_complaint = async ({
     return { error: "Failed to create complaint" };
   }
 };
+export const get_outstanding_projects = async () => {
+  try {
+    const res = await fetch(`/api/projects/outstanding`).then((res) => res.json());
+    return res;
+  } catch (error) {
+    console.error(error);
+    return { error: "Failed to retrieve outstanding projects" };
+  }
+};
+
+export const get_special_offers = async () => {
+  try {
+    const res = await fetch(`/api/special_offers`).then((res) => res.json());
+    return res;
+  } catch (error) {
+    console.error(error);
+    return { error: "Failed to retrieve special offers" };
+  }
+};
+
 
 export const functionsMap = {
   schedule_service_visit,
@@ -162,4 +182,6 @@ export const functionsMap = {
   create_return,
   create_refund,
   create_complaint,
+  get_outstanding_projects,
+  get_special_offers,
 };

--- a/config/tools-list.ts
+++ b/config/tools-list.ts
@@ -114,6 +114,14 @@ export const toolsList = [
       },
     },
   },
+  {
+    name: "get_outstanding_projects",
+    parameters: {},
+  },
+  {
+    name: "get_special_offers",
+    parameters: {},
+  },
 ];
 
 // Tools that will need to be confirmed by the human representative before execution


### PR DESCRIPTION
## Summary
- implement `/api/projects/outstanding` and `/api/special_offers` routes
- expose `get_outstanding_projects` and `get_special_offers` tools
- add handler functions to call new APIs
- include data for outstanding projects and special offers

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68645552a7588333b2c7a45d24066f46