### PR TITLE
Move search_files to server-only module

### DIFF
--- a/config/functions.ts
+++ b/config/functions.ts
@@ -321,18 +321,7 @@ export const start_chat_session = async ({
   }
 };
 
-export const search_files = async ({
-  query,
-  max_results,
-  provider,
-}: {
-  query: string;
-  max_results?: number;
-  provider?: string;
-}) => {
-  const { fileSearch } = await import("@/lib/tools/fileSearch");
-  return fileSearch({ query, max_results, provider });
-};
+export { search_files } from "@/lib/server/searchFiles";
 
 export const functionsMap = {
   get_order: get_order,
@@ -349,6 +338,5 @@ export const functionsMap = {
   get_user_profile: get_user_profile,
   create_user_profile: create_user_profile,
   start_chat_session: start_chat_session,
-  search_files: search_files,
   // add more functions as needed
 };

--- a/lib/providers/ollama.ts
+++ b/lib/providers/ollama.ts
@@ -1,7 +1,7 @@
 import { ProviderEvent } from "./openai";
 import ollama from "ollama";
 import { randomUUID } from "crypto";
-import { search_files } from "@/config/functions";
+import { search_files } from "@/lib/server/searchFiles";
 
 const model = process.env.OLLAMA_MODEL || "llama3.2";
 const num_ctx = parseInt(process.env.OLLAMA_NUM_CTX || "4096", 10);

--- a/lib/server/searchFiles.ts
+++ b/lib/server/searchFiles.ts
@@ -1,0 +1,15 @@
+'use server'
+
+import { fileSearch } from '@/lib/tools/fileSearch';
+
+export async function search_files({
+  query,
+  max_results,
+  provider,
+}: {
+  query: string;
+  max_results?: number;
+  provider?: string;
+}) {
+  return fileSearch({ query, max_results, provider });
+}


### PR DESCRIPTION
## Summary
- create `lib/server/searchFiles.ts` as a server module
- export `search_files` from `config/functions.ts` without adding it to `functionsMap`
- update `ollama` provider to use the new module

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687806c97fb88333bac74a4bdfee12af