### PR TITLE
Fix ESLint warning in ListArticles

### DIFF
--- a/components/ListArticles.tsx
+++ b/components/ListArticles.tsx
@@ -48,7 +48,7 @@ export default function ListArticles({
     };
 
     fetchFiles();
-  }, []);
+  }, [folder]);
 
   useEffect(() => {
     const urlParams = new URLSearchParams(window.location.search);


### PR DESCRIPTION
## Summary
- fix ESLint warnings by adding `folder` to the dependency array of the first `useEffect`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6878a6a3ee6c833396e4086d50b44840