### PR TITLE
Skip relevance guardrail when ticket ID provided

### DIFF
--- a/app/api/turn_response/route.ts
+++ b/app/api/turn_response/route.ts
@@ -47,8 +47,16 @@ export async function POST(request: Request) {
       userInput = Array.isArray(content)
         ? content.map((c: any) => c.text ?? "").join(" ")
         : String(content || "");
-      relevance = await runRelevanceGuardrail({ input: conversationInput });
-      console.log("Relevance guardrail result:", relevance);
+
+      const ticketRegex = /#[0-9]+\/[0-9]{4}-[0-9]{2}-[0-9]{2}/;
+      const hasTicket = ticketRegex.test(conversationInput);
+      if (hasTicket) {
+        console.log("Ticket detected, skipping relevance guardrail");
+      } else {
+        relevance = await runRelevanceGuardrail({ input: conversationInput });
+        console.log("Relevance guardrail result:", relevance);
+      }
+
       jailbreak = await runJailbreakGuardrail({ input: userInput });
       console.log("Jailbreak guardrail result:", jailbreak);
     }


### PR DESCRIPTION
## Summary
- Detect ticket IDs in conversation with pattern `#[0-9]+/[0-9]{4}-[0-9]{2}-[0-9]{2}`
- Skip the relevance guardrail when a ticket ID is present so requests aren't rejected

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fcf359874833382ac60da8eccbbc1