### PR TITLE
Add Ollama OpenAI-compatible provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,6 @@ DATABASE_URL="postgresql://user:password@localhost:5432/dbname"
 OLLAMA_MODEL=llama3.2
 OLLAMA_NUM_CTX=4096
 OLLAMA_HOST=http://localhost:11434
+# Base URL and API key for Ollama's OpenAI compatible endpoint
+OLLAMA_OPENAI_BASE_URL=http://localhost:11434/v1
+OLLAMA_OPENAI_API_KEY=ollama

--- a/README.md
+++ b/README.md
@@ -60,11 +60,12 @@ Feel free to customize this demo to suit your specific use case.
 
 4. **Choose your provider (optional):**
 
-   The assistant can run using either the `openai` API or the `ollama` package.
-   You can switch providers from the dropdown next to **Auto reply** in the
-   agent view. When selecting `ollama`, make sure you have an Ollama server
-   running locally (e.g. by executing `ollama serve`). The built-in tools work
-   the same with both providers.
+   The assistant can run using the `openai` API, the `ollama` package, or
+   Ollama's OpenAI compatible endpoint. You can switch providers from the
+   dropdown next to **Auto reply** in the agent view. When selecting either
+   `ollama` or `ollama-openai`, make sure you have an Ollama server running
+   locally (e.g. by executing `ollama serve`). The built-in tools work the same
+   with all providers.
 
 ## Running Ollama
 
@@ -92,6 +93,13 @@ When using the `ollama` provider you need a local server running.
    OLLAMA_MODEL=llama3.2
    OLLAMA_NUM_CTX=4096
    OLLAMA_HOST=http://localhost:11434
+   ```
+
+   To enable the OpenAI compatible endpoint, also set:
+
+   ```bash
+   OLLAMA_OPENAI_BASE_URL=http://localhost:11434/v1
+   OLLAMA_OPENAI_API_KEY=ollama
    ```
 
 5. **Install dependencies:**

--- a/components/AgentView.tsx
+++ b/components/AgentView.tsx
@@ -82,8 +82,9 @@ export default function AgentView() {
         >
           <option value="openai">OpenAI</option>
           <option value="ollama">Ollama</option>
+          <option value="ollama-openai">Ollama (OpenAI compat)</option>
         </select>
-        {modelProvider === "ollama" && (
+        {(modelProvider === "ollama" || modelProvider === "ollama-openai") && (
           <select
             className="text-xs border rounded p-1"
             value={ollamaModel}

--- a/lib/assistant.ts
+++ b/lib/assistant.ts
@@ -166,7 +166,10 @@ export const processMessages = async () => {
   const { setRelevantArticlesLoading, setFAQExtracts, setRelevantArticlesError } =
     useDataStore.getState();
 
-  let activeTools: any[] = modelProvider === "ollama" ? [] : [...tools];
+  let activeTools: any[] =
+    modelProvider === "ollama" || modelProvider === "ollama-openai"
+      ? []
+      : [...tools];
 
   const lastUserIndex = [...conversationItems]
     .map((m, i) => [m, i] as const)

--- a/lib/providers/index.ts
+++ b/lib/providers/index.ts
@@ -1,5 +1,6 @@
 import { openaiProvider } from "./openai";
 import { ollamaProvider } from "./ollama";
+import { ollamaOpenAIProvider } from "./ollama_openai";
 import type { ProviderEvent } from "./openai";
 
 export interface ProviderOptions {
@@ -16,6 +17,8 @@ export function getProvider(name: string | undefined): ProviderFunction {
     switch (name) {
       case "ollama":
         return ollamaProvider;
+      case "ollama-openai":
+        return ollamaOpenAIProvider;
       case "openai":
       default:
         return openaiProvider;

--- a/lib/providers/ollama_openai.ts
+++ b/lib/providers/ollama_openai.ts
@@ -1,21 +1,23 @@
 import OpenAI from "openai";
 import { MODEL } from "@/config/constants";
 import type { ProviderOptions } from "./index";
+import type { ProviderEvent } from "./openai";
 
-export interface ProviderEvent {
-  event: string;
-  data: any;
-}
-
-export async function* openaiProvider(
+/**
+ * Provider that uses the OpenAI client against Ollama's
+ * OpenAI compatible endpoint.
+ */
+export async function* ollamaOpenAIProvider(
   messages: any[],
   tools: any,
   _opts?: ProviderOptions
 ): AsyncGenerator<ProviderEvent> {
   void _opts;
   const openai = new OpenAI({
-    baseURL: process.env.OPENAI_BASE_URL,
+    baseURL: process.env.OLLAMA_OPENAI_BASE_URL || "http://localhost:11434/v1",
+    apiKey: process.env.OLLAMA_OPENAI_API_KEY || "ollama",
   });
+
   const events = await openai.responses.create({
     model: MODEL,
     input: messages,

--- a/lib/tools/fileSearch.ts
+++ b/lib/tools/fileSearch.ts
@@ -17,7 +17,7 @@ export async function fileSearch({
     typeof max_results === "number" && max_results > 0
       ? Math.floor(max_results)
       : 5;
-  if (provider === "ollama") {
+  if (provider === "ollama" || provider === "ollama-openai") {
     try {
       const results = await localVectorStore.search(query, max_results);
       return { results };


### PR DESCRIPTION
## Summary
- support custom `OPENAI_BASE_URL` in OpenAI provider
- add `ollama-openai` provider that uses Ollama's OpenAI compatible API
- update provider chooser in the Agent view
- handle `ollama-openai` provider in assistant logic and file search
- document new provider and environment variables

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687a908a8c588333b555792e5ebcce12