### PR TITLE
Unify file search default limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,8 +187,8 @@ When using the `ollama` provider you need a local server running.
    while the local store powers file search when using the `ollama` provider.
    Both stores can exist side by side.
 
-  By default, local search returns up to 10 results with a cosine similarity
-  threshold of 0.3. Provide a `limit` option to control the number of results,
+  By default, searches return up to 10 results. Local search applies a cosine
+  similarity threshold of 0.3. Provide a `limit` option to control the number of results,
   a `threshold` option to adjust the cutoff, or set `topKOnly: true` to ignore
   the threshold and rely solely on the highest scoring `limit` matches.
 

--- a/config/constants.ts
+++ b/config/constants.ts
@@ -34,3 +34,6 @@ Hi, I'm ${AGENT_NAME}, your support representative. How can I help you today?
 // Replace with the vector store ID you get after initializing the vector store
 // Go to /init_vs to initialize the vector store with the demo knowledge base
 export const VECTOR_STORE_ID = "vs_688149954aa08191841d645c1b839941";
+
+// Default maximum number of search results returned when no limit is specified
+export const DEFAULT_SEARCH_LIMIT = 10;

--- a/config/tools-list.ts
+++ b/config/tools-list.ts
@@ -23,7 +23,7 @@ export const toolsList = [
           },
           limit: {
             type: "number",
-            description: "Maximum number of results to return.",
+            description: "Maximum number of results to return. Defaults to 10.",
           },
           threshold: {
             type: "number",

--- a/lib/localVectorStore.ts
+++ b/lib/localVectorStore.ts
@@ -4,6 +4,7 @@ import crypto from "crypto";
 import ollama from "ollama";
 import { KB_FOLDERS } from "@/config/demoData";
 import { TEXT_SPLITTER_CONFIG } from "@/config/vectorStore";
+import { DEFAULT_SEARCH_LIMIT } from "@/config/constants";
 import cleanMarkdown from "./cleanMarkdown";
 import { splitText } from "./textSplitter";
 import pLimit from "p-limit";
@@ -174,15 +175,16 @@ class LocalVectorStore {
    * Search the local vector store.
    *
    * By default, returns up to `limit` entries with a cosine similarity score
-   * of at least `threshold` (defaults to `0.5`).
-   * Set `topKOnly` to `true` to ignore the threshold and rely solely on the
-   * highest scoring `limit` matches. Lowering the threshold increases recall,
-   * while raising it can improve precision.
+   * of at least `threshold` (defaults to `0.5`). When `limit` is omitted,
+   * the search returns up to 10 results. Set `topKOnly` to `true` to ignore
+   * the threshold and rely solely on the highest scoring `limit` matches.
+   * Lowering the threshold increases recall, while raising it can improve
+   * precision.
    */
   async search(
     query: string,
     {
-      limit: rawLimit = 10,
+      limit: rawLimit = DEFAULT_SEARCH_LIMIT,
       threshold: rawThreshold = 0.5,
       topKOnly = false,
     }: { limit?: number; threshold?: number; topKOnly?: boolean } = {},
@@ -194,8 +196,10 @@ class LocalVectorStore {
 
     let limit = rawLimit;
     if (!Number.isInteger(limit) || limit <= 0) {
-      console.warn(`Invalid limit ${rawLimit}; defaulting to 10`);
-      limit = 10;
+      console.warn(
+        `Invalid limit ${rawLimit}; defaulting to ${DEFAULT_SEARCH_LIMIT}`
+      );
+      limit = DEFAULT_SEARCH_LIMIT;
     }
 
     let threshold = rawThreshold;

--- a/lib/server/searchFiles.ts
+++ b/lib/server/searchFiles.ts
@@ -1,5 +1,6 @@
 'use server'
 
+import { DEFAULT_SEARCH_LIMIT } from '@/config/constants';
 import { fileSearch } from '@/lib/tools/fileSearch';
 import { localVectorStore } from '../localVectorStore';
 import { generateSearchQueries } from '../generateSearchQueries';
@@ -13,7 +14,7 @@ const OLLAMA_SEARCH_THRESHOLD = Number(
  * If `queries` is not provided, the single `query` string will be split into
  * shorter phrases to broaden the search. Optional parameters can tune the
  * vector search:
- * - `limit` controls the maximum number of results.
+ * - `limit` controls the maximum number of results (defaults to 10).
  * - `threshold` sets the minimum cosine similarity score.
  * - `topKOnly` ignores the threshold and returns only the top `limit` items.
  */
@@ -46,7 +47,7 @@ export async function search_knowledge_base({
     const thresholdNum =
       typeof threshold === "string" ? parseFloat(threshold) : threshold;
 
-    const max_results = limitNum ?? 10;
+    const max_results = limitNum ?? DEFAULT_SEARCH_LIMIT;
     let collected: any[] = [];
 
     try {

--- a/lib/tools/fileSearch.ts
+++ b/lib/tools/fileSearch.ts
@@ -1,4 +1,4 @@
-import { VECTOR_STORE_ID } from "@/config/constants";
+import { VECTOR_STORE_ID, DEFAULT_SEARCH_LIMIT } from "@/config/constants";
 import { localVectorStore } from "@/lib/localVectorStore";
 
 const OLLAMA_SEARCH_THRESHOLD = Number(
@@ -8,7 +8,7 @@ const OLLAMA_SEARCH_THRESHOLD = Number(
 /**
  * Parameters for searching files locally or via the OpenAI Vector Store.
  *
- * `limit` controls the maximum number of results returned.
+ * `limit` controls the maximum number of results returned (defaults to 10).
  * `threshold` sets the minimum cosine similarity when `topKOnly` is false.
  * When `topKOnly` is true, only the top `limit` matches are returned.
  */
@@ -27,7 +27,7 @@ export async function fileSearch({
   threshold,
   topKOnly,
 }: FileSearchParams) {
-  const max_results = limit ?? 20;
+  const max_results = limit ?? DEFAULT_SEARCH_LIMIT;
   if (provider?.includes("ollama")) {
     try {
       const results = await localVectorStore.search(query, {


### PR DESCRIPTION
## Summary
- add `DEFAULT_SEARCH_LIMIT` constant set to 10
- use the constant for local and remote file searches and server helper
- document new default and update tool schema descriptions

## Testing
- `npm run lint`
- `npm test` *(fails: PrismaClientInitializationError: Prisma Client could not locate the Query Engine for runtime "debian-openssl-3.0.x")*

------
https://chatgpt.com/codex/tasks/task_e_68921eaee8208333b5b1eae7e7417179