### PR TITLE
Fix image config and cancel route

### DIFF
--- a/app/api/orders/[order_id]/cancel/route.ts
+++ b/app/api/orders/[order_id]/cancel/route.ts
@@ -1,10 +1,9 @@
 export async function POST(
   request: Request,
-  context: { params: { order_id: string } }
+  { params }: { params: { order_id: string } }
 ) {
   try {
-    const { params } = context;
-    const { order_id } = await params;
+    const { order_id } = params;
     // Simulate order cancellation
     return new Response(
       JSON.stringify({ message: `Order ${order_id} cancelled successfully` }),

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -1,5 +1,10 @@
 "use client";
-import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogTrigger,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import Image from "next/image";
 import React from "react";
 
@@ -13,8 +18,9 @@ export default function ImageModal({ src, children }: ImageModalProps) {
     <Dialog>
       <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogContent className="p-0 w-[90vw] max-w-3xl flex items-center justify-center">
+        <DialogTitle className="sr-only">Image preview</DialogTitle>
         <div className="relative w-full h-[90vh]">
-          <Image src={src} alt="image" fill className="object-contain" />
+          <Image src={src} alt="image" fill quality={100} className="object-contain" />
         </div>
       </DialogContent>
     </Dialog>

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,20 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   devIndicators: false,
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'automationghana.com',
+        pathname: '/**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'store.automationghana.com',
+        pathname: '/**',
+      },
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- switch Next.js image config to remote patterns for automationghana.com domains
- enhance accessibility of ImageModal with `DialogTitle`
- improve large image quality
- fix order cancel API handler signature

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68735f59d8708333bef5820369b42f2c