### PR TITLE
feat: add session summarization utility

### DIFF
--- a/lib/server/summarizeSession.ts
+++ b/lib/server/summarizeSession.ts
@@ -1,0 +1,15 @@
+import OpenAI from "openai";
+
+export async function summarizeSession(messages: any[]): Promise<string> {
+  const openai = new OpenAI();
+  const prompt =
+    "Summarize the conversation in 3–5 bullet points, capturing the user's issue, actions taken, and pending follow-ups.";
+
+  const response = await openai.responses.create({
+    model: "gpt-4o-mini",
+    input: [...(Array.isArray(messages) ? messages : []), { role: "user", content: prompt }],
+  });
+
+  return response.output_text ?? "";
+}
+


### PR DESCRIPTION
## Summary
- add server helper to summarize conversations via GPT-4o mini

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689df7bb55788333895af7af24890e1d