### PR TITLE
feat: add p-limit concurrency pool

### DIFF
--- a/lib/localVectorStore.ts
+++ b/lib/localVectorStore.ts
@@ -6,6 +6,7 @@ import { KB_FOLDERS } from "@/config/demoData";
 import { TEXT_SPLITTER_CONFIG } from "@/config/vectorStore";
 import cleanMarkdown from "./cleanMarkdown";
 import { splitText } from "./textSplitter";
+import pLimit from "p-limit";
 
 const STORE_PATH = path.join(process.cwd(), "data", "local_vector_store.json");
 
@@ -97,37 +98,35 @@ class LocalVectorStore {
     }
 
     let chunksProcessed = 0;
-    let filesProcessed = 0;
+    const limit = pLimit(concurrency > 0 ? concurrency : totalChunks || 1);
+    const tasks: Promise<void>[] = [];
     for (const { folder, file, joinedChunks, overlap } of filesData) {
-      let index = 0;
-      const batchSize = concurrency > 0 ? concurrency : joinedChunks.length;
-      for (let i = 0; i < joinedChunks.length; i += batchSize) {
-        const batch = joinedChunks.slice(i, i + batchSize);
-        console.log(
-          `Embedding batch of ${batch.length} chunks in parallel (${chunksProcessed + batch.length}/${totalChunks}) from ${file}`
+      joinedChunks.forEach((chunk, idx) => {
+        tasks.push(
+          limit(async () => {
+            const current = ++chunksProcessed;
+            console.log(
+              `Embedding chunk ${current}/${totalChunks} from ${file}`
+            );
+            const embedding = await this.embedding(chunk);
+            this.store.push({
+              id: crypto.randomUUID(),
+              embedding,
+              text: chunk,
+              attributes: {
+                type: folder,
+                filename: file.replace(/\.(md|json)$/, ""),
+                filepath: `/public/${folder}/${file}`,
+                chunk: idx,
+                overlap,
+              },
+            });
+          })
         );
-        const embeddings = await Promise.all(
-          batch.map((chunk) => this.embedding(chunk))
-        );
-        embeddings.forEach((embedding, j) => {
-          const chunk = batch[j];
-          this.store.push({
-            id: crypto.randomUUID(),
-            embedding,
-            text: chunk,
-            attributes: {
-              type: folder,
-              filename: file.replace(/\.(md|json)$/, ""),
-              filepath: `/public/${folder}/${file}`,
-              chunk: index++,
-              overlap,
-            },
-          });
-        });
-        chunksProcessed += batch.length;
-      }
-      filesProcessed++;
+      });
     }
+    const filesProcessed = filesData.length;
+    await Promise.all(tasks);
     await fs.mkdir(path.dirname(STORE_PATH), { recursive: true });
     console.log(
       `Processed ${filesProcessed} files and ${chunksProcessed} chunks in parallel. Writing local vector store...`

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "next": "^15.2.3",
         "ollama": "^0.5.16",
         "openai": "^4.87.3",
+        "p-limit": "^6.2.0",
         "partial-json": "^0.1.7",
         "react": "^18",
         "react-dom": "^18",
@@ -8259,6 +8260,37 @@
       }
     },
     "node_modules/p-limit": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
+      "integrity": "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
@@ -8274,15 +8306,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+    "node_modules/p-locate/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
       "engines": {
         "node": ">=10"
       },
@@ -11178,13 +11207,12 @@
       }
     },
     "node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
+      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
       "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "next": "^15.2.3",
     "ollama": "^0.5.16",
     "openai": "^4.87.3",
+    "p-limit": "^6.2.0",
     "partial-json": "^0.1.7",
     "react": "^18",
     "react-dom": "^18",


### PR DESCRIPTION
## Summary
- use p-limit to process embeddings with a concurrency pool
- queue all chunks and dispatch as slots free up

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68912560dc5c833391aec2d681295618