### PR TITLE
Render markdown images in modal

### DIFF
--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -1,0 +1,19 @@
+"use client";
+import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
+import React from "react";
+
+interface ImageModalProps {
+  src: string;
+  children: React.ReactNode;
+}
+
+export default function ImageModal({ src, children }: ImageModalProps) {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent className="p-0 w-[90vw] max-w-3xl flex items-center justify-center">
+        <img src={src} alt="image" className="max-h-[90vh] w-auto h-auto object-contain" />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/Message.tsx
+++ b/components/Message.tsx
@@ -1,6 +1,19 @@
 import { ChatMessage } from "@/lib/assistant";
 import React from "react";
 import ReactMarkdown from "react-markdown";
+import ImageModal from "./ImageModal";
+
+const markdownComponents = {
+  img: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
+    <ImageModal src={props.src ?? ""}>
+      <img
+        {...props}
+        alt={props.alt || "image"}
+        className="w-24 h-24 object-cover rounded-md cursor-pointer"
+      />
+    </ImageModal>
+  ),
+};
 
 interface MessageProps {
   message: ChatMessage;
@@ -13,6 +26,7 @@ const Message: React.FC<MessageProps> = ({
   view,
   suggestion = false,
 }) => {
+  const item = message.content[0];
   return (
     <div className="text-sm">
       {(message.role === "user" && view === "user") ||
@@ -28,9 +42,19 @@ const Message: React.FC<MessageProps> = ({
             >
               <div>
                 <div>
-                  <ReactMarkdown>
-                    {message.content[0].text as string}
-                  </ReactMarkdown>
+                  {item.type === "output_image" && item.image_url ? (
+                    <ImageModal src={item.image_url}>
+                      <img
+                        src={item.image_url}
+                        alt="image"
+                        className="w-24 h-24 object-cover rounded-md cursor-pointer"
+                      />
+                    </ImageModal>
+                  ) : (
+                    <ReactMarkdown components={markdownComponents}>
+                      {item.text as string}
+                    </ReactMarkdown>
+                  )}
                 </div>
               </div>
             </div>
@@ -41,9 +65,19 @@ const Message: React.FC<MessageProps> = ({
           <div className="flex">
             <div className="mr-4 rounded-[16px] rounded-bl-[4px] px-4 py-2 md:mr-24 text-zinc-900 bg-[#ECECF1] font-light">
               <div>
-                <ReactMarkdown>
-                  {message.content[0].text as string}
-                </ReactMarkdown>
+                {item.type === "output_image" && item.image_url ? (
+                  <ImageModal src={item.image_url}>
+                    <img
+                      src={item.image_url}
+                      alt="image"
+                      className="w-24 h-24 object-cover rounded-md cursor-pointer"
+                    />
+                  </ImageModal>
+                ) : (
+                  <ReactMarkdown components={markdownComponents}>
+                    {item.text as string}
+                  </ReactMarkdown>
+                )}
               </div>
             </div>
           </div>

--- a/lib/assistant.ts
+++ b/lib/assistant.ts
@@ -9,9 +9,10 @@ import useDataStore from "@/stores/useDataStore";
 import { agentTools } from "@/config/tools-list";
 
 export interface ContentItem {
-  type: "input_text" | "output_text" | "refusal" | "output_audio";
+  type: "input_text" | "output_text" | "refusal" | "output_audio" | "output_image";
   annotations?: Annotation[];
   text?: string;
+  image_url?: string;
 }
 
 // Message items for storing conversation history matching API shape


### PR DESCRIPTION
## Summary
- wrap Markdown images in `ImageModal` so chat images are expandable

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6872ecc296e4833387a094cb86949247