### PR TITLE
Refactor update_info tool

### DIFF
--- a/app/api/users/[user_id]/update_info/route.ts
+++ b/app/api/users/[user_id]/update_info/route.ts
@@ -6,16 +6,21 @@ export async function POST(
 ) {
   try {
     const { user_id } = params;
-    const { info } = await request.json();
+    const { email, phone, address, name } = await request.json();
+    const data = {
+      ...(email && { email }),
+      ...(phone && { phone }),
+      ...(address && { address }),
+      ...(name && { name }),
+    };
     await prisma.user.update({
       where: { id: user_id },
-      data: { [info.field]: info.value },
+      data,
     });
     return new Response(
       JSON.stringify({
         message: `User ${user_id} info updated`,
-        updatedField: info.field,
-        newValue: info.value,
+        updated: data,
       }),
       { status: 200 }
     );

--- a/config/functions.ts
+++ b/config/functions.ts
@@ -216,10 +216,16 @@ export const create_ticket = async ({
 
 export const update_info = async ({
   user_id,
-  info,
+  email,
+  phone,
+  address,
+  name,
 }: {
   user_id: string;
-  info: { field: string; value: string };
+  email?: string;
+  phone?: string;
+  address?: string;
+  name?: string;
 }) => {
   try {
     const res = await fetch(`/api/users/${user_id}/update_info`, {
@@ -227,7 +233,7 @@ export const update_info = async ({
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ info }),
+      body: JSON.stringify({ email, phone, address, name }),
     }).then((res) => res.json());
     return res;
   } catch (error) {

--- a/config/tools-list.ts
+++ b/config/tools-list.ts
@@ -153,7 +153,7 @@ export const toolsList = [
     parameters: {
       user_id: {
         type: "string",
-        description: "User ID to update",
+        description: "User ID to update information for",
       },
       email: { type: "string", description: "New email", nullable: true },
       phone: { type: "string", description: "New phone", nullable: true },

--- a/config/tools-list.ts
+++ b/config/tools-list.ts
@@ -153,26 +153,14 @@ export const toolsList = [
     parameters: {
       user_id: {
         type: "string",
-        description: "User ID to update information for",
+        description: "User ID to update",
       },
-      info: {
-        type: "object",
-        description: "Information to update",
-        properties: {
-          field: {
-            type: "string",
-            description: "Field to update",
-            enum: ["email", "phone", "address", "name"],
-          },
-          value: {
-            type: "string",
-            description: "Value to update",
-          },
-        },
-        additionalProperties: false,
-        required: ["field", "value"],
-      },
+      email: { type: "string", description: "New email", nullable: true },
+      phone: { type: "string", description: "New phone", nullable: true },
+      address: { type: "string", description: "New address", nullable: true },
+      name: { type: "string", description: "New name", nullable: true },
     },
+    required: ["user_id"],
   },
   {
     name: "get_user_profile",

--- a/public/knowledge_base/update_info.md
+++ b/public/knowledge_base/update_info.md
@@ -12,3 +12,7 @@ Once verified, use the update_info tool to update:
 - Name
 
 Confirm the changes with the customer first to prevent errors.
+
+Use the tool by passing only the fields that need to change, e.g.:
+
+`update_info({ user_id, email, phone })`


### PR DESCRIPTION
## Summary
- update `update_info` tool definition with optional fields
- accept optional fields in `update_info` client helper
- adjust API route to update only provided fields
- document usage of the new optional parameters

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e987818908333b3f767e74e9b72f7