### PR TITLE
Add automationghana domains

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   devIndicators: false,
+  images: {
+    domains: ['automationghana.com', 'store.automationghana.com'],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- configure Next.js to allow images from `automationghana.com` and `store.automationghana.com`

## Testing
- `npm run build` *(fails: invalid type in app/api/orders/[order_id]/cancel/route.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68735f59d8708333bef5820369b42f2c