### PR TITLE
Handle failed embeddings during initialization

### DIFF
--- a/lib/localVectorStore.ts
+++ b/lib/localVectorStore.ts
@@ -108,25 +108,32 @@ class LocalVectorStore {
             console.log(
               `Embedding chunk ${current}/${totalChunks} from ${file}`
             );
-            const embedding = await this.embedding(chunk);
-            this.store.push({
-              id: crypto.randomUUID(),
-              embedding,
-              text: chunk,
-              attributes: {
-                type: folder,
-                filename: file.replace(/\.(md|json)$/, ""),
-                filepath: `/public/${folder}/${file}`,
-                chunk: idx,
-                overlap,
-              },
-            });
+            try {
+              const embedding = await this.embedding(chunk);
+              this.store.push({
+                id: crypto.randomUUID(),
+                embedding,
+                text: chunk,
+                attributes: {
+                  type: folder,
+                  filename: file.replace(/\.(md|json)$/, ""),
+                  filepath: `/public/${folder}/${file}`,
+                  chunk: idx,
+                  overlap,
+                },
+              });
+            } catch (err) {
+              console.error(
+                `Failed to embed chunk ${current}/${totalChunks} from ${file}:`,
+                err
+              );
+            }
           })
         );
       });
     }
     const filesProcessed = filesData.length;
-    await Promise.all(tasks);
+    await Promise.allSettled(tasks);
     await fs.mkdir(path.dirname(STORE_PATH), { recursive: true });
     console.log(
       `Processed ${filesProcessed} files and ${chunksProcessed} chunks in parallel. Writing local vector store...`


### PR DESCRIPTION
## Summary
- guard vector store initialization against per-chunk embedding failures
- run all embedding tasks with Promise.allSettled and log failures

## Testing
- `npm test` *(fails: /workspace/openai-support-agent-demo/tests/tickets.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_689127b49d1c83339fcc1fb90d9325f9