### PR TITLE
refactor: track contact type and id

### DIFF
--- a/config/functions.ts
+++ b/config/functions.ts
@@ -210,10 +210,9 @@ export const create_ticket = async ({
       },
       body: JSON.stringify({ user_id }),
     }).then((res) => res.json());
-    const { setTicketId, setEmailRefused } = useDataStore.getState();
+    const { setContact } = useDataStore.getState();
     if (res?.ticket_id) {
-      setTicketId(res.ticket_id);
-      setEmailRefused(true);
+      setContact({ contactType: "ticket", contactId: res.ticket_id });
     }
     return res.ticket_id;
   } catch (error) {
@@ -245,8 +244,15 @@ export const update_info = async ({
     }).then((res) => res.json());
 
     if (res && res.updated) {
-      const { customerDetails, setCustomerDetails } = useDataStore.getState();
+      const {
+        customerDetails,
+        setCustomerDetails,
+        setContact,
+      } = useDataStore.getState();
       setCustomerDetails({ ...customerDetails, ...res.updated });
+      if (email) {
+        setContact({ contactType: "email", contactId: email });
+      }
     }
 
     return res;
@@ -264,7 +270,9 @@ export const get_user_profile = async ({ email }: { email: string }) => {
       (res) => res.json()
     );
     if (!user.error) {
-      useDataStore.getState().setCustomerDetails(setDetailsFromUser(user));
+      const { setCustomerDetails, setContact } = useDataStore.getState();
+      setCustomerDetails(setDetailsFromUser(user));
+      setContact({ contactType: "email", contactId: email });
     }
     return user;
   } catch (error) {
@@ -293,7 +301,9 @@ export const create_user_profile = async ({
       body: JSON.stringify({ email, name, phone, address }),
     }).then((res) => res.json());
     if (!user.error) {
-      useDataStore.getState().setCustomerDetails(setDetailsFromUser(user));
+      const { setCustomerDetails, setContact } = useDataStore.getState();
+      setCustomerDetails(setDetailsFromUser(user));
+      setContact({ contactType: "email", contactId: email });
     }
     return user;
   } catch (error) {
@@ -324,7 +334,14 @@ export const start_chat_session = async ({
       body: JSON.stringify({ email: identifier, ticket_id, name, phone, address }),
     }).then((res) => res.json());
     if (res.user && !res.user.error) {
-      useDataStore.getState().setCustomerDetails(setDetailsFromUser(res.user));
+      const { setCustomerDetails, setContact } = useDataStore.getState();
+      setCustomerDetails(setDetailsFromUser(res.user));
+      if (identifier) {
+        setContact({
+          contactType: email ? "email" : "ticket",
+          contactId: identifier,
+        });
+      }
     }
     return res;
   } catch (error) {

--- a/lib/assistant.ts
+++ b/lib/assistant.ts
@@ -75,16 +75,16 @@ export const handleTurn = async (
   model?: string
 ) => {
   try {
-    const { emailRefused, ticketId } = useDataStore.getState();
+    const { contactType, contactId } = useDataStore.getState();
     const messagesWithTicket =
-      emailRefused && ticketId
+      contactType === "ticket" && contactId
         ? [
             {
               role: "system",
               content: [
                 {
                   type: "input_text",
-                  text: `Customer refused to share an email and uses ticket ${ticketId}.`,
+                  text: `Customer refused to share an email and uses ticket ${contactId}.`,
                 },
               ],
             },

--- a/stores/useDataStore.ts
+++ b/stores/useDataStore.ts
@@ -46,16 +46,17 @@ interface DataState {
   relevantArticlesError: string | null;
   relevantArticlesLoading: boolean;
   additionalContext?: ContextItem[] | null;
-  ticketId: string | null;
-  emailRefused: boolean;
+  contactType: "email" | "ticket" | null;
+  contactId: string | null;
   setCustomerDetails: (details: CustomerDetails) => void;
   setFAQExtracts: (searchResults: any[], provider?: string) => void;
   setRelevantArticlesError: (error: string | null) => void;
   setAdditionalContext: (context: ContextItem[]) => void;
   setRelevantArticlesLoading: (loading: boolean) => void;
   addContextItem: (item: ContextItem) => void;
-  setTicketId: (id: string | null) => void;
-  setEmailRefused: (refused: boolean) => void;
+  setContact: (
+    info: { contactType: "email" | "ticket"; contactId: string } | null
+  ) => void;
 }
 
 const getFileUrl = (type: string, filename: string) => {
@@ -74,8 +75,8 @@ const useDataStore = create<DataState>((set) => ({
   relevantArticlesError: null,
   relevantArticlesLoading: false,
   additionalContext: null,
-  ticketId: null,
-  emailRefused: false,
+  contactType: null,
+  contactId: null,
   setCustomerDetails: (details) => set({ customerDetails: details }),
   setFAQExtracts: (searchResults, provider?: string) => {
     console.log("searchResults", searchResults);
@@ -114,8 +115,11 @@ const useDataStore = create<DataState>((set) => ({
     })),
   setRelevantArticlesLoading: (loading) =>
     set({ relevantArticlesLoading: loading }),
-  setTicketId: (id) => set({ ticketId: id }),
-  setEmailRefused: (refused) => set({ emailRefused: refused }),
+  setContact: (info) =>
+    set({
+      contactType: info ? info.contactType : null,
+      contactId: info ? info.contactId : null,
+    }),
 }));
 
 export default useDataStore;


### PR DESCRIPTION
## Summary
- replace ticket/email refusal flags with `contactType` and `contactId`
- set contact info in ticket, session, and email-related functions
- only inject ticket reminder system message when contact type is `ticket`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e730b27e48333a781d7dc0a4c44c2