### PR TITLE
Handle ticket creation errors with JSON

### DIFF
--- a/app/api/tickets/create/route.ts
+++ b/app/api/tickets/create/route.ts
@@ -32,6 +32,9 @@ export async function POST(request: Request) {
     return new Response(JSON.stringify({ ticket_id }), { status: 200 });
   } catch (error) {
     console.error("Error creating ticket:", error);
-    return new Response("Error creating ticket", { status: 500 });
+    return new Response(
+      JSON.stringify({ error: "Error creating ticket" }),
+      { status: 500 }
+    );
   }
 }

--- a/config/functions.ts
+++ b/config/functions.ts
@@ -203,21 +203,34 @@ export const create_ticket = async ({
   user_id?: string;
 }) => {
   try {
-    const res = await fetch(`/api/tickets/create`, {
+    const response = await fetch(`/api/tickets/create`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
       },
       body: JSON.stringify({ user_id }),
-    }).then((res) => res.json());
+    });
+
+    if (!response.ok) {
+      let message = `Request failed with status ${response.status}`;
+      try {
+        const err = await response.json();
+        if (err?.error) message = err.error;
+      } catch {
+        // ignore JSON parsing errors
+      }
+      throw new Error(message);
+    }
+
+    const res = await response.json();
     const { setContact } = useDataStore.getState();
     if (res?.ticket_id) {
       setContact({ contactType: "ticket", contactId: res.ticket_id });
     }
     return res.ticket_id;
-  } catch (error) {
+  } catch (error: any) {
     console.error(error);
-    return { error: "Failed to create ticket" };
+    return { error: error?.message || "Failed to create ticket" };
   }
 };
 

--- a/tests/tickets.test.js
+++ b/tests/tickets.test.js
@@ -1,0 +1,85 @@
+const assert = require('assert');
+const test = require('node:test');
+require('ts-node/register/transpile-only');
+require('tsconfig-paths/register');
+
+const { POST } = require('../app/api/tickets/create/route.ts');
+const prisma = require('../lib/prisma').default;
+const { create_ticket } = require('../config/functions.ts');
+const useDataStore = require('../stores/useDataStore').default;
+
+test('create ticket route success returns JSON', async () => {
+  const originalCount = prisma.ticket.count;
+  const originalCreate = prisma.ticket.create;
+  prisma.ticket.count = async () => 0;
+  prisma.ticket.create = async () => ({});
+  try {
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({ user_id: 'u1' }),
+    });
+    const res = await POST(req);
+    assert.strictEqual(res.status, 200);
+    const text = await res.text();
+    const data = JSON.parse(text);
+    assert.ok(data.ticket_id);
+  } finally {
+    prisma.ticket.count = originalCount;
+    prisma.ticket.create = originalCreate;
+  }
+});
+
+test('create ticket route error returns JSON', async () => {
+  const originalCount = prisma.ticket.count;
+  prisma.ticket.count = async () => {
+    throw new Error('db error');
+  };
+  try {
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({ user_id: 'u1' }),
+    });
+    const res = await POST(req);
+    assert.strictEqual(res.status, 500);
+    const text = await res.text();
+    const data = JSON.parse(text);
+    assert.deepStrictEqual(data, { error: 'Error creating ticket' });
+  } finally {
+    prisma.ticket.count = originalCount;
+  }
+});
+
+test('create_ticket handles success', async () => {
+  const originalFetch = global.fetch;
+  global.fetch = async () =>
+    new Response(JSON.stringify({ ticket_id: 'T1' }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  try {
+    useDataStore.setState({ contactType: null, contactId: null });
+    const result = await create_ticket({ user_id: 'u1' });
+    assert.strictEqual(result, 'T1');
+    const state = useDataStore.getState();
+    assert.strictEqual(state.contactType, 'ticket');
+    assert.strictEqual(state.contactId, 'T1');
+  } finally {
+    global.fetch = originalFetch;
+    useDataStore.setState({ contactType: null, contactId: null });
+  }
+});
+
+test('create_ticket surfaces API errors', async () => {
+  const originalFetch = global.fetch;
+  global.fetch = async () =>
+    new Response(JSON.stringify({ error: 'Error creating ticket' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  try {
+    const result = await create_ticket({ user_id: 'u1' });
+    assert.deepStrictEqual(result, { error: 'Error creating ticket' });
+  } finally {
+    global.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Summary
- return JSON error bodies from ticket creation API
- surface API errors in `create_ticket`
- test ticket creation success and failure cases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fa5b6d5f88333ad474ad763e975f5