### PR TITLE
Add provider abstraction for chat responses

### DIFF
--- a/lib/assistant.ts
+++ b/lib/assistant.ts
@@ -47,7 +47,8 @@ export type Item = ChatMessage | ToolCallItem;
 
 export const handleTurn = async (
   messages: any[],
-  onMessage: (data: any) => void
+  onMessage: (data: any) => void,
+  provider = "openai"
 ) => {
   try {
     // Get response from the API (defined in app/api/turn_response/route.ts)
@@ -57,6 +58,7 @@ export const handleTurn = async (
       body: JSON.stringify({
         messages: messages,
         tools: tools,
+        provider,
       }),
     });
 
@@ -148,7 +150,9 @@ export const processMessages = async () => {
   let assistantMessageContent = "";
   let functionArguments = "";
 
-  await handleTurn(allConversationItems, async ({ event, data }) => {
+  await handleTurn(
+    allConversationItems,
+    async ({ event, data }) => {
     switch (event) {
       case "response.output_text.delta":
       case "response.output_text.annotation.added": {
@@ -405,5 +409,6 @@ export const processMessages = async () => {
 
       // Handle other events as needed
     }
-  });
+  },
+  "openai");
 };

--- a/lib/providers/index.ts
+++ b/lib/providers/index.ts
@@ -1,0 +1,18 @@
+import { openaiProvider } from "./openai";
+import { ollamaProvider } from "./ollama";
+import type { ProviderEvent } from "./openai";
+
+export type ProviderFunction = (
+  messages: any[],
+  tools: any
+) => AsyncGenerator<ProviderEvent>;
+
+export function getProvider(name: string | undefined): ProviderFunction {
+  switch (name) {
+    case "ollama":
+      return ollamaProvider;
+    case "openai":
+    default:
+      return openaiProvider;
+  }
+}

--- a/lib/providers/ollama.ts
+++ b/lib/providers/ollama.ts
@@ -1,0 +1,47 @@
+import { ProviderEvent } from "./openai";
+
+export async function* ollamaProvider(messages: any[], _tools: any): AsyncGenerator<ProviderEvent> {
+  const converted = (messages || []).map((m: any) => ({
+    role: m.role === "developer" ? "system" : m.role,
+    content: Array.isArray(m.content)
+      ? m.content.map((c: any) => (typeof c === "string" ? c : c.text || "")).join(" ")
+      : String(m.content ?? ""),
+  }));
+
+  const response = await fetch("http://localhost:11434/api/chat", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ model: "llama3", messages: converted, stream: true }),
+  });
+
+  if (!response.body) throw new Error("No response body from Ollama");
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let finalText = "";
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop() ?? "";
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      const data = JSON.parse(line);
+      const content = data.message?.content ?? "";
+      if (content) {
+        finalText += content;
+        yield { event: "response.output_text.delta", data: { delta: content } } as ProviderEvent;
+      }
+      if (data.done) {
+        yield { event: "response.output_text.done", data: {} } as ProviderEvent;
+        yield {
+          event: "response.output_item.done",
+          data: { item: { type: "message", role: "assistant", content: finalText } },
+        } as ProviderEvent;
+      }
+    }
+  }
+}

--- a/lib/providers/openai.ts
+++ b/lib/providers/openai.ts
@@ -1,0 +1,23 @@
+import OpenAI from "openai";
+import { MODEL } from "@/config/constants";
+
+export interface ProviderEvent {
+  event: string;
+  data: any;
+}
+
+export async function* openaiProvider(messages: any[], tools: any): AsyncGenerator<ProviderEvent> {
+  const openai = new OpenAI();
+  const events = await openai.responses.create({
+    model: MODEL,
+    input: messages,
+    tools,
+    stream: true,
+    include: ["file_search_call.results"],
+    parallel_tool_calls: false,
+  });
+
+  for await (const event of events) {
+    yield { event: event.type, data: event } as ProviderEvent;
+  }
+}


### PR DESCRIPTION
## Summary
- abstract response streaming into provider interface
- support OpenAI and basic Ollama providers
- wire API route to pick provider
- send provider in client `handleTurn`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870166b56a08333b5d380228cb44eec