### PR TITLE
feat: track tickets for email refusals

### DIFF
--- a/config/functions.ts
+++ b/config/functions.ts
@@ -210,6 +210,11 @@ export const create_ticket = async ({
       },
       body: JSON.stringify({ user_id }),
     }).then((res) => res.json());
+    const { setTicketId, setEmailRefused } = useDataStore.getState();
+    if (res?.ticket_id) {
+      setTicketId(res.ticket_id);
+      setEmailRefused(true);
+    }
     return res.ticket_id;
   } catch (error) {
     console.error(error);

--- a/lib/assistant.ts
+++ b/lib/assistant.ts
@@ -75,12 +75,29 @@ export const handleTurn = async (
   model?: string
 ) => {
   try {
+    const { emailRefused, ticketId } = useDataStore.getState();
+    const messagesWithTicket =
+      emailRefused && ticketId
+        ? [
+            {
+              role: "system",
+              content: [
+                {
+                  type: "input_text",
+                  text: `Customer refused to share an email and uses ticket ${ticketId}.`,
+                },
+              ],
+            },
+            ...messages,
+          ]
+        : messages;
+
     // Get response from the API (defined in app/api/turn_response/route.ts)
     const response = await fetch("/api/turn_response", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        messages: messages,
+        messages: messagesWithTicket,
         tools: toolsArg,
         provider,
         model,

--- a/stores/useDataStore.ts
+++ b/stores/useDataStore.ts
@@ -46,12 +46,16 @@ interface DataState {
   relevantArticlesError: string | null;
   relevantArticlesLoading: boolean;
   additionalContext?: ContextItem[] | null;
+  ticketId: string | null;
+  emailRefused: boolean;
   setCustomerDetails: (details: CustomerDetails) => void;
   setFAQExtracts: (searchResults: any[], provider?: string) => void;
   setRelevantArticlesError: (error: string | null) => void;
   setAdditionalContext: (context: ContextItem[]) => void;
   setRelevantArticlesLoading: (loading: boolean) => void;
   addContextItem: (item: ContextItem) => void;
+  setTicketId: (id: string | null) => void;
+  setEmailRefused: (refused: boolean) => void;
 }
 
 const getFileUrl = (type: string, filename: string) => {
@@ -70,6 +74,8 @@ const useDataStore = create<DataState>((set) => ({
   relevantArticlesError: null,
   relevantArticlesLoading: false,
   additionalContext: null,
+  ticketId: null,
+  emailRefused: false,
   setCustomerDetails: (details) => set({ customerDetails: details }),
   setFAQExtracts: (searchResults, provider?: string) => {
     console.log("searchResults", searchResults);
@@ -108,6 +114,8 @@ const useDataStore = create<DataState>((set) => ({
     })),
   setRelevantArticlesLoading: (loading) =>
     set({ relevantArticlesLoading: loading }),
+  setTicketId: (id) => set({ ticketId: id }),
+  setEmailRefused: (refused) => set({ emailRefused: refused }),
 }));
 
 export default useDataStore;


### PR DESCRIPTION
## Summary
- track ticketId and email refusal in data store
- set ticket context when creating tickets
- prepend refusal notice to assistant calls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e609558a08333ab635961e7199890