### PR TITLE
docs: clarify OpenAI key needed with Ollama

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ Feel free to customize this demo to suit your specific use case.
    OPENAI_API_KEY=<your_api_key>
    ```
 
+   **Note:** Even when using the `ollama` provider, the `search_files` function
+   queries the OpenAI vector store. Make sure your `OPENAI_API_KEY` is set so
+   this call succeeds.
+
 4. **Install dependencies:**
 
    Run in the project root:


### PR DESCRIPTION
## Summary
- note that the Ollama provider still calls `search_files`
- mention that an OpenAI key is required for vector store access

## Testing
- `npm run lint` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870f7197f4c8333aa93f10d33f29a75