### PR TITLE
Limit session messages and preload trimmed history

### DIFF
--- a/app/api/sessions/start/route.ts
+++ b/app/api/sessions/start/route.ts
@@ -1,5 +1,6 @@
 import prisma from "@/lib/prisma";
 import redis from "@/lib/redis";
+import { MAX_SESSION_MESSAGES } from "@/config/constants";
 
 export async function POST(request: Request) {
   try {
@@ -29,7 +30,13 @@ export async function POST(request: Request) {
       });
     }
     const summary = await redis.get(identifier);
-    return new Response(JSON.stringify({ user, session, summary }), { status: 200 });
+    const trimmedSession = session
+      ? { ...session, messages: (session.messages as any[]).slice(-MAX_SESSION_MESSAGES) }
+      : session;
+    return new Response(
+      JSON.stringify({ user, session: trimmedSession, summary }),
+      { status: 200 }
+    );
   } catch (error) {
     console.error("Error starting session:", error);
     return new Response("Error starting session", { status: 500 });

--- a/config/constants.ts
+++ b/config/constants.ts
@@ -37,3 +37,6 @@ export const VECTOR_STORE_ID = "vs_688149954aa08191841d645c1b839941";
 
 // Default maximum number of search results returned when no limit is specified
 export const DEFAULT_SEARCH_LIMIT = 10;
+
+// Maximum number of past session messages to return to the client
+export const MAX_SESSION_MESSAGES = 20;

--- a/config/functions.ts
+++ b/config/functions.ts
@@ -349,8 +349,28 @@ export const start_chat_session = async ({
     }).then((res) => res.json());
     const { setCustomerDetails, setContact, setSummary, setSessionId } =
       useDataStore.getState();
+    const { setConversationItems, setChatMessages } =
+      useConversationStore.getState();
     if (res.session?.id) {
       setSessionId(res.session.id);
+    }
+    if (Array.isArray(res.session?.messages) && res.session.messages.length > 0) {
+      setConversationItems(res.session.messages);
+      const chatMsgs = res.session.messages
+        .filter((m: any) => m.role === "user" || m.role === "assistant")
+        .map((m: any) => ({
+          type: "message",
+          role: m.role === "assistant" ? "agent" : "user",
+          content: Array.isArray(m.content)
+            ? m.content
+            : [
+                {
+                  type: m.role === "assistant" ? "output_text" : "input_text",
+                  text: m.content,
+                },
+              ],
+        }));
+      setChatMessages(chatMsgs);
     }
     if (res.user && !res.user.error) {
       setCustomerDetails(setDetailsFromUser(res.user));


### PR DESCRIPTION
## Summary
- add `MAX_SESSION_MESSAGES` config to cap returned session history
- slice `session.messages` in session start API before responding
- hydrate client stores with trimmed messages while relying on Redis `summary` for older context

## Testing
- `npx prisma generate`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a2221b9e083338524867b65f6a6b7