### PR TITLE
test: expect default limit of 10 results

### DIFF
--- a/tests/localVectorStore.test.js
+++ b/tests/localVectorStore.test.js
@@ -13,18 +13,18 @@ function setupStore(embeddings) {
   localVectorStore.embedding = async () => [1, 0];
 }
 
-test('defaults to 10 when limit is non-positive', async () => {
+test('defaults to 10 results when limit is non-positive', async () => {
   const embeddings = Array.from({ length: 10 }, () => [1, 0]);
   setupStore(embeddings);
   const results = await localVectorStore.search('q', { limit: -3, topKOnly: true });
-  assert.strictEqual(results.length, 10);
+  assert.strictEqual(results.length, 10, 'defaults to 10 results');
 });
 
-test('defaults to 10 when limit is non-integer', async () => {
+test('defaults to 10 results when limit is non-integer', async () => {
   const embeddings = Array.from({ length: 10 }, () => [1, 0]);
   setupStore(embeddings);
   const results = await localVectorStore.search('q', { limit: 2.7, topKOnly: true });
-  assert.strictEqual(results.length, 10);
+  assert.strictEqual(results.length, 10, 'defaults to 10 results');
 });
 
 test('clamps threshold above 1 to 1', async () => {


### PR DESCRIPTION
## Summary
- clarify tests to expect 10 results when limit is non-positive or non-integer

## Testing
- `npm test tests/localVectorStore.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6891abe57f4083338788fed70661fc2e