### PR TITLE
Allow configuring ollama model via env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 OPENAI_API_KEY=<your-openai-api-key>
 DATABASE_URL="postgresql://user:password@localhost:5432/dbname"
+OLLAMA_MODEL=llama3.2
+OLLAMA_NUM_CTX=4096

--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ The command downloads the model if needed. Use `ollama run <model>` or `ollama p
 
 3. After installing multiple models, switch between them using the **Model** dropdown in the agent view. Ensure the provider dropdown is set to `ollama`.
 
+4. (Optional) Configure the default model and context size by adding the following variables to your `.env` file (see `.env.example`):
+
+   ```bash
+   OLLAMA_MODEL=llama3.2
+   OLLAMA_NUM_CTX=4096
+   ```
+
 
 5. **Install dependencies:**
 

--- a/lib/providers/ollama.ts
+++ b/lib/providers/ollama.ts
@@ -3,6 +3,9 @@ import ollama from "ollama";
 import { randomUUID } from "crypto";
 import { search_files } from "@/config/functions";
 
+const model = process.env.OLLAMA_MODEL || "llama3.2";
+const num_ctx = parseInt(process.env.OLLAMA_NUM_CTX || "4096", 10);
+
 export async function* ollamaProvider(messages: any[], tools: any): AsyncGenerator<ProviderEvent> {
   const converted = (messages || []).map((m: any) => ({
     role: m.role === "developer" ? "system" : m.role,
@@ -47,10 +50,11 @@ export async function* ollamaProvider(messages: any[], tools: any): AsyncGenerat
   }
 
   const stream = await ollama.chat({
-    model: "llama3.2",
+    model,
     messages: converted,
     tools,
     stream: true,
+    options: { num_ctx },
   });
 
   let finalText = "";


### PR DESCRIPTION
## Summary
- make ollama provider read OLLAMA_MODEL and OLLAMA_NUM_CTX
- set default model and context in .env.example
- document the env vars in the README under the Running Ollama section

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6876a7becb688333864ac8a85cd4c41a