### PR TITLE
Track session IDs and initialize sessions for anonymous tickets

### DIFF
--- a/config/functions.ts
+++ b/config/functions.ts
@@ -226,6 +226,7 @@ export const create_ticket = async ({
     const { setContact } = useDataStore.getState();
     if (res?.ticket_id) {
       setContact({ contactType: "ticket", contactId: res.ticket_id });
+      await start_chat_session({ ticket_id: res.ticket_id });
     }
     return res.ticket_id;
   } catch (error: any) {
@@ -346,9 +347,12 @@ export const start_chat_session = async ({
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ email: identifier, ticket_id, name, phone, address }),
     }).then((res) => res.json());
+    const { setCustomerDetails, setContact, setSummary, setSessionId } =
+      useDataStore.getState();
+    if (res.session?.id) {
+      setSessionId(res.session.id);
+    }
     if (res.user && !res.user.error) {
-      const { setCustomerDetails, setContact, setSummary } =
-        useDataStore.getState();
       setCustomerDetails(setDetailsFromUser(res.user));
       if (identifier) {
         setContact({

--- a/lib/assistant.ts
+++ b/lib/assistant.ts
@@ -76,8 +76,9 @@ export const handleTurn = async (
   model?: string
 ) => {
   try {
-    const { contactType, contactId, summary } = useDataStore.getState();
-    const session_id = (useDataStore.getState() as any).sessionId;
+    const { contactType, contactId, summary, sessionId } =
+      useDataStore.getState();
+    const session_id = sessionId;
     const systemMessages: any[] = [];
     if (summary) {
       systemMessages.push({

--- a/stores/useDataStore.ts
+++ b/stores/useDataStore.ts
@@ -48,6 +48,7 @@ interface DataState {
   additionalContext?: ContextItem[] | null;
   contactType: "email" | "ticket" | null;
   contactId: string | null;
+  sessionId: string | null;
   summary: string | null;
   emailRefused: boolean;
   setCustomerDetails: (details: CustomerDetails) => void;
@@ -59,6 +60,7 @@ interface DataState {
   setContact: (
     info: { contactType: "email" | "ticket"; contactId: string } | null
   ) => void;
+  setSessionId: (id: string | null) => void;
   setSummary: (summary: string | null) => void;
   setEmailRefused: (refused: boolean) => void;
 }
@@ -81,6 +83,7 @@ const useDataStore = create<DataState>((set) => ({
   additionalContext: null,
   contactType: null,
   contactId: null,
+  sessionId: null,
   summary: null,
   emailRefused: false,
   setCustomerDetails: (details) => set({ customerDetails: details }),
@@ -126,6 +129,7 @@ const useDataStore = create<DataState>((set) => ({
       contactType: info ? info.contactType : null,
       contactId: info ? info.contactId : null,
     }),
+  setSessionId: (id) => set({ sessionId: id }),
   setSummary: (summary) => set({ summary }),
   setEmailRefused: (refused) => set({ emailRefused: refused }),
 }));


### PR DESCRIPTION
## Summary
- add `sessionId` and `setSessionId` to data store
- persist session id when starting chat and when creating anonymous tickets
- send stored session id with every assistant turn

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68908d13d7148333aa8cbc6baaddbb73