### PR TITLE
refactor: use TokenTextSplitter

### DIFF
--- a/lib/textSplitter.ts
+++ b/lib/textSplitter.ts
@@ -1,7 +1,7 @@
-import { RecursiveCharacterTextSplitter } from "langchain/text_splitter";
+import { TokenTextSplitter } from "langchain/text_splitter";
 import { TEXT_SPLITTER_CONFIG } from "@/config/vectorStore";
 
-const splitter = new RecursiveCharacterTextSplitter({
+const splitter = new TokenTextSplitter({
   ...TEXT_SPLITTER_CONFIG,
   encodingName: "cl100k_base",
 });


### PR DESCRIPTION
## Summary
- refactor text splitting to use TokenTextSplitter with cl100k_base encoding

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689102b17db48333abb315bb9296816a