### PR TITLE
feat: add threshold options for local vector search

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,11 @@ When using the `ollama` provider you need a local server running.
    while the local store powers file search when using the `ollama` provider.
    Both stores can exist side by side.
 
+   By default, local search returns up to 5 results with a cosine similarity
+   threshold of 0.5. Pass a `threshold` option to adjust the cutoff or set
+   `topKOnly: true` to ignore the threshold and rely solely on the highest
+   scoring `limit` matches.
+
 ## Demo Flow
 
 To try out the demo, you can ask questions that will trigger a file search.

--- a/lib/localVectorStore.ts
+++ b/lib/localVectorStore.ts
@@ -170,23 +170,43 @@ class LocalVectorStore {
     );
   }
 
-  async search(query: string, limit = 5) {
+  /**
+   * Search the local vector store.
+   *
+   * By default, returns up to `limit` entries with a cosine similarity score
+   * of at least `threshold` (defaults to `0.5`).
+   * Set `topKOnly` to `true` to ignore the threshold and rely solely on the
+   * highest scoring `limit` matches. Lowering the threshold increases recall,
+   * while raising it can improve precision.
+   */
+  async search(
+    query: string,
+    {
+      limit = 5,
+      threshold = 0.5,
+      topKOnly = false,
+    }: { limit?: number; threshold?: number; topKOnly?: boolean } = {}
+  ) {
     await this.ensureLoaded();
     if (this.store.length === 0) {
       throw new Error("Local vector store is empty");
     }
     console.log(`Searching ${this.store.length} stored entries...`);
     const qEmbed = await this.embedding(query);
-    const threshold = 0.5
-    const results = this.store
+    let results = this.store
       .map((e) => ({
         text: e.text,
         attributes: e.attributes,
         score: cosineSimilarity(qEmbed, e.embedding),
       }))
-      .filter((r) => r.score >= threshold)
-      .sort((a, b) => b.score - a.score)
-      .slice(0, limit);
+      .sort((a, b) => b.score - a.score);
+
+    if (!topKOnly) {
+      results = results.filter((r) => r.score >= threshold);
+    }
+
+    results = results.slice(0, limit);
+
     console.log(
       "Top scores:",
       results.map((r) => r.score.toFixed(3))

--- a/lib/server/searchFiles.ts
+++ b/lib/server/searchFiles.ts
@@ -35,7 +35,7 @@ export async function search_knowledge_base({
       const arrays = await Promise.all(
         searchParts.map(async (q) => {
           if (provider === 'ollama' || provider === 'ollama-openai') {
-            return await localVectorStore.search(q, max_results);
+            return await localVectorStore.search(q, { limit: max_results });
           }
 
           const res = await fileSearch({ query: q, provider });

--- a/lib/tools/fileSearch.ts
+++ b/lib/tools/fileSearch.ts
@@ -13,7 +13,7 @@ export async function fileSearch({
   const max_results = 20;
   if (provider === "ollama" || provider === "ollama-openai") {
     try {
-      const results = await localVectorStore.search(query, max_results);
+      const results = await localVectorStore.search(query, { limit: max_results });
       return { results };
     } catch (error) {
       console.error("Local file search failed", error);


### PR DESCRIPTION
## Summary
- allow callers to set similarity threshold or disable it for top-k retrieval in the local vector store
- document threshold defaults and tuning options

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68912c3cf4a48333bbd71f2f5fb0dbb6