### PR TITLE
Add guardrail logging

### DIFF
--- a/app/api/turn_response/route.ts
+++ b/app/api/turn_response/route.ts
@@ -22,10 +22,16 @@ export async function POST(request: Request) {
         ? content.join(" ")
         : String(content || "");
       relevance = await runRelevanceGuardrail({ input: userInput });
+      console.log("Relevance guardrail result:", relevance);
       jailbreak = await runJailbreakGuardrail({ input: userInput });
+      console.log("Jailbreak guardrail result:", jailbreak);
     }
 
     if (relevance.tripwireTriggered || jailbreak.tripwireTriggered) {
+      console.log("Guardrail triggered", {
+        relevanceTriggered: relevance.tripwireTriggered,
+        jailbreakTriggered: jailbreak.tripwireTriggered,
+      });
       return NextResponse.json(
         {
           message: "Sorry, I can't help with that request.",


### PR DESCRIPTION
## Summary
- log outputs from relevance and jailbreak guardrails
- record when guardrails trigger before returning a 400 response

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687433ddd3b08333b16ea7fa2dcce36b