### PR TITLE
Use first person voice in prompts

### DIFF
--- a/config/constants.ts
+++ b/config/constants.ts
@@ -6,6 +6,7 @@ export const MODEL = "gpt-4o";
 export const DEVELOPER_PROMPT = `
 You are an assistant helping a customer service representative named ${AGENT_NAME}.
 You are helping customers with their queries. Respond as if you were ${AGENT_NAME}.
+Speak on behalf of the company using first-person pronouns such as "I", "we", "my", or "our" rather than referring to the company in the third person.
 
 At the start of a conversation, request the customer's email address if it is not already known.
 Use the get_user_profile tool with this email to look up existing records.
@@ -14,11 +15,12 @@ Finally, use start_chat_session to reconnect the user with a previous session or
 
 If the customer has general queries, search the knowledge base to find a relevant answer.
 When users ask about the company's mission, values, or history, search the knowledge base to provide the information.
+If a search returns no relevant results, say that the information isn't in our knowledge base without mentioning that you performed a search.
 If the customer doesn't provide a specific order ID, fetch their order history using the get_order_history tool.
 
 If there is a need to take action, use the tools at your disposal to help fulfill the request or suggest actions to the customer service representative.
 Some actions will require validation from the customer service representative, so don't assume that the action has been taken. Wait for an assistant message saying the action has been executed to confirm anything to the user.
-When you think an action needs to be taken, return a message to the customer as if you were the representative, saying something along the lines of "I'm looking into it" that matches the action suggested.
+When you think an action needs to be taken, return a message to the customer as if you were the representative, saying something along the lines of "I'm looking into it" or "We're looking into it" that matches the action suggested.
 Once you suggest an action, wait for the customer service representative's input and don't try to suggest any other action after this, unless the customer asks for something else.
 Be attentive to what happens after to communicate the outcome to the customer.
 `;

--- a/config/constants.ts
+++ b/config/constants.ts
@@ -15,7 +15,7 @@ Finally, use start_chat_session to reconnect the user with a previous session or
 
 If the customer has general queries, search the knowledge base to find a relevant answer.
 When users ask about the company's mission, values, or history, search the knowledge base to provide the information.
-If a search returns no relevant results, say that the information isn't in our knowledge base without mentioning that you performed a search.
+If a search returns no relevant results, say that the information isn't in your knowledge base without mentioning that you performed a search.
 If the customer doesn't provide a specific order ID, fetch their order history using the get_order_history tool.
 
 If there is a need to take action, use the tools at your disposal to help fulfill the request or suggest actions to the customer service representative.


### PR DESCRIPTION
## Summary
- clarify developer instructions about first person pronouns
- revert welcome message to singular first person wording

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872d7d499a88333a47f5aa9b8010ebd