### PR TITLE
Check for file_search tool before calling search_files

### DIFF
--- a/lib/providers/ollama.ts
+++ b/lib/providers/ollama.ts
@@ -27,8 +27,12 @@ export async function* ollamaProvider(messages: any[], tools: any): AsyncGenerat
       : String(m.content ?? ""),
   }));
 
+  const hasFileSearchTool =
+    Array.isArray(tools) &&
+    tools.some((t: any) => t.type === "file_search" || t.name === "search_files");
+
   const lastUser = [...(messages || [])].reverse().find((m: any) => m.role === "user");
-  if (lastUser) {
+  if (hasFileSearchTool && lastUser) {
     const q = Array.isArray(lastUser.content)
       ? lastUser.content.map((c: any) => (typeof c === "string" ? c : c.text || "")).join(" ")
       : String(lastUser.content ?? "");


### PR DESCRIPTION
## Summary
- skip file search unless a `file_search`/`search_files` tool is defined

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6877a148f8448333b2b0375603dd9f66