### PR TITLE
Fix ollama tool args serialization

### DIFF
--- a/lib/providers/ollama.ts
+++ b/lib/providers/ollama.ts
@@ -45,6 +45,11 @@ export function convertMessages(messages: any[]) {
     .filter(Boolean);
 }
 
+export function serializeToolCallArgs(args: any): string {
+  if (typeof args === "string") return args;
+  return JSON.stringify(args ?? {});
+}
+
 export async function* ollamaProvider(
   messages: any[],
   tools: any,
@@ -95,7 +100,7 @@ const converted = convertMessages(messages);
       const id = (call as any).id ?? randomUUID();
       if (seenCalls.has(id)) continue;
       seenCalls.add(id);
-      const args = JSON.stringify(call.function?.arguments ?? {});
+      const args = serializeToolCallArgs(call.function?.arguments);
       yield {
         event: "response.output_item.added",
         data: { item: { type: "function_call", id, name: call.function?.name, call_id: id, arguments: "" } },

--- a/tests/provider.test.js
+++ b/tests/provider.test.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const test = require('node:test');
 require('ts-node/register/transpile-only');
-const { convertMessages } = require('../lib/providers/ollama.ts');
+const { convertMessages, serializeToolCallArgs } = require('../lib/providers/ollama.ts');
 
 test('ollamaProvider serializes function_call_output', () => {
   const messages = [
@@ -15,4 +15,14 @@ test('ollamaProvider serializes function_call_output', () => {
     { role: 'user', content: 'hi' },
     { role: 'tool', tool_call_id: '123', content: 'ok' },
   ]);
+});
+
+test('serializeToolCallArgs handles string arguments', () => {
+  const input = '{"a":1}';
+  assert.strictEqual(serializeToolCallArgs(input), input);
+});
+
+test('serializeToolCallArgs handles object arguments', () => {
+  const input = { a: 1 };
+  assert.strictEqual(serializeToolCallArgs(input), JSON.stringify(input));
 });


### PR DESCRIPTION
## Summary
- ensure ollamaProvider preserves string arguments
- expose helper to serialize tool call arguments
- test serialization of string and object arguments

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6888b8f2cdec8333a8a375a040c0f02d