### PR TITLE
Add Ollama section

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,27 @@ Feel free to customize this demo to suit your specific use case.
    running locally (e.g. by executing `ollama serve`). The built-in tools work
    the same with both providers.
 
+## Running Ollama
+
+When using the `ollama` provider you need a local server running.
+
+1. Start the server:
+
+```bash
+ollama serve
+```
+
+2. Begin with a lightweight model such as `llama3`:
+
+```bash
+ollama run llama3
+```
+
+The command downloads the model if needed. Use `ollama run <model>` or `ollama pull <model>` to get other models.
+
+3. After installing multiple models, switch between them using the **Model** dropdown in the agent view. Ensure the provider dropdown is set to `ollama`.
+
+
 5. **Install dependencies:**
 
    Run in the project root:


### PR DESCRIPTION
## Summary
- document starting the Ollama server and using lightweight models
- explain how to download additional models and switch them via the model dropdown

## Testing
- `npm run lint` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68717269680483338f0cf9300867367b