### PR TITLE
docs: clarify message persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ This demo can store customer profiles and chat sessions in a local PostgreSQL da
    REDIS_URL=redis://localhost:6379
    ```
 
-The new API endpoints under `/api/users` and `/api/sessions/start` allow the agent to create or retrieve customer records, manage chat sessions, and store conversation history using this database and Redis.
+The new API endpoints under `/api/users` and `/api/sessions/start` allow the agent to create or retrieve customer records, manage chat sessions, and store conversation history using this database and Redis. During each turn, `/api/turn_response` persists messages via `saveSessionMessages`, so a separate `/api/sessions/[session_id]/save` call is no longer required.
 
 ## Contributing
 

--- a/app/api/turn_response/route.ts
+++ b/app/api/turn_response/route.ts
@@ -3,6 +3,11 @@ import { runRelevanceGuardrail, runJailbreakGuardrail } from "@/lib/guardrails";
 import { getProvider } from "@/lib/providers";
 import { saveSessionMessages } from "@/lib/server/saveSessionMessages";
 
+/**
+ * Handle a single conversation turn and stream the model response.
+ * When a `session_id` is provided, messages are persisted using
+ * `saveSessionMessages` so they can be retrieved later.
+ */
 export async function POST(request: Request) {
   const start = Date.now();
   try {

--- a/lib/assistant.ts
+++ b/lib/assistant.ts
@@ -93,7 +93,9 @@ export const handleTurn = async (
           ]
         : messages;
 
-    // Get response from the API (defined in app/api/turn_response/route.ts)
+    // Get response from the API (app/api/turn_response/route.ts).
+    // This endpoint streams the assistant's reply and persists the turn
+    // using saveSessionMessages on the server.
     const response = await fetch("/api/turn_response", {
       method: "POST",
       headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary
- clarify that `/api/turn_response` saves messages with `saveSessionMessages`
- remove need to call obsolete `/api/sessions/[session_id]/save`
- document persistence behavior in route and assistant comments

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f54297a28833396cf4a005ffe9fc2