### PR TITLE
Remove user reference from ticket creation

### DIFF
--- a/app/api/tickets/create/route.ts
+++ b/app/api/tickets/create/route.ts
@@ -1,9 +1,7 @@
 import prisma from "@/lib/prisma";
 
-export async function POST(request: Request) {
+export async function POST() {
   try {
-    const { user_id } = await request.json();
-
     const start = new Date();
     start.setUTCHours(0, 0, 0, 0);
     const end = new Date();
@@ -25,7 +23,6 @@ export async function POST(request: Request) {
     await prisma.ticket.create({
       data: {
         ticket: ticket_id,
-        userId: user_id || null,
       },
     });
 

--- a/config/demoData.ts
+++ b/config/demoData.ts
@@ -15,9 +15,7 @@ export const CUSTOMER_DETAILS = {
 
 export const DEFAULT_ACTION: Action = {
   name: "create_ticket",
-  parameters: {
-    user_id: CUSTOMER_DETAILS.id,
-  },
+  parameters: {},
 };
 
 export const DEFAULT_ARTICLES: FAQExtract[] = [

--- a/config/functions.ts
+++ b/config/functions.ts
@@ -197,18 +197,14 @@ export const create_complaint = async ({
   }
 };
 
-export const create_ticket = async ({
-  user_id,
-}: {
-  user_id?: string;
-}) => {
+export const create_ticket = async () => {
   try {
     const response = await fetch(`/api/tickets/create`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ user_id }),
+      body: JSON.stringify({}),
     });
 
     if (!response.ok) {
@@ -227,8 +223,9 @@ export const create_ticket = async ({
     if (res?.ticket_id) {
       setContact({ contactType: "ticket", contactId: res.ticket_id });
       await start_chat_session({ ticket_id: res.ticket_id });
+      return `Your ticket ID is ${res.ticket_id}`;
     }
-    return res.ticket_id;
+    return { error: "Failed to create ticket" };
   } catch (error: any) {
     console.error(error);
     return { error: error?.message || "Failed to create ticket" };

--- a/config/tools-list.ts
+++ b/config/tools-list.ts
@@ -236,12 +236,7 @@ export const toolsList = [
         "Generate a session ticket for customers without an email.",
       parameters: {
         type: "object",
-        properties: {
-          user_id: {
-            type: "string",
-            description: "User ID to link the session with, if available",
-          },
-        },
+        properties: {},
         additionalProperties: false,
       },
     },

--- a/lib/assistant.ts
+++ b/lib/assistant.ts
@@ -1,5 +1,4 @@
 import { DEVELOPER_PROMPT } from "@/config/constants";
-import { CUSTOMER_DETAILS } from "@/config/demoData";
 import { parse } from "partial-json";
 import { handleTool } from "@/lib/tools/tools-handling";
 import useConversationStore from "@/stores/useConversationStore";
@@ -220,7 +219,6 @@ export const processMessages = async () => {
     setEmailRefused,
     contactType,
     contactId,
-    customerDetails,
   } = useDataStore.getState();
 
   const lastUserMessage = [...conversationItems]
@@ -247,10 +245,7 @@ export const processMessages = async () => {
     emailRefusalRegex.test(lastUserText)
   ) {
     setEmailRefused(true);
-    const userId = customerDetails?.id;
-    const params =
-      userId && userId !== CUSTOMER_DETAILS.id ? { user_id: userId } : {};
-    await create_ticket(params);
+    await create_ticket();
   }
 
   let toolSet: any[] =

--- a/tests/assistant.test.js
+++ b/tests/assistant.test.js
@@ -168,7 +168,7 @@ test('handleTurn prefixes summary before ticket message', async () => {
   }
 });
 
-test('create_ticket called without user_id when using placeholder ID', async () => {
+test('create_ticket sends empty body when using placeholder ID', async () => {
   const { processMessages } = require('../lib/assistant');
   const { CUSTOMER_DETAILS } = require('../config/demoData');
   const useDataStore = require('../stores/useDataStore').default;
@@ -179,6 +179,12 @@ test('create_ticket called without user_id when using placeholder ID', async () 
     if (url === '/api/tickets/create') {
       ticketBody = options.body;
       return new Response('{"ticket_id":"T1"}', {
+        headers: { 'Content-Type': 'application/json' },
+        status: 200,
+      });
+    }
+    if (url === '/api/sessions/start') {
+      return new Response('{}', {
         headers: { 'Content-Type': 'application/json' },
         status: 200,
       });
@@ -211,7 +217,7 @@ test('create_ticket called without user_id when using placeholder ID', async () 
   }
 });
 
-test('create_ticket includes user_id when profile updated', async () => {
+test('create_ticket still sends empty body when profile updated', async () => {
   const { processMessages } = require('../lib/assistant');
   const useDataStore = require('../stores/useDataStore').default;
   const useConversationStore = require('../stores/useConversationStore').default;
@@ -221,6 +227,12 @@ test('create_ticket includes user_id when profile updated', async () => {
     if (url === '/api/tickets/create') {
       ticketBody = options.body;
       return new Response('{"ticket_id":"T1"}', {
+        headers: { 'Content-Type': 'application/json' },
+        status: 200,
+      });
+    }
+    if (url === '/api/sessions/start') {
+      return new Response('{}', {
         headers: { 'Content-Type': 'application/json' },
         status: 200,
       });
@@ -247,7 +259,7 @@ test('create_ticket includes user_id when profile updated', async () => {
       ],
     });
     await processMessages();
-    assert.strictEqual(ticketBody, '{"user_id":"cus_real"}');
+    assert.strictEqual(ticketBody, '{}');
   } finally {
     global.fetch = originalFetch;
   }

--- a/tests/tickets.test.js
+++ b/tests/tickets.test.js
@@ -16,7 +16,7 @@ test('create ticket route success returns JSON', async () => {
   try {
     const req = new Request('http://localhost', {
       method: 'POST',
-      body: JSON.stringify({ user_id: 'u1' }),
+      body: JSON.stringify({}),
     });
     const res = await POST(req);
     assert.strictEqual(res.status, 200);
@@ -39,7 +39,7 @@ test('create ticket route error returns JSON', async () => {
   try {
     const req = new Request('http://localhost', {
       method: 'POST',
-      body: JSON.stringify({ user_id: 'u1' }),
+      body: JSON.stringify({}),
     });
     const res = await POST(req);
     assert.strictEqual(res.status, 500);
@@ -61,8 +61,8 @@ test('create_ticket handles success', async () => {
     });
   try {
     useDataStore.setState({ contactType: null, contactId: null });
-    const result = await create_ticket({ user_id: 'u1' });
-    assert.strictEqual(result, 'T1');
+    const result = await create_ticket();
+    assert.strictEqual(result, 'Your ticket ID is T1');
     const state = useDataStore.getState();
     assert.strictEqual(state.contactType, 'ticket');
     assert.strictEqual(state.contactId, 'T1');
@@ -82,7 +82,7 @@ test('create_ticket surfaces API errors', async () => {
       headers: { 'Content-Type': 'application/json' },
     });
   try {
-    const result = await create_ticket({ user_id: 'u1' });
+    const result = await create_ticket();
     assert.deepStrictEqual(result, { error: 'Error creating ticket' });
   } finally {
     global.fetch = originalFetch;


### PR DESCRIPTION
## Summary
- stop accepting a `user_id` for `create_ticket` and drop that parameter from tool configuration
- have `create_ticket` generate a ticket and return `"Your ticket ID is ${ticket_id}"`
- ignore `user_id` in the ticket creation API and call `create_ticket` without user details

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890a11ecc14833398cfbb7fbde88769