### PR TITLE
Fix Next.js Image usage

### DIFF
--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -13,7 +13,9 @@ export default function ImageModal({ src, children }: ImageModalProps) {
     <Dialog>
       <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogContent className="p-0 w-[90vw] max-w-3xl flex items-center justify-center">
-        <Image src={src} alt="image" className="max-h-[90vh] w-auto h-auto object-contain" />
+        <div className="relative w-full h-[90vh]">
+          <Image src={src} alt="image" fill className="object-contain" />
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/components/Message.tsx
+++ b/components/Message.tsx
@@ -2,14 +2,16 @@ import { ChatMessage } from "@/lib/assistant";
 import React from "react";
 import ReactMarkdown from "react-markdown";
 import ImageModal from "./ImageModal";
-import Image from "next/image";
+import Image, { ImageProps } from "next/image";
 
 const markdownComponents = {
-  img: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
-    <ImageModal src={props.src ?? ""}>
+  img: (props: ImageProps) => (
+    <ImageModal src={(props.src as string) ?? ""}>
       <Image
         {...props}
         alt={props.alt || "image"}
+        width={96}
+        height={96}
         className="w-24 h-24 object-cover rounded-md cursor-pointer"
       />
     </ImageModal>
@@ -48,6 +50,8 @@ const Message: React.FC<MessageProps> = ({
                       <Image
                         src={item.image_url}
                         alt="image"
+                        width={96}
+                        height={96}
                         className="w-24 h-24 object-cover rounded-md cursor-pointer"
                       />
                     </ImageModal>
@@ -71,6 +75,8 @@ const Message: React.FC<MessageProps> = ({
                     <Image
                       src={item.image_url}
                       alt="image"
+                      width={96}
+                      height={96}
                       className="w-24 h-24 object-cover rounded-md cursor-pointer"
                     />
                   </ImageModal>


### PR DESCRIPTION
## Summary
- use `next/image` properly in ImageModal with fill
- update markdown image handling in Message component
- size output image thumbnails for Next.js

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68734dba6fac83338f5989b99cdef02e