### PR TITLE
Add provider toggle for agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,10 @@ Feel free to customize this demo to suit your specific use case.
 4. **Choose your provider (optional):**
 
    The assistant can run using either the `openai` API or the `ollama` package.
-   To switch providers, edit `lib/assistant.ts` and change the last argument
-   passed to `handleTurn` inside `processMessages()` (`"openai"` by default).
-   When selecting `ollama`, make sure you have an Ollama server running locally
-   (e.g. by executing `ollama serve`). The built-in tools work the same with
-   both providers.
+   You can switch providers from the dropdown next to **Auto reply** in the
+   agent view. When selecting `ollama`, make sure you have an Ollama server
+   running locally (e.g. by executing `ollama serve`). The built-in tools work
+   the same with both providers.
 
 5. **Install dependencies:**
 

--- a/components/AgentView.tsx
+++ b/components/AgentView.tsx
@@ -15,8 +15,15 @@ import Chat from "./Chat";
 import { Switch } from "./ui/switch";
 
 export default function AgentView() {
-  const { chatMessages, addConversationItem, addChatMessage, autoReply, setAutoReply } =
-    useConversationStore();
+  const {
+    chatMessages,
+    addConversationItem,
+    addChatMessage,
+    autoReply,
+    setAutoReply,
+    modelProvider,
+    setModelProvider,
+  } = useConversationStore();
 
   const handleSendMessage = async (message: string) => {
     if (!message.trim()) return;
@@ -37,9 +44,23 @@ export default function AgentView() {
 
   return (
     <div className="relative flex flex-1 min-h-0 bg-white rounded-lg p-4 gap-4">
-      <div className="absolute top-4 left-4 flex items-center gap-2">
-        <span className="text-xs text-zinc-500">Auto reply</span>
-        <Switch checked={autoReply} onCheckedChange={setAutoReply} mode="custom" />
+      <div className="absolute top-4 left-4 flex items-center gap-4">
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-zinc-500">Auto reply</span>
+          <Switch
+            checked={autoReply}
+            onCheckedChange={setAutoReply}
+            mode="custom"
+          />
+        </div>
+        <select
+          className="text-xs border rounded p-1"
+          value={modelProvider}
+          onChange={(e) => setModelProvider(e.target.value)}
+        >
+          <option value="openai">OpenAI</option>
+          <option value="ollama">Ollama</option>
+        </select>
       </div>
       <div className="w-full md:w-3/5">
         <Chat

--- a/lib/assistant.ts
+++ b/lib/assistant.ts
@@ -133,6 +133,7 @@ export const processMessages = async () => {
     addChatMessage,
     removeRecommendedAction,
     autoReply,
+    modelProvider,
   } = useConversationStore.getState();
 
   const { setRelevantArticlesLoading, setFAQExtracts } =
@@ -410,5 +411,5 @@ export const processMessages = async () => {
       // Handle other events as needed
     }
   },
-  "openai");
+  modelProvider);
 };

--- a/stores/useConversationStore.ts
+++ b/stores/useConversationStore.ts
@@ -34,6 +34,9 @@ interface ConversationState {
   autoReply: boolean;
   setAutoReply: (flag: boolean) => void;
 
+  modelProvider: string;
+  setModelProvider: (provider: string) => void;
+
   setChatMessages: (items: Item[]) => void;
   setConversationItems: (messages: any[]) => void;
   addChatMessage: (item: Item) => void;
@@ -61,10 +64,12 @@ const useConversationStore = create<ConversationState>((set) => ({
   userTyping: false,
   agentTyping: false,
   autoReply: false,
+  modelProvider: "openai",
   composerText: "",
   setUserTyping: (typing) => set({ userTyping: typing }),
   setAgentTyping: (typing) => set({ agentTyping: typing }),
   setAutoReply: (flag) => set({ autoReply: flag }),
+  setModelProvider: (provider) => set({ modelProvider: provider }),
   setComposerText: (text) => set({ composerText: text }),
   setChatMessages: (items) => set({ chatMessages: items }),
   setConversationItems: (messages) => set({ conversationItems: messages }),


### PR DESCRIPTION
## Summary
- store selected `modelProvider`
- allow changing provider in AgentView
- include provider when processing messages
- document provider selection in README

## Testing
- `npm run lint` *(fails: many eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68710b56e8ec83338cb1f5070baac385