### PR TITLE
Add local vector store powered by Ollama embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,10 @@ Feel free to customize this demo to suit your specific use case.
    OPENAI_API_KEY=<your_api_key>
    ```
 
-   **Note:** Even when using the `ollama` provider, the `search_files` function
-   queries the OpenAI vector store. Make sure your `OPENAI_API_KEY` is set so
-   this call succeeds.
+   **Note:** When using the `ollama` provider, file search runs against a local
+   vector store built from the knowledge base. Embeddings are generated using
+   Ollama's `embeddings` endpoint, so an OpenAI API key is only required when
+   using the `openai` provider.
 
 4. **Choose your provider (optional):**
 
@@ -110,7 +111,9 @@ When using the `ollama` provider you need a local server running.
 
 7. **Initialize the vector store:**
 
-   Go to [`/init_vs`](http://localhost:3000/init_vs) to create a vector store and initialize it with the knowledge base. Once you have created the vector store, update `config/constants.ts` with your own vector store ID.
+   Visit [`/init_vs`](http://localhost:3000/init_vs) to generate embeddings for
+   the knowledge base using Ollama and store them locally. This step prepares the
+   search index used when the provider is set to `ollama`.
 
 ## Demo Flow
 

--- a/app/api/local_vector_store/init/route.ts
+++ b/app/api/local_vector_store/init/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import { localVectorStore } from "@/lib/localVectorStore";
+
+export async function POST() {
+  try {
+    await localVectorStore.initialize();
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Error initializing local vector store:", error);
+    return NextResponse.json(
+      { error: (error as Error).message },
+      { status: 500 }
+    );
+  }
+}

--- a/app/init_vs/page.tsx
+++ b/app/init_vs/page.tsx
@@ -1,86 +1,24 @@
 "use client";
-import { KB_FOLDERS } from "@/config/demoData";
-import { Copy } from "lucide-react";
 import { useState } from "react";
-
-interface KBFile {
-  type: string;
-  filename: string;
-  filepath: string;
-}
 
 export default function InitVS() {
   const [loading, setLoading] = useState(false);
-  const [vectorStoreId, setVectorStoreId] = useState<string | null>(null);
   const [status, setStatus] = useState<string>("");
   const [error, setError] = useState<string | null>(null);
-  const [success, setSuccess] = useState<boolean>(false);
-
-  const copyToClipboard = (text: string) => {
-    navigator.clipboard.writeText(text);
-  };
+  const [success, setSuccess] = useState(false);
 
   const handleInitialize = async () => {
     setLoading(true);
     setSuccess(false);
-    setStatus("Creating vector store...");
-    const response = await fetch("/api/vector_stores/create_store", {
-      method: "POST",
-      body: JSON.stringify({ name: "CS Knowledge Base" }),
-    });
-    if (response.status === 200) {
-      const vs = await response.json();
-      setVectorStoreId(vs.id);
-      setStatus("Fetching files...");
-      const filesList: KBFile[] = [];
-      for (const folder of KB_FOLDERS) {
-        const folderFiles = await fetch(
-          `/api/list_files?folder=${folder}`
-        ).then((res) => res.json());
-        console.log(`Files found in folder ${folder}:`, folderFiles);
-        filesList.push(
-          ...folderFiles.map((file: string) => ({
-            type: folder,
-            filename: file.split(".")[0],
-            filepath: `/public/${folder}/${file}`,
-          }))
-        );
-      }
-      setStatus(`Uploading ${filesList.length} files to vector store...`);
-      for (const file of filesList) {
-        console.log(`Uploading file ${file.filepath}...`);
-        const response = await fetch("/api/vector_stores/upload_file", {
-          method: "POST",
-          body: JSON.stringify({ filePath: file.filepath }),
-        });
-        if (response.status === 200) {
-          const fileData = await response.json();
-          const fileId = fileData.id;
-          const attributes = {
-            type: file.type,
-            filename: file.filename,
-            filepath: file.filepath,
-          };
-          const addFileResponse = await fetch("/api/vector_stores/add_file", {
-            method: "POST",
-            body: JSON.stringify({ vectorStoreId: vs.id, fileId, attributes }),
-          });
-          if (addFileResponse.status === 200) {
-            setStatus(`Uploaded ${file.type}/${file.filename}`);
-          } else {
-            setError(`Failed to add file ${file.filename} to vector store`);
-          }
-        } else {
-          setError(`Failed to upload file ${file.filename} to vector store`);
-        }
-      }
-      setStatus("Uploaded all files to vector store.");
-      setLoading(false);
+    setStatus("Generating embeddings...");
+    const res = await fetch("/api/local_vector_store/init", { method: "POST" });
+    if (res.ok) {
+      setStatus("Knowledge base loaded.");
       setSuccess(true);
     } else {
-      setError("Failed to create vector store");
-      setLoading(false);
+      setError("Failed to initialize vector store");
     }
+    setLoading(false);
   };
 
   return (
@@ -89,35 +27,14 @@ export default function InitVS() {
         <div className="text-2xl font-bold">Initialize the Vector Store</div>
         <div className="text-sm text-zinc-500 space-y-2">
           <p>
-            For this demo to work, you need to load knowledge base content into
-            a vector store. This vector store will be used by the File Search
-            tool to search for relevant content that can help answer the user
-            query.
+            For this demo to work, you need to load knowledge base content into a vector store.
+            The content in the <span className="font-mono bg-zinc-100 rounded-md p-1">/public/knowledge_base</span> and
+            <span className="font-mono bg-zinc-100 rounded-md p-1">/public/faq</span> folders will be embedded using Ollama
+            and stored locally.
           </p>
           <p>
-            When you click on the button below, the content contained in the{" "}
-            <span className="font-mono bg-zinc-100 rounded-md p-1">
-              /public/knowledge_base
-            </span>{" "}
-            and{" "}
-            <span className="font-mono bg-zinc-100 rounded-md p-1">
-              /public/faq
-            </span>{" "}
-            folders will be loaded into a vector store.
-          </p>
-          <p>
-            Feel free to update these articles with your own content. If you
-            change the folder names, make sure to update the reference to the
-            folders below. After you make changes, you can re-initialize the
-            vector store to load the new content.
-          </p>
-          <p>
-            Once the content is loaded, you will see the newly created vector
-            store&apos;s ID below. You can then configure the vector store ID in{" "}
-            <span className="font-mono bg-zinc-100 rounded-md p-1">
-              /config/constants.ts
-            </span>{" "}
-            to use with the File Search tool.
+            Feel free to update these articles with your own content. After making changes you can re-run this step to
+            regenerate the embeddings.
           </p>
         </div>
         <div className="flex">
@@ -136,20 +53,7 @@ export default function InitVS() {
       <div className="mt-6 text-left w-full max-w-lg">
         {error && <div className="text-red-500 text-sm">{error}</div>}
         {success && !error && (
-          <div className="text-zinc-600 text-sm">
-            Knowledge base updated successfully.
-            <div className="flex items-center gap-2 mt-4">
-              <div className="text-zinc-900">Vector Store ID:</div>
-              <div className="font-mono text-sm p-1 bg-zinc-100 rounded-md">
-                {vectorStoreId ?? ""}
-              </div>
-              <Copy
-                onClick={() => copyToClipboard(vectorStoreId ?? "")}
-                size={16}
-                className="cursor-pointer text-zinc-400 hover:text-zinc-600 transition-all duration-100"
-              />
-            </div>
-          </div>
+          <div className="text-zinc-600 text-sm">Knowledge base updated successfully.</div>
         )}
       </div>
     </div>

--- a/config/functions.ts
+++ b/config/functions.ts
@@ -324,12 +324,14 @@ export const start_chat_session = async ({
 export const search_files = async ({
   query,
   max_results,
+  provider,
 }: {
   query: string;
   max_results?: number;
+  provider?: string;
 }) => {
   const { fileSearch } = await import("@/lib/tools/fileSearch");
-  return fileSearch({ query, max_results });
+  return fileSearch({ query, max_results, provider });
 };
 
 export const functionsMap = {

--- a/lib/localVectorStore.ts
+++ b/lib/localVectorStore.ts
@@ -1,0 +1,94 @@
+import fs from "fs/promises";
+import path from "path";
+import crypto from "crypto";
+import ollama from "ollama";
+import { KB_FOLDERS } from "@/config/demoData";
+
+const STORE_PATH = path.join(process.cwd(), "data", "local_vector_store.json");
+
+interface Entry {
+  id: string;
+  embedding: number[];
+  text: string;
+  attributes: {
+    type: string;
+    filename: string;
+    filepath: string;
+  };
+}
+
+function cosineSimilarity(a: number[], b: number[]) {
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
+class LocalVectorStore {
+  private store: Entry[] = [];
+  private loaded = false;
+
+  private async ensureLoaded() {
+    if (this.loaded) return;
+    try {
+      const data = await fs.readFile(STORE_PATH, "utf8");
+      this.store = JSON.parse(data);
+    } catch {
+      this.store = [];
+    }
+    this.loaded = true;
+  }
+
+  private async embedding(text: string): Promise<number[]> {
+    const model = process.env.OLLAMA_MODEL || "llama3";
+    const res = await ollama.embeddings({ model, prompt: text });
+    return res.embedding;
+  }
+
+  async initialize() {
+    await this.ensureLoaded();
+    if (this.store.length > 0) return;
+    for (const folder of KB_FOLDERS) {
+      const dir = path.join(process.cwd(), "public", folder);
+      const files = await fs.readdir(dir);
+      for (const file of files) {
+        const filePath = path.join(dir, file);
+        const text = await fs.readFile(filePath, "utf8");
+        const embedding = await this.embedding(text);
+        this.store.push({
+          id: crypto.randomUUID(),
+          embedding,
+          text,
+          attributes: {
+            type: folder,
+            filename: file.replace(/\.md$/, ""),
+            filepath: `/public/${folder}/${file}`,
+          },
+        });
+      }
+    }
+    await fs.mkdir(path.dirname(STORE_PATH), { recursive: true });
+    await fs.writeFile(STORE_PATH, JSON.stringify(this.store, null, 2));
+  }
+
+  async search(query: string, max_results = 5) {
+    await this.ensureLoaded();
+    if (this.store.length === 0) return [];
+    const qEmbed = await this.embedding(query);
+    return this.store
+      .map((e) => ({
+        text: e.text,
+        attributes: e.attributes,
+        score: cosineSimilarity(qEmbed, e.embedding),
+      }))
+      .sort((a, b) => b.score - a.score)
+      .slice(0, max_results);
+  }
+}
+
+export const localVectorStore = new LocalVectorStore();

--- a/lib/providers/ollama.ts
+++ b/lib/providers/ollama.ts
@@ -37,7 +37,7 @@ export async function* ollamaProvider(messages: any[], tools: any): AsyncGenerat
       ? lastUser.content.map((c: any) => (typeof c === "string" ? c : c.text || "")).join(" ")
       : String(lastUser.content ?? "");
     try {
-      const results = await search_files({ query: q });
+      const results = await search_files({ query: q, provider: "ollama" });
       if (results && !(results as any).error) {
         const searchResults = results.data || results.results || [];
         const snippets = searchResults

--- a/lib/tools/fileSearch.ts
+++ b/lib/tools/fileSearch.ts
@@ -1,11 +1,26 @@
 import { VECTOR_STORE_ID } from "@/config/constants";
+import { localVectorStore } from "@/lib/localVectorStore";
 
 export interface FileSearchParams {
   query: string;
   max_results?: number;
+  provider?: string;
 }
 
-export async function fileSearch({ query, max_results = 5 }: FileSearchParams) {
+export async function fileSearch({
+  query,
+  max_results = 5,
+  provider,
+}: FileSearchParams) {
+  if (provider === "ollama") {
+    try {
+      const results = await localVectorStore.search(query, max_results);
+      return { results };
+    } catch (error) {
+      console.error("Local file search failed", error);
+      return { error: "Failed to search files" };
+    }
+  }
   try {
     const res = await fetch(
       `https://api.openai.com/v1/vector_stores/${VECTOR_STORE_ID}/search`,


### PR DESCRIPTION
## Summary
- implement `localVectorStore` using Ollama embeddings
- expose `/api/local_vector_store/init` to generate local embeddings
- search the local store when provider is `ollama`
- update `/init_vs` page for local store initialization
- document local store behaviour in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6877f6d0805c8333957f9f7c95933b01