### PR TITLE
feat: persist session messages after turn

### DIFF
--- a/app/api/turn_response/route.ts
+++ b/app/api/turn_response/route.ts
@@ -1,11 +1,19 @@
 import { NextResponse } from "next/server";
 import { runRelevanceGuardrail, runJailbreakGuardrail } from "@/lib/guardrails";
 import { getProvider } from "@/lib/providers";
+import { saveSessionMessages } from "@/lib/server/saveSessionMessages";
 
 export async function POST(request: Request) {
   const start = Date.now();
   try {
-    const { messages, tools, provider, model } = await request.json();
+    const {
+      messages,
+      tools,
+      provider,
+      model,
+      session_id,
+      identifier,
+    } = await request.json();
     console.log("Received messages:", messages);
 
     const lastMessage =
@@ -59,16 +67,42 @@ export async function POST(request: Request) {
       async start(controller) {
         try {
           let first = true;
+          let assistantText = "";
           for await (const { event, data } of events) {
             if (first) {
               first = false;
               console.log("Model response latency:", Date.now() - start, "ms");
             }
+
+            if (
+              event === "response.output_text.delta" &&
+              typeof data?.delta === "string"
+            ) {
+              assistantText += data.delta;
+            }
+
             const payload = JSON.stringify({ event, data });
             controller.enqueue(`data: ${payload}\n\n`);
           }
+
           console.log("Total response time:", Date.now() - start, "ms");
           controller.close();
+
+          if (session_id && lastMessage) {
+            try {
+              const assistantMessage = {
+                role: "assistant",
+                content: assistantText,
+              } as any;
+              await saveSessionMessages(
+                session_id,
+                [lastMessage, assistantMessage],
+                identifier
+              );
+            } catch (err) {
+              console.error("Error saving session messages:", err);
+            }
+          }
         } catch (error) {
           console.error("Error in streaming loop:", error);
           controller.error(error);

--- a/lib/assistant.ts
+++ b/lib/assistant.ts
@@ -76,6 +76,7 @@ export const handleTurn = async (
 ) => {
   try {
     const { contactType, contactId } = useDataStore.getState();
+    const session_id = (useDataStore.getState() as any).sessionId;
     const messagesWithTicket =
       contactType === "ticket" && contactId
         ? [
@@ -101,6 +102,8 @@ export const handleTurn = async (
         tools: toolsArg,
         provider,
         model,
+        session_id,
+        identifier: contactId,
       }),
     });
 

--- a/lib/server/saveSessionMessages.ts
+++ b/lib/server/saveSessionMessages.ts
@@ -1,0 +1,48 @@
+import prisma from "@/lib/prisma";
+import redis from "@/lib/redis";
+
+export async function saveSessionMessages(
+  session_id: string,
+  messages: any[],
+  identifier?: string
+) {
+  try {
+    const session = await prisma.chatSession.findUnique({
+      where: { id: session_id },
+      include: { user: true },
+    });
+    if (!session) {
+      return { error: "Session not found" };
+    }
+
+    const updatedMessages = [
+      ...((session.messages as any[]) || []),
+      ...messages,
+    ];
+
+    await prisma.chatSession.update({
+      where: { id: session_id },
+      data: { messages: updatedMessages },
+    });
+
+    if (updatedMessages.length < 5) {
+      return { success: true };
+    }
+
+    const last = updatedMessages
+      .slice(-5)
+      .map((m: any) => m.content || "")
+      .join(" ");
+    const summary = last.slice(0, 200);
+
+    const key = identifier || session.user.email;
+    if (key) {
+      await redis.set(key, summary);
+    }
+
+    return { success: true, summary };
+  } catch (error) {
+    console.error("Error saving session messages:", error);
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary
- allow turn_response endpoint to accept `session_id` and `identifier`
- stream handler now saves user/assistant messages and caches summary
- pass `session_id` and `identifier` from client with each turn

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f415c72608333ad2f11e9f2f0343a