### PR TITLE
Handle empty Ollama responses

### DIFF
--- a/lib/assistant.ts
+++ b/lib/assistant.ts
@@ -351,6 +351,15 @@ export const processMessages = async () => {
         // After output item is done, adding tool call ID
         const { item } = data || {};
 
+        if (
+          item?.type === "message" &&
+          item.role === "assistant" &&
+          (!item.content || !(item.content as string).trim())
+        ) {
+          // ignore empty assistant messages
+          break;
+        }
+
         conversationItems.push({
           ...item,
           results: undefined,

--- a/lib/providers/ollama.ts
+++ b/lib/providers/ollama.ts
@@ -121,10 +121,15 @@ export async function* ollamaProvider(
     }
 
     if (chunk.done) {
+      let msg = finalText;
+      if (!msg.trim()) {
+        msg = "Ollama returned no content";
+        yield { event: "error", data: { message: msg } } as ProviderEvent;
+      }
       yield { event: "response.output_text.done", data: {} } as ProviderEvent;
       yield {
         event: "response.output_item.done",
-        data: { item: { type: "message", role: "assistant", content: finalText } },
+        data: { item: { type: "message", role: "assistant", content: msg } },
       } as ProviderEvent;
     }
   }


### PR DESCRIPTION
## Summary
- flag missing content when Ollama streaming ends
- ignore blank assistant messages in `processMessages`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6878b32ead4c8333baa431e6e03f0131