### PR TITLE
Clarify dependency install step

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ When using the `ollama` provider you need a local server running.
    npm install
    ```
 
+   You must run this command before executing `npm run lint` or `npm run dev`.
+
 6. **Run the app:**
 
    ```bash


### PR DESCRIPTION
## Summary
- add note that `npm install` must run before `npm run lint` or `npm run dev`

## Testing
- `npm run lint`
- `npm run dev` *(server start & stop)*

------
https://chatgpt.com/codex/tasks/task_e_6878a80978008333a33caf7bda4d1dbc