### PR TITLE
Add Redis-based chat session summary storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,4 @@ OLLAMA_HOST=http://localhost:11434
 # Base URL and API key for Ollama's OpenAI compatible endpoint
 OLLAMA_OPENAI_BASE_URL=http://localhost:11434/v1
 OLLAMA_OPENAI_API_KEY=ollama
+REDIS_URL=redis://localhost:6379

--- a/README.md
+++ b/README.md
@@ -209,7 +209,13 @@ This demo can store customer profiles and chat sessions in a local PostgreSQL da
    npx prisma migrate deploy
    ```
 
-The new API endpoints under `/api/users` and `/api/sessions/start` allow the agent to create or retrieve customer records and chat sessions using this database.
+3. Configure Redis by setting `REDIS_URL` in your `.env` file:
+
+   ```bash
+   REDIS_URL=redis://localhost:6379
+   ```
+
+The new API endpoints under `/api/users`, `/api/sessions/start`, and `/api/sessions/[session_id]/save` allow the agent to create or retrieve customer records, manage chat sessions, and store conversation history using this database and Redis.
 
 ## Contributing
 

--- a/app/api/sessions/[session_id]/save/route.ts
+++ b/app/api/sessions/[session_id]/save/route.ts
@@ -1,0 +1,52 @@
+import prisma from "@/lib/prisma";
+import redis from "@/lib/redis";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ session_id: string }> }
+) {
+  try {
+    const { session_id } = await params;
+    const { messages, identifier } = await request.json();
+
+    if (!Array.isArray(messages)) {
+      return new Response(JSON.stringify({ error: "Messages array required" }), {
+        status: 400,
+      });
+    }
+
+    const session = await prisma.chatSession.findUnique({
+      where: { id: session_id },
+      include: { user: true },
+    });
+    if (!session) {
+      return new Response(JSON.stringify({ error: "Session not found" }), {
+        status: 404,
+      });
+    }
+
+    const updatedMessages = [...(session.messages as any[] || []), ...messages];
+
+    await prisma.chatSession.update({
+      where: { id: session_id },
+      data: { messages: updatedMessages },
+    });
+
+    // Build simple summary from last few messages
+    const last = updatedMessages.slice(-5)
+      .map((m: any) => (m.content || "")).join(" ");
+    const summary = last.slice(0, 200);
+
+    const key = identifier || session.user.email;
+    if (key) {
+      await redis.set(key, summary);
+    }
+
+    return new Response(JSON.stringify({ success: true, summary }), {
+      status: 200,
+    });
+  } catch (error) {
+    console.error("Error saving session messages:", error);
+    return new Response("Error saving session messages", { status: 500 });
+  }
+}

--- a/app/api/sessions/start/route.ts
+++ b/app/api/sessions/start/route.ts
@@ -1,4 +1,5 @@
 import prisma from "@/lib/prisma";
+import redis from "@/lib/redis";
 
 export async function POST(request: Request) {
   try {
@@ -27,7 +28,8 @@ export async function POST(request: Request) {
         data: { userId: user.id, messages: [] },
       });
     }
-    return new Response(JSON.stringify({ user, session }), { status: 200 });
+    const summary = await redis.get(identifier);
+    return new Response(JSON.stringify({ user, session, summary }), { status: 200 });
   } catch (error) {
     console.error("Error starting session:", error);
     return new Response("Error starting session", { status: 500 });

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -1,0 +1,10 @@
+import Redis from "ioredis";
+
+const url = process.env.REDIS_URL;
+if (!url) {
+  throw new Error("REDIS_URL env variable not set");
+}
+
+const redis = new Redis(url);
+
+export default redis;

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0",
         "highlight.js": "^11.11.1",
+        "ioredis": "^5.3.2",
         "lucide-react": "^0.441.0",
         "next": "^15.2.3",
         "ollama": "^0.5.16",
@@ -808,6 +809,12 @@
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.3.0.tgz",
+      "integrity": "sha512-M/T6Zewn7sDaBQEqIZ8Rb+i9y8qfGmq+5SDFSf9sA2lUZTmdDLVdOiQaeDp+Q4wElZ9HG1GAX5KhDaidp6LQsQ==",
+      "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -3644,6 +3651,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/cmdk": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
@@ -4189,6 +4205,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -5949,6 +5974,30 @@
         "node": ">=12"
       }
     },
+    "node_modules/ioredis": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.6.1.tgz",
+      "integrity": "sha512-UxC0Yv1Y4WRJiGQxQkP0hfdL0/5/6YvdfOOClRgJ0qppSarkhneSa6UvkMkms0AkdGimSH3Ikqm+6mkMmX7vGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -6646,6 +6695,18 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
       "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
       "license": "MIT"
     },
     "node_modules/lodash.isplainobject": {
@@ -8607,6 +8668,27 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -9333,6 +9415,12 @@
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
       "license": "MIT"
     },
     "node_modules/statuses": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^1.1.2",
     "zod": "^3.23.8",
-    "zustand": "^5.0.2"
+    "zustand": "^5.0.2",
+    "ioredis": "^5.3.2"
   },
   "devDependencies": {
     "@types/node": "^20.16.10",


### PR DESCRIPTION
## Summary
- create `lib/redis.ts` for Redis client
- store chat session summaries in Redis when saving messages
- expose new `/api/sessions/[session_id]/save` endpoint
- check Redis for saved summary on `/api/sessions/start`
- document Redis setup and new endpoint
- add ioredis dependency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b2eee12c88333baad139fef9e40a8