### PR TITLE
Refactor create_ticket to generate session ID

### DIFF
--- a/config/demoData.ts
+++ b/config/demoData.ts
@@ -17,8 +17,6 @@ export const DEFAULT_ACTION: Action = {
   name: "create_ticket",
   parameters: {
     user_id: CUSTOMER_DETAILS.id,
-    type: "other",
-    details: "Need more help with the request",
   },
 };
 

--- a/config/functions.ts
+++ b/config/functions.ts
@@ -199,14 +199,8 @@ export const create_complaint = async ({
 
 export const create_ticket = async ({
   user_id,
-  type,
-  details,
-  order_id,
 }: {
-  user_id: string;
-  type: string;
-  details: string;
-  order_id: string;
+  user_id?: string;
 }) => {
   try {
     const res = await fetch(`/api/tickets/create`, {
@@ -214,9 +208,9 @@ export const create_ticket = async ({
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ user_id, type, details, order_id }),
+      body: JSON.stringify({ user_id }),
     }).then((res) => res.json());
-    return res;
+    return res.ticket_id;
   } catch (error) {
     console.error(error);
     return { error: "Failed to create ticket" };

--- a/config/tools-list.ts
+++ b/config/tools-list.ts
@@ -232,30 +232,16 @@ export const toolsList = [
     type: "function",
     function: {
       name: "create_ticket",
-      description: "Open a customer support ticket",
+      description:
+        "Generate a session ticket for customers without an email.",
       parameters: {
         type: "object",
         properties: {
           user_id: {
             type: "string",
-            description: "User ID to create ticket for",
-          },
-          type: {
-            type: "string",
-            description: "Type of ticket",
-            enum: ["bug_reported", "damaged_product", "other"],
-          },
-          details: {
-            type: "string",
-            description: "Details of the ticket",
-          },
-          order_id: {
-            type: "string",
-            description:
-              "Order ID linked to the ticket, N/A if not linked to an order",
+            description: "User ID to link the session with, if available",
           },
         },
-        required: ["user_id", "type", "details", "order_id"],
         additionalProperties: false,
       },
     },

--- a/public/knowledge_base/damaged_product.md
+++ b/public/knowledge_base/damaged_product.md
@@ -2,7 +2,7 @@
 
 When handling damaged product cases:
 Confirm damage using provided photographic evidence.
-Log the case in the internal system using the create_ticket tool.
+Log the case in the internal system by generating a session ticket with the create_ticket tool.
 Use the send_replacement tool to issue an immediate replacement.
 
 Inform the customer about the replacement timeline and next steps:


### PR DESCRIPTION
## Summary
- drop old ticket fields so `create_ticket` simply generates a session ID
- update default action and knowledge base references

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688a3a92569c8333acb3c123c6694a30