### PR TITLE
Always run relevance guardrail on sanitized conversation

### DIFF
--- a/app/api/turn_response/route.ts
+++ b/app/api/turn_response/route.ts
@@ -48,14 +48,16 @@ export async function POST(request: Request) {
         ? content.map((c: any) => c.text ?? "").join(" ")
         : String(content || "");
 
-      const ticketRegex = /#[0-9]+\/[0-9]{4}-[0-9]{2}-[0-9]{2}/;
+      const ticketRegex = /#[0-9]+\/[0-9]{4}-[0-9]{2}-[0-9]{2}/g;
       const hasTicket = ticketRegex.test(conversationInput);
+      const sanitizedConversation = conversationInput.replace(ticketRegex, "");
       if (hasTicket) {
-        console.log("Ticket detected, skipping relevance guardrail");
-      } else {
-        relevance = await runRelevanceGuardrail({ input: conversationInput });
-        console.log("Relevance guardrail result:", relevance);
+        console.log(
+          "Ticket detected, running relevance guardrail on sanitized conversation"
+        );
       }
+      relevance = await runRelevanceGuardrail({ input: sanitizedConversation });
+      console.log("Relevance guardrail result:", relevance);
 
       jailbreak = await runJailbreakGuardrail({ input: userInput });
       console.log("Jailbreak guardrail result:", jailbreak);


### PR DESCRIPTION
## Summary
- run relevance guardrail on conversation input with ticket numbers removed
- detect tickets with global regex and log when present instead of skipping guardrail

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fd7ed28a48333b641440e92df3be5