### PR TITLE
Handle invalid max_results in fileSearch

### DIFF
--- a/lib/tools/fileSearch.ts
+++ b/lib/tools/fileSearch.ts
@@ -12,6 +12,11 @@ export async function fileSearch({
   max_results = 5,
   provider,
 }: FileSearchParams) {
+  // Fallback to default when max_results is missing or not positive
+  max_results =
+    typeof max_results === "number" && max_results > 0
+      ? Math.floor(max_results)
+      : 5;
   if (provider === "ollama") {
     try {
       const results = await localVectorStore.search(query, max_results);


### PR DESCRIPTION
## Summary
- sanitize `max_results` before searching
- fallback to `5` when given 0 or negative

## Testing
- `npm run lint`
- `npx tsx test_ollama.ts` (default 5 used for `ollama` provider)
- `npx tsx test.ts` (default 5 used for OpenAI provider)


------
https://chatgpt.com/codex/tasks/task_e_687961984a1483338cd0110bfc7ba680