### PR TITLE
Improve Ollama provider call tracking

### DIFF
--- a/lib/providers/ollama.ts
+++ b/lib/providers/ollama.ts
@@ -80,7 +80,7 @@ const converted = convertMessages(messages);
     return;
   }
 
-  const seenCalls = new Set<string>();
+  const calls = new Map<string, { name?: string; args: string }>();
 
   for await (const chunk of stream) {
     console.log(
@@ -98,31 +98,54 @@ const converted = convertMessages(messages);
     const toolCalls = chunk.message?.tool_calls || [];
     for (const call of toolCalls) {
       const id = (call as any).id ?? randomUUID();
-      if (seenCalls.has(id)) continue;
-      seenCalls.add(id);
-      const args = serializeToolCallArgs(call.function?.arguments);
-      yield {
-        event: "response.output_item.added",
-        data: { item: { type: "function_call", id, name: call.function?.name, call_id: id, arguments: "" } },
-      } as ProviderEvent;
-      if (args) {
-        yield { event: "response.function_call_arguments.delta", data: { item_id: id, delta: args } } as ProviderEvent;
-        yield { event: "response.function_call_arguments.done", data: { item_id: id, arguments: args } } as ProviderEvent;
+      let state = calls.get(id);
+      if (!state) {
+        state = { name: call.function?.name, args: "" };
+        calls.set(id, state);
+        yield {
+          event: "response.output_item.added",
+          data: { item: { type: "function_call", id, name: state.name, call_id: id, arguments: "" } },
+        } as ProviderEvent;
       }
-      yield {
-        event: "response.output_item.done",
-        data: { item: { type: "function_call", id, name: call.function?.name, call_id: id, arguments: args } },
-      } as ProviderEvent;
+
+      if (call.function?.arguments) {
+        state.args += call.function.arguments;
+        yield {
+          event: "response.function_call_arguments.delta",
+          data: { item_id: id, delta: call.function.arguments },
+        } as ProviderEvent;
+      }
     }
 
     if (chunk.done) {
+      for (const [id, state] of calls.entries()) {
+        yield {
+          event: "response.function_call_arguments.done",
+          data: { item_id: id, arguments: state.args },
+        } as ProviderEvent;
+        yield {
+          event: "response.output_item.done",
+          data: {
+            item: {
+              type: "function_call",
+              id,
+              name: state.name,
+              call_id: id,
+              arguments: state.args,
+            },
+          },
+        } as ProviderEvent;
+      }
+
       if (finalText.trim()) {
         yield { event: "response.output_text.done", data: {} } as ProviderEvent;
         yield {
           event: "response.output_item.done",
-          data: { item: { type: "message", role: "assistant", content: finalText } },
+          data: {
+            item: { type: "message", role: "assistant", content: finalText },
+          },
         } as ProviderEvent;
-      } else if (seenCalls.size === 0) {
+      } else if (calls.size === 0) {
         const msg = "Ollama returned no content";
         console.error("No content returned", "finalText length", finalText.length);
         yield { event: "error", data: { message: msg } } as ProviderEvent;

--- a/tests/provider.test.js
+++ b/tests/provider.test.js
@@ -26,3 +26,44 @@ test('serializeToolCallArgs handles object arguments', () => {
   const input = { a: 1 };
   assert.strictEqual(serializeToolCallArgs(input), JSON.stringify(input));
 });
+
+test('tool call arguments accumulate across chunks', async () => {
+  async function* gen() {
+    yield { message: { tool_calls: [ { id: '1', function: { name: 'do', arguments: '{"a":' } } ] } };
+    yield { message: { tool_calls: [ { id: '1', function: { arguments: '1}' } } ] } };
+    yield { message: { tool_calls: [] }, done: true };
+  }
+
+  const calls = new Map();
+  const events = [];
+  let finalText = '';
+  for await (const chunk of gen()) {
+    const toolCalls = chunk.message?.tool_calls || [];
+    for (const call of toolCalls) {
+      const id = call.id;
+      let state = calls.get(id);
+      if (!state) {
+        state = { name: call.function?.name, args: '' };
+        calls.set(id, state);
+        events.push({ event: 'response.output_item.added', id });
+      }
+      if (call.function?.arguments) {
+        state.args += call.function.arguments;
+        events.push({ event: 'response.function_call_arguments.delta', id, delta: call.function.arguments });
+      }
+    }
+
+    if (chunk.done) {
+      for (const [id, state] of calls.entries()) {
+        events.push({ event: 'response.function_call_arguments.done', id, arguments: state.args });
+        events.push({ event: 'response.output_item.done', id, arguments: state.args });
+      }
+      if (finalText.trim()) events.push({ event: 'response.output_text.done' });
+    }
+  }
+
+  const deltas = events.filter(e => e.event === 'response.function_call_arguments.delta');
+  assert.deepStrictEqual(deltas.map(d => d.delta), ['{"a":', '1}']);
+  const done = events.find(e => e.event === 'response.function_call_arguments.done');
+  assert.strictEqual(done.arguments, '{"a":1}');
+});


### PR DESCRIPTION
## Summary
- track ongoing tool calls in `ollamaProvider`
- accumulate function call arguments across chunks
- finalize tool call events only at completion
- test argument accumulation logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888c9c86b088333a83f03bdeaef78ab