### PR TITLE
feat: limit messages to token budget

### DIFF
--- a/lib/assistant.ts
+++ b/lib/assistant.ts
@@ -7,6 +7,7 @@ import { Annotation } from "@/components/Annotations";
 import { functionsMap, create_ticket, start_chat_session } from "@/config/functions";
 import useDataStore from "@/stores/useDataStore";
 import { agentTools } from "@/config/tools-list";
+import { encodingForModel } from "js-tiktoken";
 
 // generateId uses browser crypto if available, otherwise Math.random
 export function generateId() {
@@ -67,6 +68,66 @@ export interface ToolCallItem {
 
 export type Item = ChatMessage | ToolCallItem;
 
+const TOKEN_THRESHOLD = 25_000;
+
+function estimateMessageTokens(messages: any[], modelName = "gpt-4o-mini") {
+  const encoding = encodingForModel(modelName);
+  let total = 0;
+  for (const msg of messages) {
+    const content = (msg as any).content;
+    if (Array.isArray(content)) {
+      for (const part of content) {
+        if (typeof part?.text === "string") {
+          total += encoding.encode(part.text).length;
+        }
+      }
+    } else if (typeof content === "string") {
+      total += encoding.encode(content).length;
+    }
+  }
+  return total;
+}
+
+function trimMessagesToTokenLimit(
+  allMessages: any[],
+  limit: number,
+  summary: string | null,
+  systemCount: number,
+  modelName?: string
+) {
+  let trimmed = [...allMessages];
+  let tokenEstimate = estimateMessageTokens(trimmed, modelName);
+
+  const removed: any[] = [];
+
+  while (tokenEstimate > limit && trimmed.length > systemCount + 1) {
+    removed.push(trimmed[systemCount]);
+    trimmed.splice(systemCount, 1);
+    tokenEstimate = estimateMessageTokens(trimmed, modelName);
+  }
+
+  if (removed.length > 0 && !summary) {
+    const removedText = removed
+      .map((m) =>
+        Array.isArray(m.content)
+          ? m.content.map((c: any) => c.text ?? "").join(" ")
+          : m.content ?? ""
+      )
+      .join(" ");
+    trimmed.unshift({
+      role: "system",
+      content: [
+        {
+          type: "input_text",
+          text: `Previous conversation summary: ${removedText}`,
+        },
+      ],
+    });
+  }
+
+  return trimmed;
+}
+
 export const handleTurn = async (
   messages: any[],
   onMessage: (data: any) => void,
@@ -104,6 +165,14 @@ export const handleTurn = async (
     const messagesWithTicket =
       systemMessages.length > 0 ? [...systemMessages, ...messages] : messages;
 
+    const limitedMessages = trimMessagesToTokenLimit(
+      messagesWithTicket,
+      TOKEN_THRESHOLD,
+      summary,
+      systemMessages.length,
+      model
+    );
+
     // Get response from the API (app/api/turn_response/route.ts).
     // This endpoint streams the assistant's reply and persists the turn
     // using saveSessionMessages on the server.
@@ -111,7 +180,7 @@ export const handleTurn = async (
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        messages: messagesWithTicket,
+        messages: limitedMessages,
         tools: toolsArg,
         provider,
         model,

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "dotenv": "^17.2.1",
         "highlight.js": "^11.11.1",
         "ioredis": "^5.3.2",
+        "js-tiktoken": "^1.0.21",
         "langchain": "^0.3.30",
         "lucide-react": "^0.441.0",
         "next": "^15.2.3",
@@ -6712,9 +6713,9 @@
       }
     },
     "node_modules/js-tiktoken": {
-      "version": "1.0.20",
-      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.20.tgz",
-      "integrity": "sha512-Xlaqhhs8VfCd6Sh7a1cFkZHQbYTLCwVJJWiHVxBYzLPxW0XsoxBy1hitmjkdIjD3Aon5BXLHFwU5O8WUx6HH+A==",
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
+      "integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
       "license": "MIT",
       "dependencies": {
         "base64-js": "^1.5.1"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "dotenv": "^17.2.1",
     "highlight.js": "^11.11.1",
     "ioredis": "^5.3.2",
+    "js-tiktoken": "^1.0.21",
     "langchain": "^0.3.30",
     "lucide-react": "^0.441.0",
     "next": "^15.2.3",


### PR DESCRIPTION
## Summary
- estimate message tokens with js-tiktoken
- trim oldest messages when over 25k tokens, keeping summary for context

## Testing
- `npm test` *(fails: PrismaClientInitializationError: Prisma Client could not locate the Query Engine for runtime "debian-openssl-3.0.x")*

------
https://chatgpt.com/codex/tasks/task_e_689a9eef14b88333b50ee0c2410a0b41