### PR TITLE
Load env vars for session cleanup script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0",
+        "dotenv": "^17.2.1",
         "highlight.js": "^11.11.1",
         "ioredis": "^5.3.2",
         "lucide-react": "^0.441.0",
@@ -4307,6 +4308,18 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",
+    "dotenv": "^17.2.1",
     "highlight.js": "^11.11.1",
+    "ioredis": "^5.3.2",
     "lucide-react": "^0.441.0",
     "next": "^15.2.3",
     "ollama": "^0.5.16",
@@ -44,8 +46,7 @@
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^1.1.2",
     "zod": "^3.23.8",
-    "zustand": "^5.0.2",
-    "ioredis": "^5.3.2"
+    "zustand": "^5.0.2"
   },
   "devDependencies": {
     "@types/node": "^20.16.10",

--- a/scripts/cleanupSessions.ts
+++ b/scripts/cleanupSessions.ts
@@ -1,3 +1,4 @@
+import "dotenv/config";
 import prisma from "@/lib/prisma";
 
 async function run() {


### PR DESCRIPTION
## Summary
- load `.env` variables in the cleanup script
- add `dotenv` dependency for env loading

## Testing
- `npm run cleanup:sessions` (fails to connect but reads `localhost:5432` from DATABASE_URL)
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f637e82cc8333a03dc7a5379df3d6