### PR TITLE
Summarize chat session on end

### DIFF
--- a/app/api/sessions/[session_id]/end/route.ts
+++ b/app/api/sessions/[session_id]/end/route.ts
@@ -1,5 +1,7 @@
 import prisma from "@/lib/prisma";
+import redis from "@/lib/redis";
 import { saveSessionMessages } from "@/lib/server/saveSessionMessages";
+import { summarizeSession } from "@/lib/server/summarizeSession";
 
 export async function POST(
   request: Request,
@@ -7,18 +9,32 @@ export async function POST(
 ) {
   try {
     const { session_id } = await params;
-    const { messages = [] } = await request.json();
+    const { messages = [], identifier } = await request.json();
 
     if (Array.isArray(messages) && messages.length > 0) {
-      await saveSessionMessages(session_id, messages);
+      await saveSessionMessages(session_id, messages, identifier);
     }
+
+    const session = await prisma.chatSession.findUnique({
+      where: { id: session_id },
+    });
+    const sessionMessages = Array.isArray(session?.messages)
+      ? (session!.messages as any[])
+      : [];
+    const summary = await summarizeSession(sessionMessages);
 
     await prisma.chatSession.update({
       where: { id: session_id },
-      data: { endedAt: new Date() },
+      data: { endedAt: new Date(), summary },
     });
 
-    return new Response(JSON.stringify({ success: true }), { status: 200 });
+    if (identifier) {
+      await redis.set(identifier, summary);
+    }
+
+    return new Response(JSON.stringify({ success: true, summary }), {
+      status: 200,
+    });
   } catch (error) {
     console.error("Error ending session:", error);
     return new Response("Error ending session", { status: 500 });


### PR DESCRIPTION
## Summary
- Fetch full session after saving messages and generate a summary
- Persist session summary in database and Redis cache on session end
- Return success state and session summary from end session endpoint

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689dffa20b64833391f54410f923a5ed