### PR TITLE
Add session retention configuration example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,4 @@ OLLAMA_OPENAI_BASE_URL=http://localhost:11434/v1
 OLLAMA_OPENAI_API_KEY=ollama
 # Redis connection URL
 REDIS_URL=redis://localhost:6379
+SESSION_RETENTION_DAYS=30 # Controls automatic cleanup of ended sessions


### PR DESCRIPTION
## Summary
- document SESSION_RETENTION_DAYS env var for automatic cleanup of ended sessions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f6812a5b08333bac0c22ee9bc983a