### PR TITLE
Add UI option to rebuild local vector store

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,10 @@ When using the `ollama` provider you need a local server running.
      `config/constants.ts` as `VECTOR_STORE_ID`.
   - **Initialize Ollama vector store**: click the <kbd>Ollama</kbd> button to
     generate embeddings locally. This stores the embeddings in the
-    `data/local_vector_store.json` file. To rebuild the embeddings from scratch
-    later on, send a POST request to
-    `/api/local_vector_store/init?force=true`.
+    `data/local_vector_store.json` file.
+  - **Rebuild Ollama vector store**: click the <kbd>Rebuild Ollama</kbd> button
+    on the same page to regenerate embeddings after updating the knowledge base
+    (this calls `/api/local_vector_store/init?force=true`).
 
    The OpenAI vector store will be used when the provider is set to `openai`
    while the local store powers file search when using the `ollama` provider.

--- a/app/init_vs/page.tsx
+++ b/app/init_vs/page.tsx
@@ -107,6 +107,23 @@ export default function InitVS() {
     setLoadingOllama(false);
   };
 
+  const handleRebuildOllama = async () => {
+    setLoadingOllama(true);
+    setSuccessOllama(false);
+    setErrorOllama(null);
+    setStatusOllama("Rebuilding embeddings...");
+    const res = await fetch("/api/local_vector_store/init?force=true", {
+      method: "POST",
+    });
+    if (res.ok) {
+      setStatusOllama("Knowledge base rebuilt.");
+      setSuccessOllama(true);
+    } else {
+      setErrorOllama("Failed to rebuild vector store");
+    }
+    setLoadingOllama(false);
+  };
+
   return (
     <div className="h-screen w-full bg-white flex flex-col items-center pt-16 md:pt-32">
       <div className="flex flex-col gap-4 max-w-lg">
@@ -134,7 +151,7 @@ export default function InitVS() {
           ) : (
             <div className="text-sm text-zinc-500 animate-pulse">{statusOpenAI}</div>
           )}
-          {!loadingOllama ? (
+        {!loadingOllama ? (
             <div
               className="bg-black text-white text-sm font-medium py-2 px-4 rounded-lg hover:bg-zinc-800 cursor-pointer"
               onClick={handleInitializeOllama}
@@ -144,6 +161,14 @@ export default function InitVS() {
           ) : (
             <div className="text-sm text-zinc-500 animate-pulse">{statusOllama}</div>
           )}
+          {!loadingOllama ? (
+            <div
+              className="bg-black text-white text-sm font-medium py-2 px-4 rounded-lg hover:bg-zinc-800 cursor-pointer"
+              onClick={handleRebuildOllama}
+            >
+              Rebuild Ollama
+            </div>
+          ) : null}
         </div>
       </div>
       <div className="mt-6 text-left w-full max-w-lg space-y-4">


### PR DESCRIPTION
## Summary
- allow rebuilding local vector store from `/init_vs`
- document the new button in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e1cca65b88333b8bd0312a31ec77a