### PR TITLE
Handle placeholder user IDs when creating tickets

### DIFF
--- a/lib/assistant.ts
+++ b/lib/assistant.ts
@@ -1,4 +1,5 @@
 import { DEVELOPER_PROMPT } from "@/config/constants";
+import { CUSTOMER_DETAILS } from "@/config/demoData";
 import { parse } from "partial-json";
 import { handleTool } from "@/lib/tools/tools-handling";
 import useConversationStore from "@/stores/useConversationStore";
@@ -232,7 +233,8 @@ export const processMessages = async () => {
   ) {
     setEmailRefused(true);
     const userId = customerDetails?.id;
-    const params = userId ? { user_id: userId } : {};
+    const params =
+      userId && userId !== CUSTOMER_DETAILS.id ? { user_id: userId } : {};
     await create_ticket(params);
   }
 

--- a/tests/assistant.test.js
+++ b/tests/assistant.test.js
@@ -124,7 +124,50 @@ test('handleTurn prefixes ticket system message', async () => {
   }
 });
 
-test('create_ticket called without user_id when profile missing', async () => {
+test('create_ticket called without user_id when using placeholder ID', async () => {
+  const { processMessages } = require('../lib/assistant');
+  const { CUSTOMER_DETAILS } = require('../config/demoData');
+  const useDataStore = require('../stores/useDataStore').default;
+  const useConversationStore = require('../stores/useConversationStore').default;
+  const originalFetch = global.fetch;
+  let ticketBody;
+  global.fetch = async (url, options = {}) => {
+    if (url === '/api/tickets/create') {
+      ticketBody = options.body;
+      return new Response('{"ticket_id":"T1"}', {
+        headers: { 'Content-Type': 'application/json' },
+        status: 200,
+      });
+    }
+    if (url === '/api/turn_response') {
+      return new Response('data: [DONE]\n\n', {
+        headers: { 'Content-Type': 'text/plain' },
+        status: 200,
+      });
+    }
+    return originalFetch(url, options);
+  };
+
+  try {
+    useDataStore.setState({
+      contactType: null,
+      contactId: null,
+      emailRefused: false,
+      customerDetails: { id: CUSTOMER_DETAILS.id },
+    });
+    useConversationStore.setState({
+      conversationItems: [
+        { role: 'user', content: 'No, I won\'t provide that info' },
+      ],
+    });
+    await processMessages();
+    assert.strictEqual(ticketBody, '{}');
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test('create_ticket includes user_id when profile updated', async () => {
   const { processMessages } = require('../lib/assistant');
   const useDataStore = require('../stores/useDataStore').default;
   const useConversationStore = require('../stores/useConversationStore').default;
@@ -152,7 +195,7 @@ test('create_ticket called without user_id when profile missing', async () => {
       contactType: null,
       contactId: null,
       emailRefused: false,
-      customerDetails: {},
+      customerDetails: { id: 'cus_real' },
     });
     useConversationStore.setState({
       conversationItems: [
@@ -160,7 +203,7 @@ test('create_ticket called without user_id when profile missing', async () => {
       ],
     });
     await processMessages();
-    assert.strictEqual(ticketBody, '{}');
+    assert.strictEqual(ticketBody, '{"user_id":"cus_real"}');
   } finally {
     global.fetch = originalFetch;
   }


### PR DESCRIPTION
## Summary
- Skip passing a user ID to the ticket API when the customer profile still has the demo placeholder ID
- Include the real user ID once customer details are updated
- Add unit tests covering both scenarios

## Testing
- `npm test` *(fails: tests/tickets.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_688fa9840dc08333b2e34ba174fc89b0