### PR TITLE
Increase default local search limit to 10

### DIFF
--- a/lib/localVectorStore.ts
+++ b/lib/localVectorStore.ts
@@ -182,7 +182,7 @@ class LocalVectorStore {
   async search(
     query: string,
     {
-      limit: rawLimit = 5,
+      limit: rawLimit = 10,
       threshold: rawThreshold = 0.5,
       topKOnly = false,
     }: { limit?: number; threshold?: number; topKOnly?: boolean } = {},
@@ -194,8 +194,8 @@ class LocalVectorStore {
 
     let limit = rawLimit;
     if (!Number.isInteger(limit) || limit <= 0) {
-      console.warn(`Invalid limit ${rawLimit}; defaulting to 5`);
-      limit = 5;
+      console.warn(`Invalid limit ${rawLimit}; defaulting to 10`);
+      limit = 10;
     }
 
     let threshold = rawThreshold;

--- a/tests/localVectorStore.test.js
+++ b/tests/localVectorStore.test.js
@@ -13,18 +13,18 @@ function setupStore(embeddings) {
   localVectorStore.embedding = async () => [1, 0];
 }
 
-test('defaults to 5 when limit is non-positive', async () => {
+test('defaults to 10 when limit is non-positive', async () => {
   const embeddings = Array.from({ length: 10 }, () => [1, 0]);
   setupStore(embeddings);
   const results = await localVectorStore.search('q', { limit: -3, topKOnly: true });
-  assert.strictEqual(results.length, 5);
+  assert.strictEqual(results.length, 10);
 });
 
-test('defaults to 5 when limit is non-integer', async () => {
+test('defaults to 10 when limit is non-integer', async () => {
   const embeddings = Array.from({ length: 10 }, () => [1, 0]);
   setupStore(embeddings);
   const results = await localVectorStore.search('q', { limit: 2.7, topKOnly: true });
-  assert.strictEqual(results.length, 5);
+  assert.strictEqual(results.length, 10);
 });
 
 test('clamps threshold above 1 to 1', async () => {


### PR DESCRIPTION
## Summary
- raise default `limit` to 10 for local vector store searches and adjust warning and fallback values
- update local vector store tests to match the new default limit

## Testing
- `npm test` *(fails: Prisma Client could not locate the Query Engine for runtime `debian-openssl-3.0.x`)*

------
https://chatgpt.com/codex/tasks/task_e_689158b17bf88333a5feb8758e03b2ec