### PR TITLE
Add product search endpoint and tool

### DIFF
--- a/app/api/products/search/route.ts
+++ b/app/api/products/search/route.ts
@@ -1,0 +1,19 @@
+import { promises as fs } from "fs";
+import path from "path";
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const query = (searchParams.get("query") || "").toLowerCase();
+    const filePath = path.join(process.cwd(), "public/knowledge_base/products.json");
+    const file = await fs.readFile(filePath, "utf-8");
+    const products: { name: string; price: string; url: string }[] = JSON.parse(file);
+    const results = products
+      .filter((p) => p.name.toLowerCase().includes(query))
+      .slice(0, 5);
+    return new Response(JSON.stringify(results), { status: 200 });
+  } catch (error) {
+    console.error("Error searching products:", error);
+    return new Response("Error searching products", { status: 500 });
+  }
+}

--- a/config/functions.ts
+++ b/config/functions.ts
@@ -223,6 +223,18 @@ export const update_info = async ({
   }
 };
 
+export const get_products = async ({ query }: { query: string }) => {
+  try {
+    const res = await fetch(
+      `/api/products/search?query=${encodeURIComponent(query)}`
+    ).then((res) => res.json());
+    return res;
+  } catch (error) {
+    console.error(error);
+    return { error: "Failed to search products" };
+  }
+};
+
 export const functionsMap = {
   get_order: get_order,
   get_order_history: get_order_history,
@@ -235,5 +247,6 @@ export const functionsMap = {
   create_complaint: create_complaint,
   update_info: update_info,
   create_ticket: create_ticket,
+  get_products: get_products,
   // add more functions as needed
 };

--- a/config/tools-list.ts
+++ b/config/tools-list.ts
@@ -174,6 +174,15 @@ export const toolsList = [
       },
     },
   },
+  {
+    name: "get_products",
+    parameters: {
+      query: {
+        type: "string",
+        description: "Product name or partial name",
+      },
+    },
+  },
   // add more tools as needed
 ];
 

--- a/public/knowledge_base/products.json
+++ b/public/knowledge_base/products.json
@@ -1,0 +1,4 @@
+[
+  { "name": "Sample Widget", "price": "$9.99", "url": "https://example.com/widget" },
+  { "name": "Sample Gizmo",  "price": "$19.99", "url": "https://example.com/gizmo" }
+]


### PR DESCRIPTION
## Summary
- add sample products JSON data
- create `/api/products/search` endpoint for product lookup
- expose `get_products` function and tool definition

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68668e2391588333805a1d4aa1515dae