### PR TITLE
Implement multi-query search

### DIFF
--- a/config/functions.ts
+++ b/config/functions.ts
@@ -332,9 +332,11 @@ export const start_chat_session = async ({
 
 export const search_knowledge_base = async ({
   query,
+  queries,
   options,
 }: {
   query: string;
+  queries?: string[];
   options?: {
     domain_filter?: string | null;
     sort_by?: string | null;
@@ -365,30 +367,34 @@ export const search_knowledge_base = async ({
           ? options.sort_by
           : "relevance",
     };
-    if (lastSearchQuery === query && lastSearchResults) {
+    // Use all provided queries to build a stable cache key
+    const queryKey =
+      queries && queries.length > 0 ? queries.join("|") : query;
+    if (lastSearchQuery === queryKey && lastSearchResults) {
       setFAQExtracts(lastSearchResults, provider);
       setRelevantArticlesError(null);
       return { results: lastSearchResults };
     }
 
-    const cacheKey = `${query}|${finalOptions.domain_filter}|${finalOptions.sort_by}`;
+    const cacheKey = `${queryKey}|${finalOptions.domain_filter}|${finalOptions.sort_by}`;
     if (fileSearchCache.has(cacheKey)) {
       const cached = fileSearchCache.get(cacheKey)!;
       setFAQExtracts(cached, provider);
-      setLastSearchQuery(query);
+      setLastSearchQuery(queryKey);
       setLastSearchResults(cached);
       setRelevantArticlesError(null);
       return { results: cached };
     }
 
-    const result = await serverSearchKnowledgeBase({ 
-      query, 
-      provider, 
-      options: finalOptions, 
+    const result = await serverSearchKnowledgeBase({
+      query,
+      queries,
+      provider,
+      options: finalOptions,
     });
     if (result.results) {
       setFAQExtracts(result.results, provider);
-      setLastSearchQuery(query);
+      setLastSearchQuery(queryKey);
       setLastSearchResults(result.results);
       fileSearchCache.set(cacheKey, result.results);
       setRelevantArticlesError(null);

--- a/config/tools-list.ts
+++ b/config/tools-list.ts
@@ -15,6 +15,12 @@ export const toolsList = [
             type: "string",
             description: "The user question or search query.",
           },
+          queries: {
+            type: "array",
+            description:
+              "Optional list of search queries derived from the user question.",
+            items: { type: "string" },
+          },
           options: {
             type: "object",
             properties: {

--- a/lib/server/searchFiles.ts
+++ b/lib/server/searchFiles.ts
@@ -3,34 +3,75 @@
 import { fileSearch } from '@/lib/tools/fileSearch';
 import { localVectorStore } from '../localVectorStore';
 
+// Break a user query into smaller search phrases when `queries` isn't provided
+function splitQueries(query: string): string[] {
+  return query
+    .split(/(?:[.!?;,]|\band\b|\bor\b)/i)
+    .map((p) => p.trim())
+    .filter((p) => p);
+}
+
+/**
+ * Search the knowledge base using one or multiple queries.
+ * If `queries` is not provided, the single `query` string will be split into
+ * shorter phrases to broaden the search.
+ */
 export async function search_knowledge_base({
   query,
+  queries,
   provider,
   options,
 }: {
-  query: string;
+  query?: string;
+  queries?: string[];
   provider?: string;
   options?: {
     domain_filter: string | null;
     sort_by: string | null;
   };
 }) {
-  if (provider === 'ollama' || provider === 'ollama-openai') {
-    const max_results = 20;
-    const results = await localVectorStore.search(query, max_results);
-    let filtered = results;
-    if (options?.domain_filter) {
-      const df = options.domain_filter.toLowerCase();
-      filtered = filtered.filter((r) =>
-        r.attributes.type.toLowerCase().includes(df)
-      );
+  const searchParts =
+    queries && queries.length > 0
+      ? queries
+      : query
+      ? splitQueries(query)
+      : [];
+
+  const max_results = 20;
+  let collected: any[] = [];
+
+  for (const q of searchParts) {
+    if (provider === 'ollama' || provider === 'ollama-openai') {
+      const results = await localVectorStore.search(q, max_results);
+      collected = collected.concat(results);
+    } else {
+      const res = await fileSearch({ query: q, provider });
+      if (res.results) {
+        collected = collected.concat(res.results);
+      }
     }
-    if (options?.sort_by === 'alphabetical') {
-      filtered = [...filtered].sort((a, b) =>
-        a.attributes.filename.localeCompare(b.attributes.filename)
-      );
-    }
-    return { results: filtered };
   }
-  return fileSearch({ query, provider });
+
+  const seen = new Set<string>();
+  const merged = collected.filter((r) => {
+    const key = `${r.text}|${r.attributes?.filepath ?? ''}|${r.attributes?.chunk ?? ''}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+
+  let filtered = merged;
+  if (options?.domain_filter) {
+    const df = options.domain_filter.toLowerCase();
+    filtered = filtered.filter((r) =>
+      r.attributes?.type?.toLowerCase().includes(df)
+    );
+  }
+  if (options?.sort_by === 'alphabetical') {
+    filtered = [...filtered].sort((a, b) =>
+      (a.attributes?.filename ?? '').localeCompare(b.attributes?.filename ?? '')
+    );
+  }
+
+  return { results: filtered };
 }


### PR DESCRIPTION
## Summary
- extend knowledge base search tool schema with optional `queries` parameter
- update search wrapper and caching to handle multiple queries
- enhance server search logic to split queries and merge results

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fc6c9d44883338ef2d1ae26cee98d