### PR TITLE
Fix Ollama provider tool calls

### DIFF
--- a/config/functions.ts
+++ b/config/functions.ts
@@ -2,7 +2,8 @@
 // Define one function per tool call - each tool call should have a matching function
 // Parameters for a tool call are passed as an object to the corresponding function
 import useDataStore from "@/stores/useDataStore";
-import { search_files } from "./functions";
+import useConversationStore from "@/stores/useConversationStore";
+import { search_files as serverSearchFiles } from "@/lib/server/searchFiles";
 
 const setDetailsFromUser = (user: any) => ({
   id: user.id,
@@ -322,7 +323,16 @@ export const start_chat_session = async ({
   }
 };
 
-export { search_files } from "@/lib/server/searchFiles";
+export const search_files = async ({
+  query,
+  max_results,
+}: {
+  query: string;
+  max_results?: number;
+}) => {
+  const provider = useConversationStore.getState().modelProvider;
+  return serverSearchFiles({ query, max_results, provider });
+};
 
 export const functionsMap = {
   get_order: get_order,

--- a/lib/providers/ollama.ts
+++ b/lib/providers/ollama.ts
@@ -26,12 +26,14 @@ export async function* ollamaProvider(
   options?: ProviderOptions
 ): AsyncGenerator<ProviderEvent> {
   const model = options?.model || defaultModel;
-  const converted = (messages || []).map((m: any) => ({
-    role: m.role === "developer" ? "system" : m.role,
-    content: Array.isArray(m.content)
-      ? m.content.map((c: any) => (typeof c === "string" ? c : c.text || "")).join(" ")
-      : String(m.content ?? ""),
-  }));
+  const converted = (messages || [])
+    .filter((m: any) => m.role)
+    .map((m: any) => ({
+      role: m.role === "developer" ? "system" : m.role,
+      content: Array.isArray(m.content)
+        ? m.content.map((c: any) => (typeof c === "string" ? c : c.text || "")).join(" ")
+        : String(m.content ?? ""),
+    }));
 
   const hasFileSearchTool =
     Array.isArray(tools) &&


### PR DESCRIPTION
## Summary
- use conversation store provider when calling `search_files`
- filter out non-message items when converting messages for Ollama

## Testing
- `npm run lint` *(fails: `npm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68795441abd08333b1a384a929af54aa