### PR TITLE
fix: coerce search params to numbers

### DIFF
--- a/config/functions.ts
+++ b/config/functions.ts
@@ -375,8 +375,8 @@ export const search_knowledge_base = async ({
 }: {
   query: string;
   queries?: string[];
-  limit?: number;
-  threshold?: number;
+  limit?: number | string;
+  threshold?: number | string;
   topKOnly?: boolean;
 }): Promise<{ results?: any[] | string[]; error?: string }> => {
   const {
@@ -397,10 +397,14 @@ export const search_knowledge_base = async ({
     // Use all provided queries plus search params to build a stable cache key
     const queryKeyBase =
       Array.isArray(queries) && queries.length > 0 ? queries.join("|") : query;
+    const limitNum =
+      typeof limit === "string" ? parseInt(limit, 10) : limit;
+    const thresholdNum =
+      typeof threshold === "string" ? parseFloat(threshold) : threshold;
     const queryKey = [
       queryKeyBase,
-      limit,
-      threshold,
+      limitNum,
+      thresholdNum,
       topKOnly,
     ]
       .filter((v) => v !== undefined)
@@ -424,8 +428,8 @@ export const search_knowledge_base = async ({
       query,
       queries,
       provider,
-      limit,
-      threshold,
+      limit: limitNum,
+      threshold: thresholdNum,
       topKOnly,
     });
     if (result.results) {

--- a/lib/server/searchFiles.ts
+++ b/lib/server/searchFiles.ts
@@ -28,8 +28,8 @@ export async function search_knowledge_base({
   query?: string;
   queries?: string[];
   provider?: string;
-  limit?: number;
-  threshold?: number;
+  limit?: number | string;
+  threshold?: number | string;
   topKOnly?: boolean;
 }) {
   try {
@@ -42,7 +42,11 @@ export async function search_knowledge_base({
 
     const searchParts = Array.from(new Set(baseParts.map((p) => p.trim())));
 
-    const max_results = limit ?? 10;
+    const limitNum = typeof limit === "string" ? parseInt(limit, 10) : limit;
+    const thresholdNum =
+      typeof threshold === "string" ? parseFloat(threshold) : threshold;
+
+    const max_results = limitNum ?? 10;
     let collected: any[] = [];
 
     try {
@@ -51,7 +55,7 @@ export async function search_knowledge_base({
           if (provider?.includes('ollama')) {
             return await localVectorStore.search(q, {
               limit: max_results,
-              threshold: threshold ?? OLLAMA_SEARCH_THRESHOLD,
+              threshold: thresholdNum ?? OLLAMA_SEARCH_THRESHOLD,
               topKOnly,
             });
           }
@@ -60,7 +64,7 @@ export async function search_knowledge_base({
             query: q,
             provider,
             limit: max_results,
-            threshold,
+            threshold: thresholdNum,
             topKOnly,
           });
           if (res.error) throw new Error(res.error);


### PR DESCRIPTION
## Summary
- ensure `limit` and `threshold` are coerced to numbers before searching the knowledge base
- mirror number coercion in server-side search handler for direct API usage

## Testing
- `npm test` (fails: tickets.test.js)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891e8b882588333a9dbee337f422dba