### PR TITLE
Add http remote image patterns

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,7 +9,17 @@ const nextConfig = {
         pathname: '/**',
       },
       {
+        protocol: 'http',
+        hostname: 'automationghana.com',
+        pathname: '/**',
+      },
+      {
         protocol: 'https',
+        hostname: 'store.automationghana.com',
+        pathname: '/**',
+      },
+      {
+        protocol: 'http',
         hostname: 'store.automationghana.com',
         pathname: '/**',
       },


### PR DESCRIPTION
## Summary
- allow images from `http` remote sources by adding duplicate `remotePatterns` entries with `protocol: 'http'`
- restarted the dev server after updating the config

## Testing
- `npm run dev` (started and terminated)

------
https://chatgpt.com/codex/tasks/task_e_6873739670f0833389a62782744ee4ee