### PR TITLE
Support ticket-based chat sessions

### DIFF
--- a/app/api/sessions/start/route.ts
+++ b/app/api/sessions/start/route.ts
@@ -2,16 +2,20 @@ import prisma from "@/lib/prisma";
 
 export async function POST(request: Request) {
   try {
-    const { email, name, phone, address } = await request.json();
-    if (!email) {
+    const { email, ticket_id, name, phone, address } = await request.json();
+
+    const identifier = email || ticket_id;
+
+    if (!identifier) {
       return new Response(JSON.stringify({ error: "Email is required" }), {
         status: 400,
       });
     }
+
     const user = await prisma.user.upsert({
-      where: { email },
+      where: { email: identifier },
       update: { name, phone, address },
-      create: { email, name, phone, address },
+      create: { email: identifier, name, phone, address },
       include: { orders: true },
     });
     let session = await prisma.chatSession.findFirst({

--- a/config/functions.ts
+++ b/config/functions.ts
@@ -299,20 +299,24 @@ export const create_user_profile = async ({
 
 export const start_chat_session = async ({
   email,
+  ticket_id,
   name,
   phone,
   address,
 }: {
-  email: string;
+  email?: string;
+  ticket_id?: string;
   name?: string;
   phone?: string;
   address?: string;
 }) => {
   try {
+    const identifier = email || ticket_id;
+
     const res = await fetch(`/api/sessions/start`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ email, name, phone, address }),
+      body: JSON.stringify({ email: identifier, ticket_id, name, phone, address }),
     }).then((res) => res.json());
     if (res.user && !res.user.error) {
       useDataStore.getState().setCustomerDetails(setDetailsFromUser(res.user));


### PR DESCRIPTION
## Summary
- allow `/api/sessions/start` to use `ticket_id` as fallback identifier
- send `ticket_id` when starting a chat without an email

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a4c2aaddc8333bf6047e94912bfa6