### PR TITLE
Allow lower score threshold for Ollama searches

### DIFF
--- a/lib/server/searchFiles.ts
+++ b/lib/server/searchFiles.ts
@@ -4,6 +4,10 @@ import { fileSearch } from '@/lib/tools/fileSearch';
 import { localVectorStore } from '../localVectorStore';
 import { generateSearchQueries } from '../generateSearchQueries';
 
+const OLLAMA_SEARCH_THRESHOLD = Number(
+  process.env.OLLAMA_SEARCH_THRESHOLD ?? 0.3,
+);
+
 /**
  * Search the knowledge base using one or multiple queries.
  * If `queries` is not provided, the single `query` string will be split into
@@ -34,8 +38,11 @@ export async function search_knowledge_base({
     try {
       const arrays = await Promise.all(
         searchParts.map(async (q) => {
-          if (provider === 'ollama' || provider === 'ollama-openai') {
-            return await localVectorStore.search(q, { limit: max_results });
+          if (provider?.includes('ollama')) {
+            return await localVectorStore.search(q, {
+              limit: max_results,
+              threshold: OLLAMA_SEARCH_THRESHOLD,
+            });
           }
 
           const res = await fileSearch({ query: q, provider });
@@ -80,10 +87,9 @@ export async function search_knowledge_base({
     .slice(0, max_results)
     .map((r) => r.item);
 
-  const results =
-    provider === 'ollama' || provider === 'ollama-openai'
-      ? ranked.map((r) => r.text)
-      : ranked;
+  const results = provider?.includes('ollama')
+    ? ranked.map((r) => r.text)
+    : ranked;
 
   return { results };
   } catch (error) {

--- a/lib/tools/fileSearch.ts
+++ b/lib/tools/fileSearch.ts
@@ -1,6 +1,10 @@
 import { VECTOR_STORE_ID } from "@/config/constants";
 import { localVectorStore } from "@/lib/localVectorStore";
 
+const OLLAMA_SEARCH_THRESHOLD = Number(
+  process.env.OLLAMA_SEARCH_THRESHOLD ?? 0.3,
+);
+
 export interface FileSearchParams {
   query: string;
   provider?: string;
@@ -11,9 +15,12 @@ export async function fileSearch({
   provider,
 }: FileSearchParams) {
   const max_results = 20;
-  if (provider === "ollama" || provider === "ollama-openai") {
+  if (provider?.includes("ollama")) {
     try {
-      const results = await localVectorStore.search(query, { limit: max_results });
+      const results = await localVectorStore.search(query, {
+        limit: max_results,
+        threshold: OLLAMA_SEARCH_THRESHOLD,
+      });
       return { results };
     } catch (error) {
       console.error("Local file search failed", error);
@@ -46,3 +53,4 @@ export async function fileSearch({
     };
   }
 }
+

--- a/stores/useDataStore.ts
+++ b/stores/useDataStore.ts
@@ -108,11 +108,11 @@ const useDataStore = create<DataState>((set) => ({
         score,
       };
     });
-    // Sorting by relevance score and keeping only results with score > 0.5
+    // Sorting by relevance score and applying a provider-specific threshold
     const sortedArticles = articles.sort((a, b) => b.score - a.score);
-    const threshold = provider && provider.includes("ollama") ? 0.3 : 0.5;
+    const threshold = provider?.includes("ollama") ? 0.3 : 0.5;
     set({
-      FAQExtracts: sortedArticles.filter((a) => a.score > threshold),
+      FAQExtracts: sortedArticles.filter((a) => a.score >= threshold),
       relevantArticlesError: null,
     });
   },


### PR DESCRIPTION
## Summary
- pass configurable 0.3 similarity threshold to local vector searches for Ollama providers
- update client filtering to include scores as low as provider-specific threshold

## Testing
- `npx prisma generate`
- `npm test`
- `TS_NODE_COMPILER_OPTIONS='{"module":"CommonJS","moduleResolution":"node"}' node -r ts-node/register/transpile-only -r tsconfig-paths/register <<'NODE'
const { search_knowledge_base } = require('./lib/server/searchFiles.ts');
const { localVectorStore } = require('./lib/localVectorStore.ts');
localVectorStore.store = [
  { id:'1', embedding:[1,0], text:'text1', attributes:{filename:'f1',type:'t',filepath:'p1'}},
  { id:'2', embedding:[0.4,0.916515], text:'text2', attributes:{filename:'f2',type:'t',filepath:'p2'}},
  { id:'3', embedding:[0.3,0.953939], text:'text3', attributes:{filename:'f3',type:'t',filepath:'p3'}},
  { id:'4', embedding:[0.2,0.979796], text:'text4', attributes:{filename:'f4',type:'t',filepath:'p4'}},
];
localVectorStore.loaded = true;
localVectorStore.embedding = async () => [1,0];
search_knowledge_base({ query: 'q', provider: 'ollama' }).then((res)=>{console.log(JSON.stringify(res,null,2));});
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68913d12ae64833397d1c9193d3e9161