### PR TITLE
Add model selector for Ollama

### DIFF
--- a/app/api/ollama/models/route.ts
+++ b/app/api/ollama/models/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import ollama from "ollama";
+
+const host = process.env.OLLAMA_HOST;
+if (host) {
+  try {
+    (ollama as any).defaults = { ...(ollama as any).defaults, host };
+  } catch {
+    try {
+      (ollama as any).config.host = host;
+    } catch {}
+  }
+}
+
+export async function GET() {
+  try {
+    const models = await ollama.list();
+    return NextResponse.json(models);
+  } catch (error) {
+    console.error("Error listing models:", error);
+    return NextResponse.json(
+      { error: (error as Error).message },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/turn_response/route.ts
+++ b/app/api/turn_response/route.ts
@@ -4,7 +4,7 @@ import { getProvider } from "@/lib/providers";
 
 export async function POST(request: Request) {
   try {
-    const { messages, tools, provider } = await request.json();
+    const { messages, tools, provider, model } = await request.json();
     console.log("Received messages:", messages);
 
     const lastMessage =
@@ -52,7 +52,7 @@ export async function POST(request: Request) {
     }
 
     const providerFn = getProvider(provider);
-    const events = providerFn(messages, tools);
+    const events = providerFn(messages, tools, { model });
 
     const stream = new ReadableStream({
       async start(controller) {

--- a/components/AgentView.tsx
+++ b/components/AgentView.tsx
@@ -23,7 +23,29 @@ export default function AgentView() {
     setAutoReply,
     modelProvider,
     setModelProvider,
+    ollamaModel,
+    setOllamaModel,
   } = useConversationStore();
+
+  const [availableModels, setAvailableModels] = React.useState<string[]>([]);
+
+  React.useEffect(() => {
+    const fetchModels = async () => {
+      try {
+        const res = await fetch("/api/ollama/models");
+        const data = await res.json();
+        const names = Array.isArray(data?.models)
+          ? data.models.map((m: any) => m.name)
+          : [];
+        setAvailableModels(names);
+      } catch (err) {
+        console.error("Failed to fetch models", err);
+      }
+    };
+    if (modelProvider === "ollama") {
+      fetchModels();
+    }
+  }, [modelProvider]);
 
   const handleSendMessage = async (message: string) => {
     if (!message.trim()) return;
@@ -61,6 +83,19 @@ export default function AgentView() {
           <option value="openai">OpenAI</option>
           <option value="ollama">Ollama</option>
         </select>
+        {modelProvider === "ollama" && (
+          <select
+            className="text-xs border rounded p-1"
+            value={ollamaModel}
+            onChange={(e) => setOllamaModel(e.target.value)}
+          >
+            {availableModels.map((m) => (
+              <option key={m} value={m}>
+                {m}
+              </option>
+            ))}
+          </select>
+        )}
       </div>
       <div className="w-full md:w-3/5">
         <Chat

--- a/lib/assistant.ts
+++ b/lib/assistant.ts
@@ -50,7 +50,8 @@ export const handleTurn = async (
   messages: any[],
   onMessage: (data: any) => void,
   provider = "openai",
-  toolsArg = tools
+  toolsArg = tools,
+  model?: string
 ) => {
   try {
     // Get response from the API (defined in app/api/turn_response/route.ts)
@@ -61,6 +62,7 @@ export const handleTurn = async (
         messages: messages,
         tools: toolsArg,
         provider,
+        model,
       }),
     });
 
@@ -142,6 +144,7 @@ export const processMessages = async () => {
     removeRecommendedAction,
     autoReply,
     modelProvider,
+    ollamaModel,
   } = useConversationStore.getState();
 
   const { setRelevantArticlesLoading, setFAQExtracts } =
@@ -420,5 +423,6 @@ export const processMessages = async () => {
     }
   },
   modelProvider,
-  modelProvider === "ollama" ? ollamaTools : undefined);
+  modelProvider === "ollama" ? ollamaTools : undefined,
+  modelProvider === "ollama" ? ollamaModel : undefined);
 };

--- a/lib/providers/index.ts
+++ b/lib/providers/index.ts
@@ -2,9 +2,14 @@ import { openaiProvider } from "./openai";
 import { ollamaProvider } from "./ollama";
 import type { ProviderEvent } from "./openai";
 
+export interface ProviderOptions {
+  model?: string;
+}
+
 export type ProviderFunction = (
   messages: any[],
-  tools: any
+  tools: any,
+  options?: ProviderOptions
 ) => AsyncGenerator<ProviderEvent>;
 
 export function getProvider(name: string | undefined): ProviderFunction {

--- a/lib/providers/ollama.ts
+++ b/lib/providers/ollama.ts
@@ -2,8 +2,9 @@ import { ProviderEvent } from "./openai";
 import ollama from "ollama";
 import { randomUUID } from "crypto";
 import { search_files } from "@/lib/server/searchFiles";
+import type { ProviderOptions } from "./index";
 
-const model = process.env.OLLAMA_MODEL || "llama3.2";
+const defaultModel = process.env.OLLAMA_MODEL || "llama3.2";
 const num_ctx = parseInt(process.env.OLLAMA_NUM_CTX || "4096", 10);
 const host = process.env.OLLAMA_HOST;
 
@@ -19,7 +20,12 @@ if (host) {
   }
 }
 
-export async function* ollamaProvider(messages: any[], tools: any): AsyncGenerator<ProviderEvent> {
+export async function* ollamaProvider(
+  messages: any[],
+  tools: any,
+  options?: ProviderOptions
+): AsyncGenerator<ProviderEvent> {
+  const model = options?.model || defaultModel;
   const converted = (messages || []).map((m: any) => ({
     role: m.role === "developer" ? "system" : m.role,
     content: Array.isArray(m.content)

--- a/lib/providers/openai.ts
+++ b/lib/providers/openai.ts
@@ -1,12 +1,18 @@
 import OpenAI from "openai";
 import { MODEL } from "@/config/constants";
+import type { ProviderOptions } from "./index";
 
 export interface ProviderEvent {
   event: string;
   data: any;
 }
 
-export async function* openaiProvider(messages: any[], tools: any): AsyncGenerator<ProviderEvent> {
+export async function* openaiProvider(
+  messages: any[],
+  tools: any,
+  _opts?: ProviderOptions
+): AsyncGenerator<ProviderEvent> {
+  void _opts;
   const openai = new OpenAI();
   const events = await openai.responses.create({
     model: MODEL,

--- a/stores/useConversationStore.ts
+++ b/stores/useConversationStore.ts
@@ -37,6 +37,9 @@ interface ConversationState {
   modelProvider: string;
   setModelProvider: (provider: string) => void;
 
+  ollamaModel: string;
+  setOllamaModel: (model: string) => void;
+
   setChatMessages: (items: Item[]) => void;
   setConversationItems: (messages: any[]) => void;
   addChatMessage: (item: Item) => void;
@@ -65,11 +68,13 @@ const useConversationStore = create<ConversationState>((set) => ({
   agentTyping: false,
   autoReply: true,
   modelProvider: "openai",
+  ollamaModel: "llama3.2",
   composerText: "",
   setUserTyping: (typing) => set({ userTyping: typing }),
   setAgentTyping: (typing) => set({ agentTyping: typing }),
   setAutoReply: (flag) => set({ autoReply: flag }),
   setModelProvider: (provider) => set({ modelProvider: provider }),
+  setOllamaModel: (model) => set({ ollamaModel: model }),
   setComposerText: (text) => set({ composerText: text }),
   setChatMessages: (items) => set({ chatMessages: items }),
   setConversationItems: (messages) => set({ conversationItems: messages }),


### PR DESCRIPTION
## Summary
- support custom Ollama model in conversation store
- fetch available models and let agent view pick a model
- pass selected model through `handleTurn` and API
- update provider logic to use chosen model
- expose an API route to list Ollama models

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687895854c0c83338b943c100e88dbc6