### PR TITLE
Fix vector store search payload

### DIFF
--- a/lib/tools/fileSearch.ts
+++ b/lib/tools/fileSearch.ts
@@ -2,11 +2,19 @@ import { VECTOR_STORE_ID } from "@/config/constants";
 
 export interface FileSearchParams {
   query: string;
-  max_results?: number;
+  max_results?: number | string;
 }
 
-export async function fileSearch({ query, max_results = 5 }: FileSearchParams) {
+export async function fileSearch({ query, max_results }: FileSearchParams) {
   try {
+    const payload: Record<string, any> = { query };
+    if (max_results !== undefined && max_results !== null) {
+      const maxNumResults = Number(max_results);
+      if (!Number.isNaN(maxNumResults)) {
+        payload.max_num_results = maxNumResults;
+      }
+    }
+
     const res = await fetch(
       `https://api.openai.com/v1/vector_stores/${VECTOR_STORE_ID}/search`,
       {
@@ -16,7 +24,7 @@ export async function fileSearch({ query, max_results = 5 }: FileSearchParams) {
           Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
           "OpenAI-Beta": "assistants=v2",
         },
-        body: JSON.stringify({ query, max_results }),
+        body: JSON.stringify(payload),
       }
     );
     if (!res.ok) {


### PR DESCRIPTION
## Summary
- send `max_num_results` instead of `max_results` when searching a vector store
- parse max_results values as numbers before sending
- confirm search call works with correct payload

## Testing
- `npm run lint`
- `npm run build`
- `curl -s -X POST https://api.openai.com/v1/vector_stores/vs_6869490c152c8191b2ab2b379b9faba2/search -H "Content-Type: application/json" -H "Authorization: Bearer $OPENAI_API_KEY" -H "OpenAI-Beta: assistants=v2" -d '{"query":"test","max_num_results":1}' | head -n 10`

------
https://chatgpt.com/codex/tasks/task_e_6879517155bc8333af3561cba517bb63