### PR TITLE
Add company about API and tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ To customize this demo you can:
 - Edit prompts, initial message and model in `config/constants.ts`
 - Edit available functions in `config/tools-list.ts`
 - Edit functions logic in `config/functions.ts`
+- Use the `get_about_us` tool to retrieve text from the company website
 - (optional) Edit the demo data in `config/demoData.ts`
 
 You can also customize the endpoints in the `/api` folder to call your own backend or external services.

--- a/app/api/company/about/route.ts
+++ b/app/api/company/about/route.ts
@@ -1,0 +1,12 @@
+export async function GET() {
+  try {
+    const res = await fetch("https://automationghana.com/new-home-2/");
+    const html = await res.text();
+    // basic stripping of HTML tags
+    const text = html.replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim();
+    return new Response(JSON.stringify({ text }), { status: 200 });
+  } catch (error) {
+    console.error("Error fetching about page:", error);
+    return new Response("Error fetching about page", { status: 500 });
+  }
+}

--- a/config/functions.ts
+++ b/config/functions.ts
@@ -235,6 +235,18 @@ export const get_products = async ({ query }: { query: string }) => {
   }
 };
 
+export const get_about_us = async ({ query }: { query: string }) => {
+  try {
+    const res = await fetch(
+      `/api/company/about?query=${encodeURIComponent(query)}`
+    ).then((res) => res.json());
+    return res;
+  } catch (error) {
+    console.error(error);
+    return { error: "Failed to get about us" };
+  }
+};
+
 export const functionsMap = {
   get_order: get_order,
   get_order_history: get_order_history,
@@ -248,5 +260,6 @@ export const functionsMap = {
   update_info: update_info,
   create_ticket: create_ticket,
   get_products: get_products,
+  get_about_us: get_about_us,
   // add more functions as needed
 };

--- a/config/tools-list.ts
+++ b/config/tools-list.ts
@@ -183,6 +183,15 @@ export const toolsList = [
       },
     },
   },
+  {
+    name: "get_about_us",
+    parameters: {
+      query: {
+        type: "string",
+        description: "Search term for the about page",
+      },
+    },
+  },
   // add more tools as needed
 ];
 


### PR DESCRIPTION
## Summary
- scrape Automation Ghana for `GET /api/company/about`
- expose `get_about_us` helper in client functions
- list `get_about_us` in available tools
- document the new tool in the README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6866e2d467d48333aec2a82a676cb574