### PR TITLE
Implement user profiles and sessions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 OPENAI_API_KEY=<your-openai-api-key>
+DATABASE_URL="postgresql://user:password@localhost:5432/dbname"

--- a/README.md
+++ b/README.md
@@ -140,6 +140,24 @@ You can also customize the endpoints in the `/api` folder to call your own backe
 
 If you want to use this code repository as a starting point for your own project in production, please note that this demo is not production-ready and that you would need to implement safety measures such as input guardrails, user authentication, etc.
 
+## Local database
+
+This demo can store customer profiles and chat sessions in a local PostgreSQL database using Prisma.
+
+1. Add your connection string to `.env`:
+
+   ```
+   DATABASE_URL="postgresql://<user>:<password>@localhost:5432/<dbname>"
+   ```
+
+2. Run the migrations to create the tables:
+
+   ```bash
+   npx prisma migrate deploy
+   ```
+
+The new API endpoints under `/api/users` and `/api/sessions/start` allow the agent to create or retrieve customer records and chat sessions using this database.
+
 ## Contributing
 
 You are welcome to open issues or submit PRs to improve this app, however, please note that we may not review all suggestions.

--- a/app/api/orders/[order_id]/route.ts
+++ b/app/api/orders/[order_id]/route.ts
@@ -1,4 +1,4 @@
-import { DEMO_ORDERS } from "@/config/demoData";
+import prisma from "@/lib/prisma";
 
 export async function GET(
   request: Request,
@@ -6,7 +6,7 @@ export async function GET(
 ) {
   try {
     const { order_id } = params;
-    const order = DEMO_ORDERS.find((order) => order.id === order_id);
+    const order = await prisma.order.findUnique({ where: { orderId: order_id } });
     if (!order) {
       return new Response(JSON.stringify({ error: "Order not found" }), {
         status: 404,

--- a/app/api/sessions/start/route.ts
+++ b/app/api/sessions/start/route.ts
@@ -1,0 +1,30 @@
+import prisma from "@/lib/prisma";
+
+export async function POST(request: Request) {
+  try {
+    const { email, name, phone, address } = await request.json();
+    if (!email) {
+      return new Response(JSON.stringify({ error: "Email is required" }), {
+        status: 400,
+      });
+    }
+    const user = await prisma.user.upsert({
+      where: { email },
+      update: { name, phone, address },
+      create: { email, name, phone, address },
+    });
+    let session = await prisma.chatSession.findFirst({
+      where: { userId: user.id },
+      orderBy: { createdAt: "desc" },
+    });
+    if (!session) {
+      session = await prisma.chatSession.create({
+        data: { userId: user.id, messages: [] },
+      });
+    }
+    return new Response(JSON.stringify({ user, session }), { status: 200 });
+  } catch (error) {
+    console.error("Error starting session:", error);
+    return new Response("Error starting session", { status: 500 });
+  }
+}

--- a/app/api/users/[user_id]/order_history/route.ts
+++ b/app/api/users/[user_id]/order_history/route.ts
@@ -1,4 +1,4 @@
-import { USER_INFO } from "@/config/demoData";
+import prisma from "@/lib/prisma";
 
 export async function GET(
   request: Request,
@@ -6,8 +6,8 @@ export async function GET(
 ) {
   try {
     const { user_id } = params;
-    console.log("Retrieving order history for user:", user_id);
-    return new Response(JSON.stringify(USER_INFO.order_history), {
+    const orders = await prisma.order.findMany({ where: { userId: user_id } });
+    return new Response(JSON.stringify(orders), {
       status: 200,
     });
   } catch (error) {

--- a/app/api/users/[user_id]/update_info/route.ts
+++ b/app/api/users/[user_id]/update_info/route.ts
@@ -1,3 +1,5 @@
+import prisma from "@/lib/prisma";
+
 export async function POST(
   request: Request,
   { params }: { params: { user_id: string } }
@@ -5,7 +7,10 @@ export async function POST(
   try {
     const { user_id } = params;
     const { info } = await request.json();
-    // Simulate updating user information
+    await prisma.user.update({
+      where: { id: user_id },
+      data: { [info.field]: info.value },
+    });
     return new Response(
       JSON.stringify({
         message: `User ${user_id} info updated`,

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,0 +1,43 @@
+import prisma from "@/lib/prisma";
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const email = searchParams.get("email");
+    if (!email) {
+      return new Response(JSON.stringify({ error: "Email is required" }), {
+        status: 400,
+      });
+    }
+    const user = await prisma.user.findUnique({ where: { email } });
+    if (!user) {
+      return new Response(JSON.stringify({ error: "User not found" }), {
+        status: 404,
+      });
+    }
+    return new Response(JSON.stringify(user), { status: 200 });
+  } catch (error) {
+    console.error("Error fetching user:", error);
+    return new Response("Error fetching user", { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const { email, name, phone, address } = await request.json();
+    if (!email) {
+      return new Response(JSON.stringify({ error: "Email is required" }), {
+        status: 400,
+      });
+    }
+    const user = await prisma.user.upsert({
+      where: { email },
+      update: { name, phone, address },
+      create: { email, name, phone, address },
+    });
+    return new Response(JSON.stringify(user), { status: 200 });
+  } catch (error) {
+    console.error("Error creating user:", error);
+    return new Response("Error creating user", { status: 500 });
+  }
+}

--- a/components/CustomerDetails.tsx
+++ b/components/CustomerDetails.tsx
@@ -29,6 +29,9 @@ export default function CustomerDetails() {
           value={customerDetails.id}
           className="font-mono text-xs"
         />
+        <DetailItem label="Email" value={customerDetails.email} />
+        <DetailItem label="Phone" value={customerDetails.phone} />
+        <DetailItem label="Address" value={customerDetails.address} />
         <DetailItem
           label="# Orders"
           value={customerDetails.orderNb.toString()}

--- a/config/constants.ts
+++ b/config/constants.ts
@@ -7,6 +7,11 @@ export const DEVELOPER_PROMPT = `
 You are an assistant helping a customer service representative named ${AGENT_NAME}.
 You are helping customers with their queries. Respond as if you were ${AGENT_NAME}.
 
+At the start of a conversation, request the customer's email address if it is not already known.
+Use the get_user_profile tool with this email to look up existing records.
+If no profile exists, call create_user_profile and gather their name, phone, and address when possible.
+Finally, use start_chat_session to reconnect the user with a previous session or create a new one.
+
 If the customer has general queries, search the knowledge base to find a relevant answer.
 When users ask about the company's mission, values, or history, use the get_about_us tool or search the knowledge base to provide the information.
 If the customer doesn't provide a specific order ID, fetch their order history using the get_order_history tool.

--- a/config/demoData.ts
+++ b/config/demoData.ts
@@ -8,6 +8,9 @@ export const CUSTOMER_DETAILS = {
   id: "cus_28X44",
   orderNb: 8,
   signupDate: "2023-11-28",
+  email: "janet.deer@gmail.com",
+  phone: "+1234567890",
+  address: "123 Main St, Anytown, USA",
 };
 
 export const DEFAULT_ACTION: Action = {

--- a/config/functions.ts
+++ b/config/functions.ts
@@ -248,6 +248,68 @@ export const get_about_us = async ({ query = "" }: { query?: string }) => {
   }
 };
 
+export const get_user_profile = async ({ email }: { email: string }) => {
+  try {
+    const res = await fetch(`/api/users?email=${encodeURIComponent(email)}`).then(
+      (res) => res.json()
+    );
+    return res;
+  } catch (error) {
+    console.error(error);
+    return { error: "Failed to get user profile" };
+  }
+};
+
+export const create_user_profile = async ({
+  email,
+  name,
+  phone,
+  address,
+}: {
+  email: string;
+  name?: string;
+  phone?: string;
+  address?: string;
+}) => {
+  try {
+    const res = await fetch(`/api/users`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ email, name, phone, address }),
+    }).then((res) => res.json());
+    return res;
+  } catch (error) {
+    console.error(error);
+    return { error: "Failed to create user profile" };
+  }
+};
+
+export const start_chat_session = async ({
+  email,
+  name,
+  phone,
+  address,
+}: {
+  email: string;
+  name?: string;
+  phone?: string;
+  address?: string;
+}) => {
+  try {
+    const res = await fetch(`/api/sessions/start`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, name, phone, address }),
+    }).then((res) => res.json());
+    return res;
+  } catch (error) {
+    console.error(error);
+    return { error: "Failed to start chat session" };
+  }
+};
+
 export const functionsMap = {
   get_order: get_order,
   get_order_history: get_order_history,
@@ -260,6 +322,9 @@ export const functionsMap = {
   create_complaint: create_complaint,
   update_info: update_info,
   create_ticket: create_ticket,
+  get_user_profile: get_user_profile,
+  create_user_profile: create_user_profile,
+  start_chat_session: start_chat_session,
   get_products: get_products,
   get_about_us: get_about_us,
   // add more functions as needed

--- a/config/tools-list.ts
+++ b/config/tools-list.ts
@@ -175,6 +175,33 @@ export const toolsList = [
     },
   },
   {
+    name: "get_user_profile",
+    parameters: {
+      email: {
+        type: "string",
+        description: "Email address of the customer",
+      },
+    },
+  },
+  {
+    name: "create_user_profile",
+    parameters: {
+      email: { type: "string", description: "Email address of the customer" },
+      name: { type: "string", description: "Full name of the customer" },
+      phone: { type: "string", description: "Phone number" },
+      address: { type: "string", description: "Street address" },
+    },
+  },
+  {
+    name: "start_chat_session",
+    parameters: {
+      email: { type: "string", description: "Email address of the customer" },
+      name: { type: "string", description: "Full name of the customer" },
+      phone: { type: "string", description: "Phone number" },
+      address: { type: "string", description: "Street address" },
+    },
+  },
+  {
     name: "get_products",
     parameters: {
       query: {
@@ -207,4 +234,6 @@ export const agentTools = [
   "create_return",
   "create_complaint",
   "update_info",
+  "create_user_profile",
+  "start_chat_session",
 ];

--- a/lib/assistant.ts
+++ b/lib/assistant.ts
@@ -360,19 +360,22 @@ export const processMessages = async () => {
               removeRecommendedAction(toolCallMessage.name);
             }
 
+            // Persist conversation items before creating a new turn
+            setConversationItems([...conversationItems]);
+
             // Create another turn after tool output has been added
             await processMessages();
           }
         }
 
-        if (item.type === "file_search_call") {
-          setFAQExtracts(item.results);
-          setRelevantArticlesLoading(false);
-        }
+          if (item.type === "file_search_call") {
+            setFAQExtracts(item.results);
+            setRelevantArticlesLoading(false);
+          }
 
-        setConversationItems([...conversationItems]);
+          setConversationItems([...conversationItems]);
 
-        break;
+          break;
       }
 
       // Handle other events as needed

--- a/stores/useDataStore.ts
+++ b/stores/useDataStore.ts
@@ -6,6 +6,9 @@ interface CustomerDetails {
   id: string;
   orderNb: number;
   signupDate: string;
+  email: string;
+  phone: string;
+  address: string;
 }
 
 export interface FAQExtract {


### PR DESCRIPTION
## Summary
- extend `CustomerDetails` with contact info
- show contact fields in UI
- add Prisma-based endpoints for users and chat sessions
- allow updating user info and fetching orders from the database
- expose helper tools for managing user profiles and sessions
- document database setup and connection env var
- fix recursive turn processing when handling tool calls

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686964670e688333914e46b12698106a