### PR TITLE
Delay summary until five messages are saved

### DIFF
--- a/app/api/sessions/[session_id]/save/route.ts
+++ b/app/api/sessions/[session_id]/save/route.ts
@@ -32,9 +32,18 @@ export async function POST(
       data: { messages: updatedMessages },
     });
 
-    // Build simple summary from last few messages
-    const last = updatedMessages.slice(-5)
-      .map((m: any) => (m.content || "")).join(" ");
+    // Only generate and cache a summary once there are at least five messages
+    if (updatedMessages.length < 5) {
+      return new Response(JSON.stringify({ success: true }), {
+        status: 200,
+      });
+    }
+
+    // Build simple summary from last five messages
+    const last = updatedMessages
+      .slice(-5)
+      .map((m: any) => m.content || "")
+      .join(" ");
     const summary = last.slice(0, 200);
 
     const key = identifier || session.user.email;


### PR DESCRIPTION
## Summary
- Skip generating or caching a summary until a chat session has at least five messages.
- Once five messages exist, summarize the most recent five messages and store the result in Redis.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f3f8846f483339c20721bd1329ef9