### PR TITLE
fix required parameters for update_info tool

### DIFF
--- a/config/tools-list.ts
+++ b/config/tools-list.ts
@@ -160,7 +160,7 @@ export const toolsList = [
       address: { type: "string", description: "New address", nullable: true },
       name: { type: "string", description: "New name", nullable: true },
     },
-    required: ["user_id"],
+    required: ["user_id", "email", "phone", "address", "name"],
   },
   {
     name: "get_user_profile",

--- a/public/knowledge_base/account_recovery.md
+++ b/public/knowledge_base/account_recovery.md
@@ -4,6 +4,9 @@ If a customer is unable to recover their account using the standard email reset 
 
 Use the reset_password tool to send them a password reset email.
 
-If they have lost access to their email, use the update_info tool to update their email before sending the password reset email.
+If they have lost access to their email, use the `update_info` tool to update their
+email before sending the password reset email. Remember that `update_info`
+requires all user details (email, phone, address, and name), so include the
+current values for fields that aren't changing.
 
 Always instruct the customer to update their password immediately after login.

--- a/public/knowledge_base/update_info.md
+++ b/public/knowledge_base/update_info.md
@@ -4,7 +4,7 @@ If a customer cannot update their account details:
 
 Verify their identity by asking for their name, previous order details, billing information, or registered phone number.
 
-Once verified, use the update_info tool to update:
+Once verified, use the `update_info` tool to update the customer's details:
 
 - Email
 - Phone number
@@ -13,6 +13,7 @@ Once verified, use the update_info tool to update:
 
 Confirm the changes with the customer first to prevent errors.
 
-Use the tool by passing only the fields that need to change, e.g.:
+When calling `update_info`, **all** fields must be provided. Pass the current
+values for fields that aren't changing, for example:
 
-`update_info({ user_id, email, phone })`
+`update_info({ user_id, email, phone, address, name })`


### PR DESCRIPTION
## Summary
- update the `update_info` tool schema to require all user info fields
- explain required fields in the knowledge base documentation

## Testing
- `npm run lint` *(fails: next not found until dependencies installed)*
- `npm install`
- `npm run lint` *(fails with numerous lint errors)*
- `npm run build -- --no-lint` *(fails due to TypeScript errors)*
- `TSC_COMPILE_ON_ERROR=true npx next dev --port 3000` *(server started and returned 500 error on `/api/turn_response`)*


------
https://chatgpt.com/codex/tasks/task_e_686ef6f3dca88333ac0b3de0b09e8d1b