### PR TITLE
Manual guardrails check before streaming

### DIFF
--- a/lib/guardrails.ts
+++ b/lib/guardrails.ts
@@ -1,5 +1,5 @@
 import { Agent, run } from '@openai/agents';
-import { defineInputGuardrail } from '@openai/agents-core';
+import { defineInputGuardrail } from '@openai/agents-core/guardrail';
 import { z } from 'zod';
 import { MODEL } from '@/config/constants';
 
@@ -29,8 +29,8 @@ const jailbreak_guardrail_agent = new Agent({
 
 export const relevance_guardrail = defineInputGuardrail({
   name: 'relevance_guardrail',
-  async execute({ input }) {
-    const result = await run(guardrail_agent, input as string);
+  async execute({ input }: { input: string }) {
+    const result = await run(guardrail_agent, input);
     let parsed: any;
     try {
       parsed = typeof result.finalOutput === 'string' ? JSON.parse(result.finalOutput) : result.finalOutput;
@@ -45,8 +45,8 @@ export const relevance_guardrail = defineInputGuardrail({
 
 export const jailbreak_guardrail = defineInputGuardrail({
   name: 'jailbreak_guardrail',
-  async execute({ input }) {
-    const result = await run(jailbreak_guardrail_agent, input as string);
+  async execute({ input }: { input: string }) {
+    const result = await run(jailbreak_guardrail_agent, input);
     let parsed: any;
     try {
       parsed = typeof result.finalOutput === 'string' ? JSON.parse(result.finalOutput) : result.finalOutput;


### PR DESCRIPTION
## Summary
- switch guardrail import to `@openai/agents-core/guardrail`
- type the guardrail `execute` parameters
- run guardrails manually in the turn API
- remove guardrail usage from `responses.create`
- simplify streaming loop with `for await` syntax

## Testing
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686ee30f13048333bcb32d3578adff63