### PR TITLE
Handle ticket creation without user profile

### DIFF
--- a/lib/assistant.ts
+++ b/lib/assistant.ts
@@ -231,7 +231,9 @@ export const processMessages = async () => {
     emailRefusalRegex.test(lastUserText)
   ) {
     setEmailRefused(true);
-    await create_ticket({ user_id: customerDetails.id });
+    const userId = customerDetails?.id;
+    const params = userId ? { user_id: userId } : {};
+    await create_ticket(params);
   }
 
   let toolSet: any[] =

--- a/tests/assistant.test.js
+++ b/tests/assistant.test.js
@@ -123,3 +123,45 @@ test('handleTurn prefixes ticket system message', async () => {
     useDataStore.setState({ contactType: null, contactId: null });
   }
 });
+
+test('create_ticket called without user_id when profile missing', async () => {
+  const { processMessages } = require('../lib/assistant');
+  const useDataStore = require('../stores/useDataStore').default;
+  const useConversationStore = require('../stores/useConversationStore').default;
+  const originalFetch = global.fetch;
+  let ticketBody;
+  global.fetch = async (url, options = {}) => {
+    if (url === '/api/tickets/create') {
+      ticketBody = options.body;
+      return new Response('{"ticket_id":"T1"}', {
+        headers: { 'Content-Type': 'application/json' },
+        status: 200,
+      });
+    }
+    if (url === '/api/turn_response') {
+      return new Response('data: [DONE]\n\n', {
+        headers: { 'Content-Type': 'text/plain' },
+        status: 200,
+      });
+    }
+    return originalFetch(url, options);
+  };
+
+  try {
+    useDataStore.setState({
+      contactType: null,
+      contactId: null,
+      emailRefused: false,
+      customerDetails: {},
+    });
+    useConversationStore.setState({
+      conversationItems: [
+        { role: 'user', content: 'No, I won\'t provide that info' },
+      ],
+    });
+    await processMessages();
+    assert.strictEqual(ticketBody, '{}');
+  } finally {
+    global.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Summary
- Avoid attaching a user ID when creating a ticket if the customer profile is missing.
- Test ticket creation when the user profile is absent to ensure the `create_ticket` call omits `user_id`.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fa3cbd2cc833394cd6ed6488d7231