### PR TITLE
Handle JSON parsing errors in local vector store

### DIFF
--- a/lib/localVectorStore.ts
+++ b/lib/localVectorStore.ts
@@ -43,7 +43,20 @@ class LocalVectorStore {
     if (this.loaded) return;
     try {
       const data = await fs.readFile(STORE_PATH, "utf8");
-      this.store = JSON.parse(data);
+      try {
+        const parsed = JSON.parse(data);
+        if (Array.isArray(parsed)) {
+          this.store = parsed;
+        } else {
+          console.warn(
+            `Unexpected format in ${STORE_PATH}, initializing empty store`
+          );
+          this.store = [];
+        }
+      } catch (err) {
+        console.error(`Failed to parse ${STORE_PATH}:`, err);
+        this.store = [];
+      }
     } catch {
       this.store = [];
     }
@@ -80,7 +93,20 @@ class LocalVectorStore {
         const raw = await fs.readFile(filePath, "utf8");
         let cleaned: string;
         if (file.endsWith(".json")) {
-          cleaned = JSON.stringify(JSON.parse(raw));
+          try {
+            const parsed = JSON.parse(raw);
+            if (parsed && typeof parsed === "object") {
+              cleaned = JSON.stringify(parsed);
+            } else {
+              console.warn(
+                `Invalid JSON structure in ${file}; using raw text`
+              );
+              cleaned = raw;
+            }
+          } catch (err) {
+            console.error(`Failed to parse ${file}:`, err);
+            cleaned = raw;
+          }
         } else {
           cleaned = cleanMarkdown(raw);
         }


### PR DESCRIPTION
## Summary
- guard local vector store loading against invalid JSON and unexpected formats
- safely parse knowledge-base JSON files with validation and raw-text fallback

## Testing
- `npm test` *(fails: /workspace/openai-support-agent-demo/tests/tickets.test.js: test failed)*

------
https://chatgpt.com/codex/tasks/task_e_689129b3e26c833396676cf53ca1e0f4