### PR TITLE
Add forced reinitialization for local vector store

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,11 @@ When using the `ollama` provider you need a local server running.
    - **Initialize OpenAI vector store**: click the <kbd>OpenAI</kbd> button. Copy
      the returned vector store ID and paste it into
      `config/constants.ts` as `VECTOR_STORE_ID`.
-   - **Initialize Ollama vector store**: click the <kbd>Ollama</kbd> button to
-     generate embeddings locally. This stores the embeddings in the
-     `data/local_vector_store.json` file.
+  - **Initialize Ollama vector store**: click the <kbd>Ollama</kbd> button to
+    generate embeddings locally. This stores the embeddings in the
+    `data/local_vector_store.json` file. To rebuild the embeddings from scratch
+    later on, send a POST request to
+    `/api/local_vector_store/init?force=true`.
 
    The OpenAI vector store will be used when the provider is set to `openai`
    while the local store powers file search when using the `ollama` provider.

--- a/app/api/local_vector_store/init/route.ts
+++ b/app/api/local_vector_store/init/route.ts
@@ -1,9 +1,11 @@
 import { NextResponse } from "next/server";
 import { localVectorStore } from "@/lib/localVectorStore";
 
-export async function POST() {
+export async function POST(request: Request) {
   try {
-    await localVectorStore.initialize();
+    const url = new URL(request.url);
+    const force = url.searchParams.get("force") === "true";
+    await localVectorStore.initialize(force);
     return NextResponse.json({ success: true });
   } catch (error) {
     console.error("Error initializing local vector store:", error);

--- a/lib/localVectorStore.ts
+++ b/lib/localVectorStore.ts
@@ -50,9 +50,14 @@ class LocalVectorStore {
     return res.embedding;
   }
 
-  async initialize() {
-    await this.ensureLoaded();
-    if (this.store.length > 0) return;
+  async initialize(force = false) {
+    if (force) {
+      this.store = [];
+      this.loaded = true;
+    } else {
+      await this.ensureLoaded();
+      if (this.store.length > 0) return;
+    }
     for (const folder of KB_FOLDERS) {
       const dir = path.join(process.cwd(), "public", folder);
       const files = await fs.readdir(dir);


### PR DESCRIPTION
## Summary
- rebuild local vector store even if an existing store is present by passing `force` to `initialize`
- allow `/api/local_vector_store/init` to accept a `force` query param
- document how to force regeneration in the README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687801b23e6c83338879a7ed75ac7161