### PR TITLE
Save session messages to Redis regardless of conversation length

### DIFF
--- a/lib/server/saveSessionMessages.ts
+++ b/lib/server/saveSessionMessages.ts
@@ -27,13 +27,8 @@ export async function saveSessionMessages(
       where: { id: session_id },
       data: { messages: updatedMessages },
     });
-
-    if (updatedMessages.length < 5) {
-      return { success: true };
-    }
-
     const last = updatedMessages
-      .slice(-5)
+      .slice(-Math.min(updatedMessages.length, 5))
       .map((m: any) => m.content || "")
       .join(" ");
     const summary = last.slice(0, 200);


### PR DESCRIPTION
## Summary
- remove length check that stopped summaries from being saved for short chats
- always build and store summary from last five messages or fewer

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688feb6d23ec8333a1dad3718b0e5f52