### PR TITLE
Fix Ollama tool usage

### DIFF
--- a/lib/assistant.ts
+++ b/lib/assistant.ts
@@ -2,7 +2,7 @@ import { DEVELOPER_PROMPT } from "@/config/constants";
 import { parse } from "partial-json";
 import { handleTool } from "@/lib/tools/tools-handling";
 import useConversationStore from "@/stores/useConversationStore";
-import { tools } from "@/lib/tools/tools";
+import { tools, ollamaTools } from "@/lib/tools/tools";
 import { Annotation } from "@/components/Annotations";
 import { functionsMap } from "@/config/functions";
 import useDataStore from "@/stores/useDataStore";
@@ -420,5 +420,5 @@ export const processMessages = async () => {
     }
   },
   modelProvider,
-  modelProvider === "ollama" ? [] : undefined);
+  modelProvider === "ollama" ? ollamaTools : undefined);
 };

--- a/lib/tools/tools.ts
+++ b/lib/tools/tools.ts
@@ -1,34 +1,45 @@
 import { toolsList } from "../../config/tools-list";
 import { VECTOR_STORE_ID } from "@/config/constants";
 
+/**
+ * Tool definitions used by the assistant. The OpenAI provider expects the
+ * builtin `file_search` tool referencing the remote vector store, while the
+ * Ollama provider only needs the function tools defined in `toolsList`.
+ */
+
+const functionTools = toolsList.map((tool) => {
+  const required = (tool as any).required ?? Object.keys(tool.parameters);
+  const toolDef: {
+    type: string;
+    name: string;
+    parameters: any;
+    strict: boolean;
+    description?: string;
+  } = {
+    type: "function",
+    name: tool.name,
+    parameters: {
+      type: "object",
+      properties: { ...tool.parameters },
+      required,
+      additionalProperties: false,
+    },
+    strict: required.length === Object.keys(tool.parameters).length,
+  };
+  if ((tool as any).description) {
+    toolDef.description = (tool as any).description;
+  }
+  return toolDef;
+});
+
+// Tools for the OpenAI provider (includes built-in file search)
 export const tools = [
   {
     type: "file_search",
     vector_store_ids: [VECTOR_STORE_ID],
   },
-  // Mapping toolsList into the expected tool definition format
-  ...toolsList.map((tool) => {
-    const required = (tool as any).required ?? Object.keys(tool.parameters);
-    const toolDef: {
-      type: string;
-      name: string;
-      parameters: any;
-      strict: boolean;
-      description?: string;
-    } = {
-      type: "function",
-      name: tool.name,
-      parameters: {
-        type: "object",
-        properties: { ...tool.parameters },
-        required,
-        additionalProperties: false,
-      },
-      strict: required.length === Object.keys(tool.parameters).length,
-    };
-    if ((tool as any).description) {
-      toolDef.description = (tool as any).description;
-    }
-    return toolDef;
-  }),
+  ...functionTools,
 ];
+
+// Tools for the Ollama provider (function tools only)
+export const ollamaTools = [...functionTools];


### PR DESCRIPTION
## Summary
- support tool calls when using the Ollama provider
- provide dedicated tool list without OpenAI file search

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687005d021608333b083b67d72001a32