### PR TITLE
Handle article search failures

### DIFF
--- a/components/RelevantArticles.tsx
+++ b/components/RelevantArticles.tsx
@@ -45,6 +45,7 @@ function ArticleSkeleton() {
 
 export default function RelevantArticles() {
   const FAQExtracts = useDataStore((s) => s.FAQExtracts);
+  const relevantArticlesError = useDataStore((s) => s.relevantArticlesError);
   const relevantArticlesLoading = useDataStore(
     (s) => s.relevantArticlesLoading
   );
@@ -56,6 +57,8 @@ export default function RelevantArticles() {
           <ArticleSkeleton />
           <ArticleSkeleton />
         </>
+      ) : relevantArticlesError ? (
+        <div className="text-sm text-zinc-500">{relevantArticlesError}</div>
       ) : (
         FAQExtracts?.map((article, index) => (
           <Article

--- a/lib/assistant.ts
+++ b/lib/assistant.ts
@@ -147,7 +147,7 @@ export const processMessages = async () => {
     ollamaModel,
   } = useConversationStore.getState();
 
-  const { setRelevantArticlesLoading, setFAQExtracts } =
+  const { setRelevantArticlesLoading, setFAQExtracts, setRelevantArticlesError } =
     useDataStore.getState();
 
   const allConversationItems = [
@@ -258,6 +258,7 @@ export const processMessages = async () => {
           }
           case "file_search_call": {
             setRelevantArticlesLoading(true);
+            setRelevantArticlesError(null);
             chatMessages.push({
               type: "tool_call",
               tool_type: "file_search_call",
@@ -407,6 +408,7 @@ export const processMessages = async () => {
         if (item.type === "file_search_call") {
           setFAQExtracts(item.results);
           setRelevantArticlesLoading(false);
+          setRelevantArticlesError(null);
         }
 
         setConversationItems([...conversationItems]);
@@ -422,6 +424,8 @@ export const processMessages = async () => {
           role: "agent",
           content: [{ type: "output_text", text: message }],
         });
+        setRelevantArticlesError(message);
+        setRelevantArticlesLoading(false);
         setSuggestedMessage(null);
         setSuggestedMessageDone(false);
         setAgentTyping(false);

--- a/lib/localVectorStore.ts
+++ b/lib/localVectorStore.ts
@@ -83,7 +83,9 @@ class LocalVectorStore {
 
   async search(query: string, max_results = 5) {
     await this.ensureLoaded();
-    if (this.store.length === 0) return [];
+    if (this.store.length === 0) {
+      throw new Error("Local vector store is empty");
+    }
     const qEmbed = await this.embedding(query);
     return this.store
       .map((e) => ({

--- a/lib/providers/ollama.ts
+++ b/lib/providers/ollama.ts
@@ -44,7 +44,9 @@ export async function* ollamaProvider(
       : String(lastUser.content ?? "");
     try {
       const results = await search_files({ query: q, provider: "ollama" });
-      if (results && !(results as any).error) {
+      if (results && (results as any).error) {
+        yield { event: "error", data: { message: (results as any).error } } as ProviderEvent;
+      } else if (results) {
         const searchResults = results.data || results.results || [];
         const snippets = searchResults
           .map((r: any) => r.text)
@@ -69,6 +71,10 @@ export async function* ollamaProvider(
       }
     } catch (err) {
       console.error("search_files failed", err);
+      yield {
+        event: "error",
+        data: { message: (err as Error).message },
+      } as ProviderEvent;
     }
   }
 

--- a/lib/tools/fileSearch.ts
+++ b/lib/tools/fileSearch.ts
@@ -18,7 +18,9 @@ export async function fileSearch({
       return { results };
     } catch (error) {
       console.error("Local file search failed", error);
-      return { error: "Failed to search files" };
+      return {
+        error: error instanceof Error ? error.message : "Failed to search files",
+      };
     }
   }
   try {
@@ -40,6 +42,8 @@ export async function fileSearch({
     return await res.json();
   } catch (error) {
     console.error("Error searching files:", error);
-    return { error: "Failed to search files" };
+    return {
+      error: error instanceof Error ? error.message : "Failed to search files",
+    };
   }
 }

--- a/stores/useDataStore.ts
+++ b/stores/useDataStore.ts
@@ -43,10 +43,12 @@ type ContextItem = OrderContextItem | TicketContextItem;
 interface DataState {
   customerDetails: CustomerDetails;
   FAQExtracts?: FAQExtract[] | null;
+  relevantArticlesError: string | null;
   relevantArticlesLoading: boolean;
   additionalContext?: ContextItem[] | null;
   setCustomerDetails: (details: CustomerDetails) => void;
   setFAQExtracts: (searchResults: any[]) => void;
+  setRelevantArticlesError: (error: string | null) => void;
   setAdditionalContext: (context: ContextItem[]) => void;
   setRelevantArticlesLoading: (loading: boolean) => void;
   addContextItem: (item: ContextItem) => void;
@@ -65,6 +67,7 @@ const getFileUrl = (type: string, filename: string) => {
 const useDataStore = create<DataState>((set) => ({
   customerDetails: CUSTOMER_DETAILS,
   FAQExtracts: DEFAULT_ARTICLES,
+  relevantArticlesError: null,
   relevantArticlesLoading: false,
   additionalContext: null,
   setCustomerDetails: (details) => set({ customerDetails: details }),
@@ -88,8 +91,10 @@ const useDataStore = create<DataState>((set) => ({
     const sortedArticles = articles.sort((a, b) => b.score - a.score);
     set({
       FAQExtracts: sortedArticles.filter((a) => a.score > 0.5),
+      relevantArticlesError: null,
     });
   },
+  setRelevantArticlesError: (error) => set({ relevantArticlesError: error }),
   setAdditionalContext: (context) => set({ additionalContext: context }),
   addContextItem: (item) =>
     set((state) => ({


### PR DESCRIPTION
## Summary
- surface failures when local search isn't available
- propagate file search errors through providers
- display a message when relevant articles can't be retrieved

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6878bb5b4240833391eee0c8673eb606