### PR TITLE
Store and use conversation summary

### DIFF
--- a/config/functions.ts
+++ b/config/functions.ts
@@ -347,7 +347,8 @@ export const start_chat_session = async ({
       body: JSON.stringify({ email: identifier, ticket_id, name, phone, address }),
     }).then((res) => res.json());
     if (res.user && !res.user.error) {
-      const { setCustomerDetails, setContact } = useDataStore.getState();
+      const { setCustomerDetails, setContact, setSummary } =
+        useDataStore.getState();
       setCustomerDetails(setDetailsFromUser(res.user));
       if (identifier) {
         setContact({
@@ -355,6 +356,7 @@ export const start_chat_session = async ({
           contactId: identifier,
         });
       }
+      setSummary(res.summary || null);
     }
     return res;
   } catch (error) {

--- a/lib/assistant.ts
+++ b/lib/assistant.ts
@@ -76,23 +76,33 @@ export const handleTurn = async (
   model?: string
 ) => {
   try {
-    const { contactType, contactId } = useDataStore.getState();
+    const { contactType, contactId, summary } = useDataStore.getState();
     const session_id = (useDataStore.getState() as any).sessionId;
+    const systemMessages: any[] = [];
+    if (summary) {
+      systemMessages.push({
+        role: "system",
+        content: [
+          {
+            type: "input_text",
+            text: `Previous conversation summary: ${summary}`,
+          },
+        ],
+      });
+    }
+    if (contactType === "ticket" && contactId) {
+      systemMessages.push({
+        role: "system",
+        content: [
+          {
+            type: "input_text",
+            text: `Customer refused to share an email and uses ticket ${contactId}.`,
+          },
+        ],
+      });
+    }
     const messagesWithTicket =
-      contactType === "ticket" && contactId
-        ? [
-            {
-              role: "system",
-              content: [
-                {
-                  type: "input_text",
-                  text: `Customer refused to share an email and uses ticket ${contactId}.`,
-                },
-              ],
-            },
-            ...messages,
-          ]
-        : messages;
+      systemMessages.length > 0 ? [...systemMessages, ...messages] : messages;
 
     // Get response from the API (app/api/turn_response/route.ts).
     // This endpoint streams the assistant's reply and persists the turn

--- a/stores/useDataStore.ts
+++ b/stores/useDataStore.ts
@@ -48,6 +48,7 @@ interface DataState {
   additionalContext?: ContextItem[] | null;
   contactType: "email" | "ticket" | null;
   contactId: string | null;
+  summary: string | null;
   emailRefused: boolean;
   setCustomerDetails: (details: CustomerDetails) => void;
   setFAQExtracts: (searchResults: any[], provider?: string) => void;
@@ -58,6 +59,7 @@ interface DataState {
   setContact: (
     info: { contactType: "email" | "ticket"; contactId: string } | null
   ) => void;
+  setSummary: (summary: string | null) => void;
   setEmailRefused: (refused: boolean) => void;
 }
 
@@ -79,6 +81,7 @@ const useDataStore = create<DataState>((set) => ({
   additionalContext: null,
   contactType: null,
   contactId: null,
+  summary: null,
   emailRefused: false,
   setCustomerDetails: (details) => set({ customerDetails: details }),
   setFAQExtracts: (searchResults, provider?: string) => {
@@ -123,6 +126,7 @@ const useDataStore = create<DataState>((set) => ({
       contactType: info ? info.contactType : null,
       contactId: info ? info.contactId : null,
     }),
+  setSummary: (summary) => set({ summary }),
   setEmailRefused: (refused) => set({ emailRefused: refused }),
 }));
 

--- a/tests/assistant.test.js
+++ b/tests/assistant.test.js
@@ -116,7 +116,11 @@ test('handleTurn prefixes ticket system message', async () => {
     });
   };
   try {
-    useDataStore.setState({ contactType: 'ticket', contactId: 'TICK123' });
+    useDataStore.setState({
+      contactType: 'ticket',
+      contactId: 'TICK123',
+      summary: null,
+    });
     const messages = [
       { role: 'user', content: [{ type: 'input_text', text: 'hello' }] },
     ];
@@ -125,7 +129,42 @@ test('handleTurn prefixes ticket system message', async () => {
     assert.match(body.messages[0].content[0].text, /TICK123/);
   } finally {
     global.fetch = originalFetch;
-    useDataStore.setState({ contactType: null, contactId: null });
+    useDataStore.setState({ contactType: null, contactId: null, summary: null });
+  }
+});
+
+test('handleTurn prefixes summary before ticket message', async () => {
+  const { handleTurn } = require('../lib/assistant');
+  const useDataStore = require('../stores/useDataStore').default;
+  const originalFetch = global.fetch;
+  let body;
+  global.fetch = async (_url, options) => {
+    body = JSON.parse(options.body);
+    return new Response('data: [DONE]\n\n', {
+      headers: { 'Content-Type': 'text/plain' },
+      status: 200,
+    });
+  };
+  try {
+    useDataStore.setState({
+      contactType: 'ticket',
+      contactId: 'TICK123',
+      summary: 'old summary',
+    });
+    const messages = [
+      { role: 'user', content: [{ type: 'input_text', text: 'hello' }] },
+    ];
+    await handleTurn(messages, () => {});
+    assert.strictEqual(body.messages[0].role, 'system');
+    assert.match(
+      body.messages[0].content[0].text,
+      /Previous conversation summary: old summary/
+    );
+    assert.strictEqual(body.messages[1].role, 'system');
+    assert.match(body.messages[1].content[0].text, /TICK123/);
+  } finally {
+    global.fetch = originalFetch;
+    useDataStore.setState({ contactType: null, contactId: null, summary: null });
   }
 });
 
@@ -223,7 +262,7 @@ test('start_chat_session triggered by ticket ID', async () => {
   global.fetch = async (url, options = {}) => {
     if (url === '/api/sessions/start') {
       sessionBody = options.body;
-      return new Response('{"user":{}}', {
+      return new Response('{"user":{},"summary":"old summary"}', {
         headers: { 'Content-Type': 'application/json' },
         status: 200,
       });
@@ -238,7 +277,7 @@ test('start_chat_session triggered by ticket ID', async () => {
   };
 
   try {
-    useDataStore.setState({ contactType: null, contactId: null });
+    useDataStore.setState({ contactType: null, contactId: null, summary: null });
     useConversationStore.setState({
       conversationItems: [
         { role: 'user', content: '#12345/2024-01-01' },
@@ -252,8 +291,9 @@ test('start_chat_session triggered by ticket ID', async () => {
     const state = useDataStore.getState();
     assert.strictEqual(state.contactType, 'ticket');
     assert.strictEqual(state.contactId, '#12345/2024-01-01');
+    assert.strictEqual(state.summary, 'old summary');
   } finally {
     global.fetch = originalFetch;
-    useDataStore.setState({ contactType: null, contactId: null });
+    useDataStore.setState({ contactType: null, contactId: null, summary: null });
   }
 });


### PR DESCRIPTION
## Summary
- persist chat session summaries in the data store when starting a session
- send previous conversation summary to the model as a system message before ticket or user messages
- add tests covering summary storage and system message ordering

## Testing
- `npx prisma generate`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fe617ea54833382e97d7ae15ae6a9