### PR TITLE
Handle ticket workflow when customer refuses email

### DIFF
--- a/config/constants.ts
+++ b/config/constants.ts
@@ -8,8 +8,8 @@ You are an assistant helping a customer service representative named ${AGENT_NAM
 You are helping customers with their queries. Respond as if you were ${AGENT_NAME}.
 Speak on behalf of The Automation Ghana Group(TAGG) using first-person pronouns such as "I", "we", "my", or "our" rather than referring to the company in the third person.
 
-At the start of a conversation, request the customer's email address if it is not already known.
-If the customer declines to provide it, do not ask again. Generate a ticket using the create_ticket tool and continue assisting with the information available.
+At the start of a conversation, request the customer's email address if it is not already known. You can identify customers by either an email address or a ticket ID.
+If the customer declines to provide an email, do not ask again. Generate a ticket using the create_ticket tool, inform the customer of the ticket ID, log the conversation using that ticket, and continue assisting with the information available.
 Use the get_user_profile tool with this email to look up existing records.
 If no profile exists, call create_user_profile and gather their name, phone, and address when possible.
 Finally, use start_chat_session to reconnect the user with a previous session or create a new one.

--- a/tests/assistant.test.js
+++ b/tests/assistant.test.js
@@ -88,3 +88,38 @@ test('emailRefusalRegex detects common refusal phrases', () => {
   assert.ok(emailRefusalRegex.test("I don't want to"));
   assert.ok(emailRefusalRegex.test("I can't provide that info"));
 });
+
+test('DEVELOPER_PROMPT mentions ticket workflow', () => {
+  const { DEVELOPER_PROMPT } = require('../config/constants');
+  assert.match(
+    DEVELOPER_PROMPT,
+    /identify customers by either an email address or a ticket ID/i
+  );
+  assert.match(DEVELOPER_PROMPT, /inform the customer of the ticket ID/i);
+});
+
+test('handleTurn prefixes ticket system message', async () => {
+  const { handleTurn } = require('../lib/assistant');
+  const useDataStore = require('../stores/useDataStore').default;
+  const originalFetch = global.fetch;
+  let body;
+  global.fetch = async (_url, options) => {
+    body = JSON.parse(options.body);
+    return new Response('data: [DONE]\n\n', {
+      headers: { 'Content-Type': 'text/plain' },
+      status: 200,
+    });
+  };
+  try {
+    useDataStore.setState({ contactType: 'ticket', contactId: 'TICK123' });
+    const messages = [
+      { role: 'user', content: [{ type: 'input_text', text: 'hello' }] },
+    ];
+    await handleTurn(messages, () => {});
+    assert.strictEqual(body.messages[0].role, 'system');
+    assert.match(body.messages[0].content[0].text, /TICK123/);
+  } finally {
+    global.fetch = originalFetch;
+    useDataStore.setState({ contactType: null, contactId: null });
+  }
+});


### PR DESCRIPTION
## Summary
- clarify developer prompt that agents may identify users via email or ticket ID
- document requirement to generate and log ticket when email is refused
- test ticket-based identification and developer prompt content

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f957b7c448333a1e29885a616f32a