### PR TITLE
Validate vector search params

### DIFF
--- a/lib/localVectorStore.ts
+++ b/lib/localVectorStore.ts
@@ -182,15 +182,29 @@ class LocalVectorStore {
   async search(
     query: string,
     {
-      limit = 5,
-      threshold = 0.5,
+      limit: rawLimit = 5,
+      threshold: rawThreshold = 0.5,
       topKOnly = false,
-    }: { limit?: number; threshold?: number; topKOnly?: boolean } = {}
+    }: { limit?: number; threshold?: number; topKOnly?: boolean } = {},
   ) {
     await this.ensureLoaded();
     if (this.store.length === 0) {
       throw new Error("Local vector store is empty");
     }
+
+    let limit = rawLimit;
+    if (!Number.isInteger(limit) || limit <= 0) {
+      console.warn(`Invalid limit ${rawLimit}; defaulting to 5`);
+      limit = 5;
+    }
+
+    let threshold = rawThreshold;
+    if (typeof threshold !== "number" || Number.isNaN(threshold)) {
+      throw new Error("threshold must be a number between -1 and 1");
+    }
+    if (threshold < -1) threshold = -1;
+    if (threshold > 1) threshold = 1;
+
     console.log(`Searching ${this.store.length} stored entries...`);
     const qEmbed = await this.embedding(query);
     let results = this.store

--- a/tests/localVectorStore.test.js
+++ b/tests/localVectorStore.test.js
@@ -1,0 +1,49 @@
+const test = require('node:test');
+const assert = require('assert');
+const { localVectorStore } = require('../lib/localVectorStore');
+
+function setupStore(embeddings) {
+  localVectorStore.store = embeddings.map((embedding, idx) => ({
+    id: String(idx),
+    embedding,
+    text: `text${idx}`,
+    attributes: { type: 't', filename: 'f', filepath: 'p' },
+  }));
+  localVectorStore.loaded = true;
+  localVectorStore.embedding = async () => [1, 0];
+}
+
+test('defaults to 5 when limit is non-positive', async () => {
+  const embeddings = Array.from({ length: 10 }, () => [1, 0]);
+  setupStore(embeddings);
+  const results = await localVectorStore.search('q', { limit: -3, topKOnly: true });
+  assert.strictEqual(results.length, 5);
+});
+
+test('defaults to 5 when limit is non-integer', async () => {
+  const embeddings = Array.from({ length: 10 }, () => [1, 0]);
+  setupStore(embeddings);
+  const results = await localVectorStore.search('q', { limit: 2.7, topKOnly: true });
+  assert.strictEqual(results.length, 5);
+});
+
+test('clamps threshold above 1 to 1', async () => {
+  const embeddings = [
+    [1, 0],
+    ...Array.from({ length: 5 }, () => [0, 1]),
+  ];
+  setupStore(embeddings);
+  const results = await localVectorStore.search('q', { threshold: 2, limit: 10 });
+  assert.strictEqual(results.length, 1);
+});
+
+test('clamps threshold below -1 to -1', async () => {
+  const embeddings = [
+    [1, 0],
+    [-1, 0],
+    ...Array.from({ length: 3 }, () => [0, 1]),
+  ];
+  setupStore(embeddings);
+  const results = await localVectorStore.search('q', { threshold: -2, limit: 10 });
+  assert.strictEqual(results.length, embeddings.length);
+});


### PR DESCRIPTION
## Summary
- validate search `limit` argument and default to 5 when invalid
- clamp search `threshold` to `[-1, 1]`
- test invalid limit and threshold cases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689137e0348c833383accf1b8af5c130