### PR TITLE
Restore Ollama provider generator

### DIFF
--- a/app/api/turn_response/route.ts
+++ b/app/api/turn_response/route.ts
@@ -52,23 +52,7 @@ export async function POST(request: Request) {
     }
 
     const providerFn = getProvider(provider);
-
-    if (provider === "ollama") {
-      try {
-        const text = (await providerFn(messages, tools, { model })) as string;
-        return new Response(text, {
-          headers: { "Content-Type": "text/plain" },
-        });
-      } catch (error) {
-        console.error("Error in ollama provider:", error);
-        return NextResponse.json(
-          { error: error instanceof Error ? error.message : "Unknown error" },
-          { status: 500 }
-        );
-      }
-    }
-
-    const events = providerFn(messages, tools, { model }) as AsyncGenerator<any>;
+    const events = providerFn(messages, tools, { model });
 
     const stream = new ReadableStream({
       async start(controller) {

--- a/lib/providers/index.ts
+++ b/lib/providers/index.ts
@@ -1,5 +1,5 @@
 import { openaiProvider } from "./openai";
-import { ollamaSimple } from "./ollama";
+import { ollamaProvider } from "./ollama";
 import type { ProviderEvent } from "./openai";
 
 export interface ProviderOptions {
@@ -10,14 +10,14 @@ export type ProviderFunction = (
   messages: any[],
   tools: any,
   options?: ProviderOptions
-) => AsyncGenerator<ProviderEvent> | Promise<string>;
+) => AsyncGenerator<ProviderEvent>;
 
 export function getProvider(name: string | undefined): ProviderFunction {
-  switch (name) {
-    case "ollama":
-      return ollamaSimple as ProviderFunction;
-    case "openai":
-    default:
-      return openaiProvider;
-  }
+    switch (name) {
+      case "ollama":
+        return ollamaProvider;
+      case "openai":
+      default:
+        return openaiProvider;
+    }
 }

--- a/lib/providers/ollama.ts
+++ b/lib/providers/ollama.ts
@@ -1,4 +1,6 @@
+import { ProviderEvent } from "./openai";
 import ollama from "ollama";
+import { randomUUID } from "crypto";
 import type { ProviderOptions } from "./index";
 
 const defaultModel = process.env.OLLAMA_MODEL || "llama3.2";
@@ -17,11 +19,11 @@ if (host) {
   }
 }
 
-export async function ollamaSimple(
+export async function* ollamaProvider(
   messages: any[],
   tools: any,
   options?: ProviderOptions
-): Promise<string> {
+): AsyncGenerator<ProviderEvent> {
   const model = options?.model || defaultModel;
   const converted = (messages || [])
     .filter((m: any) => m.role)
@@ -31,32 +33,78 @@ export async function ollamaSimple(
         ? m.content.map((c: any) => (typeof c === "string" ? c : c.text || "")).join(" ")
         : String(m.content ?? ""),
     }));
-
-  const payload = {
-    model,
-    messages: converted,
-    tools,
-    stream: true,
-    options: { num_ctx },
-  } as const;
-
-  console.log("ollama.chat payload", payload);
+  let finalText = "";
 
   let stream: any;
   try {
+    const payload = {
+      model,
+      messages: converted,
+      tools,
+      stream: true,
+      options: { num_ctx },
+    } as const;
+    console.log("ollama.chat payload", payload);
     stream = await ollama.chat(payload);
   } catch (error) {
-    console.error("ollama.chat failed", error);
-    throw error;
+    console.error("ollama.chat failed", error, "finalText length", 0);
+    yield {
+      event: "error",
+      data: { message: (error as Error).message },
+    } as ProviderEvent;
+    return;
   }
 
-  let finalText = "";
+  const seenCalls = new Set<string>();
+
   for await (const chunk of stream) {
+    console.log(
+      "Stream chunk:",
+      JSON.stringify(chunk).slice(0, 80),
+      "tool calls detected:",
+      (chunk.message?.tool_calls || []).length > 0
+    );
     const content = chunk.message?.content ?? "";
     if (content) {
       finalText += content;
+      yield { event: "response.output_text.delta", data: { delta: content } } as ProviderEvent;
+    }
+
+    const toolCalls = chunk.message?.tool_calls || [];
+    for (const call of toolCalls) {
+      const id = (call as any).id ?? randomUUID();
+      if (seenCalls.has(id)) continue;
+      seenCalls.add(id);
+      const args = JSON.stringify(call.function?.arguments ?? {});
+      yield {
+        event: "response.output_item.added",
+        data: { item: { type: "function_call", id, name: call.function?.name, call_id: id, arguments: "" } },
+      } as ProviderEvent;
+      if (args) {
+        yield { event: "response.function_call_arguments.delta", data: { item_id: id, delta: args } } as ProviderEvent;
+        yield { event: "response.function_call_arguments.done", data: { item_id: id, arguments: args } } as ProviderEvent;
+      }
+      yield {
+        event: "response.output_item.done",
+        data: { item: { type: "function_call", id, name: call.function?.name, call_id: id, arguments: args } },
+      } as ProviderEvent;
+    }
+
+    if (chunk.done) {
+      if (finalText.trim()) {
+        yield { event: "response.output_text.done", data: {} } as ProviderEvent;
+        yield {
+          event: "response.output_item.done",
+          data: { item: { type: "message", role: "assistant", content: finalText } },
+        } as ProviderEvent;
+      } else if (seenCalls.size === 0) {
+        const msg = "Ollama returned no content";
+        console.error("No content returned", "finalText length", finalText.length);
+        yield { event: "error", data: { message: msg } } as ProviderEvent;
+      } else {
+        yield { event: "response.output_text.done", data: {} } as ProviderEvent;
+      }
     }
   }
-
-  return finalText;
 }
+


### PR DESCRIPTION
## Summary
- revert to the async generator implementation of the Ollama provider
- emit streaming events (`response.output_text.delta`, `response.function_call_arguments.delta`, etc.) again
- update provider registry to return the restored generator
- simplify the turn response API to stream from the provider

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_687a87f28ac88333bddb59920055d0b4