### PR TITLE
Handle unknown model encodings for token estimation

### DIFF
--- a/lib/assistant.ts
+++ b/lib/assistant.ts
@@ -7,7 +7,7 @@ import { Annotation } from "@/components/Annotations";
 import { functionsMap, create_ticket, start_chat_session } from "@/config/functions";
 import useDataStore from "@/stores/useDataStore";
 import { agentTools } from "@/config/tools-list";
-import { encodingForModel } from "js-tiktoken";
+import { encodingForModel, getEncoding } from "js-tiktoken";
 
 // generateId uses browser crypto if available, otherwise Math.random
 export function generateId() {
@@ -70,8 +70,40 @@ export type Item = ChatMessage | ToolCallItem;
 
 const TOKEN_THRESHOLD = 25_000;
 
-function estimateMessageTokens(messages: any[], modelName = MODEL) {
-  const encoding = encodingForModel(modelName);
+const OLLAMA_MODEL_PREFIX_TO_ENCODING: Record<string, string> = {
+  llama: "cl100k_base",
+  qwen: "cl100k_base",
+  mistral: "cl100k_base",
+  phi: "cl100k_base",
+  gemma: "cl100k_base",
+};
+
+function mapModelToEncoding(modelName: string) {
+  const lower = modelName.toLowerCase();
+  for (const prefix of Object.keys(OLLAMA_MODEL_PREFIX_TO_ENCODING)) {
+    if (lower.startsWith(prefix)) {
+      return OLLAMA_MODEL_PREFIX_TO_ENCODING[prefix];
+    }
+  }
+  return modelName;
+}
+
+export function estimateMessageTokens(messages: any[], modelName = MODEL) {
+  let encoding;
+  const mapped = mapModelToEncoding(modelName);
+  try {
+    encoding = encodingForModel(mapped);
+  } catch {
+    const fallbackBase = mapped.startsWith("o") || mapped.includes("gpt-4o")
+      ? "o200k_base"
+      : "cl100k_base";
+    try {
+      encoding = encodingForModel(fallbackBase);
+    } catch {
+      encoding = getEncoding(fallbackBase);
+    }
+  }
+
   let total = 0;
   for (const msg of messages) {
     const content = (msg as any).content;

--- a/tests/tokens.test.js
+++ b/tests/tokens.test.js
@@ -1,0 +1,18 @@
+const assert = require('assert');
+const test = require('node:test');
+const { estimateMessageTokens } = require('../lib/assistant');
+const { getEncoding } = require('js-tiktoken');
+
+test('estimateMessageTokens falls back to generic encoding on unknown model', () => {
+  const messages = [{ role: 'user', content: [{ type: 'input_text', text: 'hello' }] }];
+  const expected = getEncoding('cl100k_base').encode('hello').length;
+  const count = estimateMessageTokens(messages, 'unknown-model');
+  assert.strictEqual(count, expected);
+});
+
+test('estimateMessageTokens maps Ollama models to base encodings', () => {
+  const messages = [{ role: 'user', content: [{ type: 'input_text', text: 'world' }] }];
+  const expected = getEncoding('cl100k_base').encode('world').length;
+  const count = estimateMessageTokens(messages, 'llama3.1:8b');
+  assert.strictEqual(count, expected);
+});


### PR DESCRIPTION
## Summary
- add mapping and fallback to generic encodings in `estimateMessageTokens`
- cover fallback logic with tests

## Testing
- `TS_NODE_COMPILER_OPTIONS='{ "module": "CommonJS", "moduleResolution": "node" }' node -r ts-node/register/transpile-only -r tsconfig-paths/register --test tests/tokens.test.js`
- `npm test` *(fails: Prisma Client could not locate the Query Engine for runtime "debian-openssl-3.0.x")*

------
https://chatgpt.com/codex/tasks/task_e_689c5792ff888333a070fb78499c87ab