### PR TITLE
Sync customer details after user APIs

### DIFF
--- a/app/api/sessions/start/route.ts
+++ b/app/api/sessions/start/route.ts
@@ -12,6 +12,7 @@ export async function POST(request: Request) {
       where: { email },
       update: { name, phone, address },
       create: { email, name, phone, address },
+      include: { orders: true },
     });
     let session = await prisma.chatSession.findFirst({
       where: { userId: user.id },

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -9,7 +9,10 @@ export async function GET(request: Request) {
         status: 400,
       });
     }
-    const user = await prisma.user.findUnique({ where: { email } });
+    const user = await prisma.user.findUnique({
+      where: { email },
+      include: { orders: true },
+    });
     if (!user) {
       return new Response(JSON.stringify({ error: "User not found" }), {
         status: 404,
@@ -34,6 +37,7 @@ export async function POST(request: Request) {
       where: { email },
       update: { name, phone, address },
       create: { email, name, phone, address },
+      include: { orders: true },
     });
     return new Response(JSON.stringify(user), { status: 200 });
   } catch (error) {


### PR DESCRIPTION
## Summary
- expose customer info with order counts from user APIs
- update config functions to map API user records to `CustomerDetails`
- keep store in sync when fetching or creating users and when starting sessions

## Testing
- `npm run lint` *(fails: Expected an assignment or function call and instead saw an expression)*

------
https://chatgpt.com/codex/tasks/task_e_6869923bed3883339a9881dcfdf143a5