### PR TITLE
Handle guardrail responses without errors

### DIFF
--- a/app/api/turn_response/route.ts
+++ b/app/api/turn_response/route.ts
@@ -59,9 +59,10 @@ export async function POST(request: Request) {
       });
       return NextResponse.json(
         {
+          guardrail: true,
           message: "Sorry, I can't help with that request.",
         },
-        { status: 400 }
+        { status: 200 }
       );
     }
 

--- a/lib/assistant.ts
+++ b/lib/assistant.ts
@@ -109,18 +109,25 @@ export const handleTurn = async (
       }),
     });
 
-    if (!response.ok) {
-      console.error(`Error: ${response.status} - ${response.statusText}`);
-      let message = "";
-      try {
-        const errorData = await response.json();
-        message =
-          errorData.message ||
-          errorData.error ||
-          "The assistant encountered an error. Please try again.";
-      } catch {
-        message = "The assistant encountered an error. Please try again.";
+    const contentType = response.headers.get("Content-Type") || "";
+    if (contentType.includes("application/json")) {
+      const data = await response.json();
+      if (data.guardrail) {
+        onMessage({ event: "error", data: { message: data.message } });
+        return;
       }
+      if (!response.ok) {
+        console.warn(`Error: ${response.status} - ${response.statusText}`);
+        const message =
+          data.message ||
+          data.error ||
+          "The assistant encountered an error. Please try again.";
+        onMessage({ event: "error", data: { message } });
+        return;
+      }
+    } else if (!response.ok) {
+      console.warn(`Error: ${response.status} - ${response.statusText}`);
+      const message = "The assistant encountered an error. Please try again.";
       onMessage({ event: "error", data: { message } });
       return;
     }
@@ -162,7 +169,7 @@ export const handleTurn = async (
       }
     }
   } catch (error) {
-    console.error("Error handling turn:", error);
+    console.warn("Error handling turn:", error);
     const message =
       error instanceof Error && error.message
         ? error.message


### PR DESCRIPTION
## Summary
- Return guardrail responses from `turn_response` API as HTTP 200 with `guardrail` flag
- Detect guardrail responses on the client and surface the message without triggering console errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f74feea388333a13f54169d303290