### PR TITLE
Clarify local vector store logging

### DIFF
--- a/lib/localVectorStore.ts
+++ b/lib/localVectorStore.ts
@@ -60,7 +60,8 @@ class LocalVectorStore {
       await this.ensureLoaded();
       if (this.store.length > 0) return;
     }
-    let processed = 0;
+    let chunksProcessed = 0;
+    let filesProcessed = 0;
     for (const folder of KB_FOLDERS) {
       const dir = path.join(process.cwd(), "public", folder);
       const files = await fs.readdir(dir);
@@ -90,12 +91,15 @@ class LocalVectorStore {
               chunk: index++,
             },
           });
-          processed++;
+          chunksProcessed++;
         }
+        filesProcessed++;
       }
     }
     await fs.mkdir(path.dirname(STORE_PATH), { recursive: true });
-    console.log(`Processed ${processed} files. Writing local vector store...`);
+    console.log(
+      `Processed ${filesProcessed} files and ${chunksProcessed} chunks. Writing local vector store...`
+    );
     await fs.writeFile(STORE_PATH, JSON.stringify(this.store, null, 2));
     console.log(
       `Local vector store written to ${STORE_PATH} with ${this.store.length} entries.`


### PR DESCRIPTION
## Summary
- Track both file and chunk counts during local vector store initialization
- Log the number of processed files and chunks when writing the store

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890f66f6f0c8333946aa5b52e75de22