### PR TITLE
Handle additional email refusal phrases

### DIFF
--- a/lib/assistant.ts
+++ b/lib/assistant.ts
@@ -215,7 +215,15 @@ export const processMessages = async () => {
     .reverse()
     .find((m) => (m as any).role === "user");
   const lastUserText = typeof lastUserMessage?.content === "string" ? lastUserMessage.content : "";
-  const emailRefusalRegex = /don['’]?t feel comfortable giving (?:you )?my email/i;
+  const emailRefusalRegex = new RegExp(
+    [
+      "don['’]?t feel comfortable giving (?:you )?my email",
+      "i don['’]?t want to",
+      "i can['’]?t provide that info(?:rmation)?",
+      "no[,\\s]*i won['’]?t",
+    ].join("|"),
+    "i",
+  );
   if (
     !contactType &&
     !contactId &&

--- a/tests/assistant.test.js
+++ b/tests/assistant.test.js
@@ -73,3 +73,18 @@ test('suggestedMessage cleared after tool call', () => {
   assert.strictEqual(conversationItems.length, 1);
   assert.strictEqual(suggestedMessage, null);
 });
+
+test('emailRefusalRegex detects common refusal phrases', () => {
+  const emailRefusalRegex = new RegExp(
+    [
+      "don['’]?t feel comfortable giving (?:you )?my email",
+      "i don['’]?t want to",
+      "i can['’]?t provide that info(?:rmation)?",
+      "no[,\\s]*i won['’]?t",
+    ].join('|'),
+    'i',
+  );
+  assert.ok(emailRefusalRegex.test("No I won't"));
+  assert.ok(emailRefusalRegex.test("I don't want to"));
+  assert.ok(emailRefusalRegex.test("I can't provide that info"));
+});


### PR DESCRIPTION
## Summary
- broaden email refusal detection with phrases like "I don't want to", "I can't provide that info", and "No I won't"
- test regex matches for common refusal phrases

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f846a1dd88333a40fd3e38282711d