### PR TITLE
Add about page query snippet search

### DIFF
--- a/app/api/company/about/route.ts
+++ b/app/api/company/about/route.ts
@@ -1,10 +1,25 @@
-export async function GET() {
+export async function GET(request: Request) {
   try {
+    const { searchParams } = new URL(request.url);
+    const query = searchParams.get("query")?.toLowerCase() || "";
+
     const res = await fetch("https://automationghana.com/new-home-2/");
     const html = await res.text();
     // basic stripping of HTML tags
     const text = html.replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim();
-    return new Response(JSON.stringify({ text }), { status: 200 });
+
+    const words = text.split(" ");
+    let snippet = words.slice(0, 200).join(" ");
+    if (query) {
+      const index = words.findIndex((w) => w.toLowerCase().includes(query));
+      if (index !== -1) {
+        const start = Math.max(0, index - 100);
+        const end = Math.min(words.length, index + 100);
+        snippet = words.slice(start, end).join(" ");
+      }
+    }
+
+    return new Response(JSON.stringify({ snippet }), { status: 200 });
   } catch (error) {
     console.error("Error fetching about page:", error);
     return new Response("Error fetching about page", { status: 500 });


### PR DESCRIPTION
## Summary
- accept `query` parameter in `/api/company/about` route
- search the about page text for the query
- return a short snippet of around 200 words

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6866f2fad9e08333a7cb783144199fd8