### PR TITLE
Handle API HTTP errors without console noise

### DIFF
--- a/lib/assistant.ts
+++ b/lib/assistant.ts
@@ -64,13 +64,15 @@ export const handleTurn = async (
     });
 
     if (!response.ok) {
-      console.error(`Error: ${response.status} - ${response.statusText}`);
       let message = "";
       try {
         const errorData = await response.json();
-        message = errorData.message || errorData.error || "Unknown error";
+        message =
+          errorData.message ||
+          errorData.error ||
+          "The assistant encountered an error. Please try again.";
       } catch {
-        message = "Unknown error";
+        message = "The assistant encountered an error. Please try again.";
       }
       onMessage({ event: "error", data: { message } });
       return;
@@ -113,8 +115,10 @@ export const handleTurn = async (
       }
     }
   } catch (error) {
-    console.error("Error handling turn:", error);
-    const message = error instanceof Error ? error.message : "Unknown error";
+    const message =
+      error instanceof Error && error.message
+        ? error.message
+        : "An unexpected error occurred. Please try again.";
     onMessage({ event: "error", data: { message } });
   }
 };


### PR DESCRIPTION
## Summary
- stop logging errors for turn API calls
- display a friendlier message when the API call fails
- avoid showing Next.js stack traces on errors

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687330e25fbc83338a9f3c58a2b5ec5c