### PR TITLE
Log saveSessionMessages errors

### DIFF
--- a/app/api/turn_response/route.ts
+++ b/app/api/turn_response/route.ts
@@ -94,11 +94,14 @@ export async function POST(request: Request) {
                 role: "assistant",
                 content: assistantText,
               } as any;
-              await saveSessionMessages(
+              const result = await saveSessionMessages(
                 session_id,
                 [lastMessage, assistantMessage],
                 identifier
               );
+              if (result && "error" in result) {
+                console.error("Error saving session messages:", result.error);
+              }
             } catch (err) {
               console.error("Error saving session messages:", err);
             }


### PR DESCRIPTION
## Summary
- Capture `saveSessionMessages` result in turn response route and log returned errors to avoid silent failures.

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f5221674c8333b81af8bfb790889f