### PR TITLE
feat: type search knowledge base results

### DIFF
--- a/config/functions.ts
+++ b/config/functions.ts
@@ -3,10 +3,13 @@
 // Parameters for a tool call are passed as an object to the corresponding function
 import useDataStore from "@/stores/useDataStore";
 import useConversationStore from "@/stores/useConversationStore";
-import { search_knowledge_base as serverSearchKnowledgeBase } from "@/lib/server/searchFiles";
+import {
+  search_knowledge_base as serverSearchKnowledgeBase,
+  type SearchKnowledgeBaseResponse,
+} from "@/lib/server/searchFiles";
 
 // simple in-memory cache for file search results
-const fileSearchCache = new Map<string, any[] | string[]>();
+const fileSearchCache = new Map<string, SearchKnowledgeBaseResponse["results"]>();
 
 export function clearFileSearchCache() {
   fileSearchCache.clear();
@@ -378,7 +381,7 @@ export const search_knowledge_base = async ({
   limit?: number | string;
   threshold?: number | string;
   topKOnly?: boolean;
-}): Promise<{ results?: any[] | string[]; error?: string }> => {
+}): Promise<SearchKnowledgeBaseResponse> => {
   const {
     modelProvider: provider,
     lastSearchQuery,

--- a/lib/server/searchFiles.ts
+++ b/lib/server/searchFiles.ts
@@ -9,6 +9,11 @@ const OLLAMA_SEARCH_THRESHOLD = Number(
   process.env.OLLAMA_SEARCH_THRESHOLD ?? 0.3,
 );
 
+export interface SearchKnowledgeBaseResponse {
+  results?: any[] | string[];
+  error?: string;
+}
+
 /**
  * Search the knowledge base using one or multiple queries.
  * If `queries` is not provided, the single `query` string will be split into
@@ -32,7 +37,7 @@ export async function search_knowledge_base({
   limit?: number | string;
   threshold?: number | string;
   topKOnly?: boolean;
-}) {
+}): Promise<SearchKnowledgeBaseResponse> {
   try {
     const baseParts =
       Array.isArray(queries) && queries.length > 0


### PR DESCRIPTION
## Summary
- add `SearchKnowledgeBaseResponse` interface for structured knowledge base search results
- annotate `search_knowledge_base` to return `Promise<SearchKnowledgeBaseResponse>`
- consume typed response in client functions and cache

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689222eebc888333b37ed03bca2149f7