### PR TITLE
Enhance Ollama provider error handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ OPENAI_API_KEY=<your-openai-api-key>
 DATABASE_URL="postgresql://user:password@localhost:5432/dbname"
 OLLAMA_MODEL=llama3.2
 OLLAMA_NUM_CTX=4096
+OLLAMA_HOST=http://localhost:11434

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ When using the `ollama` provider you need a local server running.
    ```bash
    OLLAMA_MODEL=llama3.2
    OLLAMA_NUM_CTX=4096
+   OLLAMA_HOST=http://localhost:11434
    ```
 
 5. **Install dependencies:**

--- a/lib/providers/ollama.ts
+++ b/lib/providers/ollama.ts
@@ -5,6 +5,19 @@ import { search_files } from "@/config/functions";
 
 const model = process.env.OLLAMA_MODEL || "llama3.2";
 const num_ctx = parseInt(process.env.OLLAMA_NUM_CTX || "4096", 10);
+const host = process.env.OLLAMA_HOST;
+
+if (host) {
+  try {
+    (ollama as any).defaults = { ...(ollama as any).defaults, host };
+  } catch {
+    try {
+      (ollama as any).config.host = host;
+    } catch {
+      // ignore if unable to set host
+    }
+  }
+}
 
 export async function* ollamaProvider(messages: any[], tools: any): AsyncGenerator<ProviderEvent> {
   const converted = (messages || []).map((m: any) => ({
@@ -49,13 +62,23 @@ export async function* ollamaProvider(messages: any[], tools: any): AsyncGenerat
     }
   }
 
-  const stream = await ollama.chat({
-    model,
-    messages: converted,
-    tools,
-    stream: true,
-    options: { num_ctx },
-  });
+  let stream: any;
+  try {
+    stream = await ollama.chat({
+      model,
+      messages: converted,
+      tools,
+      stream: true,
+      options: { num_ctx },
+    });
+  } catch (error) {
+    console.error("ollama.chat failed", error);
+    yield {
+      event: "error",
+      data: { message: (error as Error).message },
+    } as ProviderEvent;
+    return;
+  }
 
   let finalText = "";
   const seenCalls = new Set<string>();


### PR DESCRIPTION
## Summary
- yield an error event if `ollama.chat()` fails
- allow specifying `OLLAMA_HOST` for custom Ollama base URL
- document `OLLAMA_HOST` in README and `.env.example`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6876c433766083339d3da36e4a9da377