### PR TITLE
Make about-us query optional

### DIFF
--- a/config/functions.ts
+++ b/config/functions.ts
@@ -235,11 +235,12 @@ export const get_products = async ({ query }: { query: string }) => {
   }
 };
 
-export const get_about_us = async ({ query }: { query: string }) => {
+export const get_about_us = async ({ query = "" }: { query?: string }) => {
   try {
-    const res = await fetch(
-      `/api/company/about?query=${encodeURIComponent(query)}`
-    ).then((res) => res.json());
+    const url = query
+      ? `/api/company/about?query=${encodeURIComponent(query)}`
+      : "/api/company/about";
+    const res = await fetch(url).then((res) => res.json());
     return res;
   } catch (error) {
     console.error(error);

--- a/config/tools-list.ts
+++ b/config/tools-list.ts
@@ -191,6 +191,7 @@ export const toolsList = [
         description: "Search term for the about page",
       },
     },
+    required: [],
   },
   // add more tools as needed
 ];

--- a/lib/tools/tools.ts
+++ b/lib/tools/tools.ts
@@ -20,7 +20,7 @@ export const tools = [
       parameters: {
         type: "object",
         properties: { ...tool.parameters },
-        required: Object.keys(tool.parameters),
+        required: (tool as any).required ?? Object.keys(tool.parameters),
         additionalProperties: false,
       },
       strict: true,


### PR DESCRIPTION
## Summary
- allow `get_about_us` to run with or without a query
- mark `query` optional in `tools-list`
- support optional `required` fields when generating tool definitions

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68671b1ed25c8333a13530794eeb538a