### PR TITLE
feat: trigger chat session from ticket

### DIFF
--- a/lib/assistant.ts
+++ b/lib/assistant.ts
@@ -5,7 +5,7 @@ import { handleTool } from "@/lib/tools/tools-handling";
 import useConversationStore from "@/stores/useConversationStore";
 import { tools, ollamaTools } from "@/lib/tools/tools";
 import { Annotation } from "@/components/Annotations";
-import { functionsMap, create_ticket } from "@/config/functions";
+import { functionsMap, create_ticket, start_chat_session } from "@/config/functions";
 import useDataStore from "@/stores/useDataStore";
 import { agentTools } from "@/config/tools-list";
 
@@ -216,6 +216,10 @@ export const processMessages = async () => {
     .reverse()
     .find((m) => (m as any).role === "user");
   const lastUserText = typeof lastUserMessage?.content === "string" ? lastUserMessage.content : "";
+  const ticketMatch = lastUserText.match(/#\d+\/\d{4}-\d{2}-\d{2}/);
+  if (!contactType && !contactId && ticketMatch) {
+    await start_chat_session({ ticket_id: ticketMatch[0] });
+  }
   const emailRefusalRegex = new RegExp(
     [
       "don['’]?t feel comfortable giving (?:you )?my email",

--- a/tests/assistant.test.js
+++ b/tests/assistant.test.js
@@ -89,6 +89,11 @@ test('emailRefusalRegex detects common refusal phrases', () => {
   assert.ok(emailRefusalRegex.test("I can't provide that info"));
 });
 
+test('ticket regex matches ticket ID', () => {
+  const ticketRegex = /#\d+\/\d{4}-\d{2}-\d{2}/;
+  assert.ok('#12345/2024-01-01'.match(ticketRegex));
+});
+
 test('DEVELOPER_PROMPT mentions ticket workflow', () => {
   const { DEVELOPER_PROMPT } = require('../config/constants');
   assert.match(
@@ -206,5 +211,49 @@ test('create_ticket includes user_id when profile updated', async () => {
     assert.strictEqual(ticketBody, '{"user_id":"cus_real"}');
   } finally {
     global.fetch = originalFetch;
+  }
+});
+
+test('start_chat_session triggered by ticket ID', async () => {
+  const { processMessages } = require('../lib/assistant');
+  const useDataStore = require('../stores/useDataStore').default;
+  const useConversationStore = require('../stores/useConversationStore').default;
+  const originalFetch = global.fetch;
+  let sessionBody;
+  global.fetch = async (url, options = {}) => {
+    if (url === '/api/sessions/start') {
+      sessionBody = options.body;
+      return new Response('{"user":{}}', {
+        headers: { 'Content-Type': 'application/json' },
+        status: 200,
+      });
+    }
+    if (url === '/api/turn_response') {
+      return new Response('data: [DONE]\n\n', {
+        headers: { 'Content-Type': 'text/plain' },
+        status: 200,
+      });
+    }
+    return originalFetch(url, options);
+  };
+
+  try {
+    useDataStore.setState({ contactType: null, contactId: null });
+    useConversationStore.setState({
+      conversationItems: [
+        { role: 'user', content: '#12345/2024-01-01' },
+      ],
+    });
+    await processMessages();
+    assert.strictEqual(
+      sessionBody,
+      '{"email":"#12345/2024-01-01","ticket_id":"#12345/2024-01-01"}'
+    );
+    const state = useDataStore.getState();
+    assert.strictEqual(state.contactType, 'ticket');
+    assert.strictEqual(state.contactId, '#12345/2024-01-01');
+  } finally {
+    global.fetch = originalFetch;
+    useDataStore.setState({ contactType: null, contactId: null });
   }
 });


### PR DESCRIPTION
## Summary
- start chat sessions when a ticket-style ID appears in the latest user message
- cover ticket ID parsing and chat session start with targeted unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fc4c1dda88333a41124113acd33db