### PR TITLE
Handle structured content in session summary builder

### DIFF
--- a/lib/server/saveSessionMessages.ts
+++ b/lib/server/saveSessionMessages.ts
@@ -29,7 +29,11 @@ export async function saveSessionMessages(
     });
     const last = updatedMessages
       .slice(-Math.min(updatedMessages.length, 5))
-      .map((m: any) => m.content || "")
+      .map((m: any) =>
+        Array.isArray(m.content)
+          ? m.content.map((c: any) => c.text ?? "").join(" ")
+          : String(m.content ?? "")
+      )
       .join(" ");
     const summary = last.slice(0, 200);
 


### PR DESCRIPTION
## Summary
- Extract text from structured message content when building session summaries
- Continue storing a 200-character trimmed summary in Redis

## Testing
- `npx prisma generate`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890c1b3a0448333a7e6075c15eafcb4