### PR TITLE
feat: expose vector search tuning options

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,10 +187,10 @@ When using the `ollama` provider you need a local server running.
    while the local store powers file search when using the `ollama` provider.
    Both stores can exist side by side.
 
-   By default, local search returns up to 5 results with a cosine similarity
-   threshold of 0.5. Pass a `threshold` option to adjust the cutoff or set
-   `topKOnly: true` to ignore the threshold and rely solely on the highest
-   scoring `limit` matches.
+  By default, local search returns up to 5 results with a cosine similarity
+  threshold of 0.5. Provide a `limit` option to control the number of results,
+  a `threshold` option to adjust the cutoff, or set `topKOnly: true` to ignore
+  the threshold and rely solely on the highest scoring `limit` matches.
 
 ## Demo Flow
 

--- a/config/functions.ts
+++ b/config/functions.ts
@@ -369,9 +369,15 @@ export const start_chat_session = async ({
 export const search_knowledge_base = async ({
   query,
   queries,
+  limit,
+  threshold,
+  topKOnly,
 }: {
   query: string;
   queries?: string[];
+  limit?: number;
+  threshold?: number;
+  topKOnly?: boolean;
 }): Promise<{ results?: any[] | string[]; error?: string }> => {
   const {
     modelProvider: provider,
@@ -388,18 +394,25 @@ export const search_knowledge_base = async ({
 
   try {
     setRelevantArticlesLoading(true);
-    // Use all provided queries to build a stable cache key
-    const queryKey =
+    // Use all provided queries plus search params to build a stable cache key
+    const queryKeyBase =
       Array.isArray(queries) && queries.length > 0 ? queries.join("|") : query;
+    const queryKey = [
+      queryKeyBase,
+      limit,
+      threshold,
+      topKOnly,
+    ]
+      .filter((v) => v !== undefined)
+      .join("|");
     if (lastSearchQuery === queryKey && lastSearchResults) {
       setFAQExtracts(lastSearchResults, provider);
       setRelevantArticlesError(null);
       return { results: lastSearchResults };
     }
 
-    const cacheKey = `${queryKey}`;
-    if (fileSearchCache.has(cacheKey)) {
-      const cached = fileSearchCache.get(cacheKey)!;
+    if (fileSearchCache.has(queryKey)) {
+      const cached = fileSearchCache.get(queryKey)!;
       setFAQExtracts(cached, provider);
       setLastSearchQuery(queryKey);
       setLastSearchResults(cached);
@@ -411,12 +424,15 @@ export const search_knowledge_base = async ({
       query,
       queries,
       provider,
+      limit,
+      threshold,
+      topKOnly,
     });
     if (result.results) {
       setFAQExtracts(result.results, provider);
       setLastSearchQuery(queryKey);
       setLastSearchResults(result.results);
-      fileSearchCache.set(cacheKey, result.results);
+      fileSearchCache.set(queryKey, result.results);
       setRelevantArticlesError(null);
     } else if (result.error) {
       setRelevantArticlesError(result.error);

--- a/config/tools-list.ts
+++ b/config/tools-list.ts
@@ -21,6 +21,20 @@ export const toolsList = [
               "Optional list of search queries derived from the user question.",
             items: { type: "string" },
           },
+          limit: {
+            type: "number",
+            description: "Maximum number of results to return.",
+          },
+          threshold: {
+            type: "number",
+            description:
+              "Minimum cosine similarity score. Ignored when topKOnly is true.",
+          },
+          topKOnly: {
+            type: "boolean",
+            description:
+              "Return only the top `limit` matches, bypassing the threshold.",
+          },
         },
         required: ["query"],
         additionalProperties: false,

--- a/lib/providers/ollama.ts
+++ b/lib/providers/ollama.ts
@@ -166,9 +166,16 @@ const converted = convertMessages(messages);
             params = { query: state.args };
           }
           const query = params.query || "";
+          const { limit, threshold, topKOnly } = params;
           let results: any = {};
           if (state.type === "file_search") {
-            const res = await fileSearch({ query, provider: "ollama" });
+            const res = await fileSearch({
+              query,
+              provider: "ollama",
+              limit,
+              threshold,
+              topKOnly,
+            });
             results = res.results;
             yield {
               event: "response.file_search_call.results",

--- a/lib/providers/ollama_openai.ts
+++ b/lib/providers/ollama_openai.ts
@@ -165,11 +165,15 @@ export async function* ollamaOpenAIProvider(
                 params = { query: state.args };
               }
               const query = params.query || "";
+              const { limit, threshold, topKOnly } = params;
               let results: any = {};
               if (state.type === "file_search") {
                 const res = await fileSearch({
                   query,
                   provider: "ollama-openai",
+                  limit,
+                  threshold,
+                  topKOnly,
                 });
                 results = res.results;
                 yield {

--- a/lib/server/searchFiles.ts
+++ b/lib/server/searchFiles.ts
@@ -11,16 +11,26 @@ const OLLAMA_SEARCH_THRESHOLD = Number(
 /**
  * Search the knowledge base using one or multiple queries.
  * If `queries` is not provided, the single `query` string will be split into
- * shorter phrases to broaden the search.
+ * shorter phrases to broaden the search. Optional parameters can tune the
+ * vector search:
+ * - `limit` controls the maximum number of results.
+ * - `threshold` sets the minimum cosine similarity score.
+ * - `topKOnly` ignores the threshold and returns only the top `limit` items.
  */
 export async function search_knowledge_base({
   query,
   queries,
   provider,
+  limit,
+  threshold,
+  topKOnly,
 }: {
   query?: string;
   queries?: string[];
   provider?: string;
+  limit?: number;
+  threshold?: number;
+  topKOnly?: boolean;
 }) {
   try {
     const baseParts =
@@ -32,7 +42,7 @@ export async function search_knowledge_base({
 
     const searchParts = Array.from(new Set(baseParts.map((p) => p.trim())));
 
-    const max_results = 10;
+    const max_results = limit ?? 10;
     let collected: any[] = [];
 
     try {
@@ -41,11 +51,18 @@ export async function search_knowledge_base({
           if (provider?.includes('ollama')) {
             return await localVectorStore.search(q, {
               limit: max_results,
-              threshold: OLLAMA_SEARCH_THRESHOLD,
+              threshold: threshold ?? OLLAMA_SEARCH_THRESHOLD,
+              topKOnly,
             });
           }
 
-          const res = await fileSearch({ query: q, provider });
+          const res = await fileSearch({
+            query: q,
+            provider,
+            limit: max_results,
+            threshold,
+            topKOnly,
+          });
           if (res.error) throw new Error(res.error);
           return res.results ?? [];
         })

--- a/lib/tools/fileSearch.ts
+++ b/lib/tools/fileSearch.ts
@@ -5,21 +5,35 @@ const OLLAMA_SEARCH_THRESHOLD = Number(
   process.env.OLLAMA_SEARCH_THRESHOLD ?? 0.3,
 );
 
+/**
+ * Parameters for searching files locally or via the OpenAI Vector Store.
+ *
+ * `limit` controls the maximum number of results returned.
+ * `threshold` sets the minimum cosine similarity when `topKOnly` is false.
+ * When `topKOnly` is true, only the top `limit` matches are returned.
+ */
 export interface FileSearchParams {
   query: string;
   provider?: string;
+  limit?: number;
+  threshold?: number;
+  topKOnly?: boolean;
 }
 
 export async function fileSearch({
   query,
   provider,
+  limit,
+  threshold,
+  topKOnly,
 }: FileSearchParams) {
-  const max_results = 20;
+  const max_results = limit ?? 20;
   if (provider?.includes("ollama")) {
     try {
       const results = await localVectorStore.search(query, {
         limit: max_results,
-        threshold: OLLAMA_SEARCH_THRESHOLD,
+        threshold: threshold ?? OLLAMA_SEARCH_THRESHOLD,
+        topKOnly,
       });
       return { results };
     } catch (error) {


### PR DESCRIPTION
## Summary
- allow file search helpers to accept `limit`, `threshold`, and `topKOnly`
- propagate vector search tuning params through knowledge base search and provider calls
- document new search options in tool schema and README

## Testing
- `npx prisma generate`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891415c58e4833388f38af91a34e588