### PR TITLE
Use session summary and cache in Redis

### DIFF
--- a/app/api/sessions/start/route.ts
+++ b/app/api/sessions/start/route.ts
@@ -29,12 +29,22 @@ export async function POST(request: Request) {
         data: { userId: user.id, messages: [] },
       });
     }
-    const summary = await redis.get(identifier);
+    let summary = session?.summary;
+    if (!summary) {
+      summary = await redis.get(identifier);
+    }
+    if (summary) {
+      await redis.set(identifier, summary);
+    }
     const trimmedSession = session
-      ? { ...session, messages: (session.messages as any[]).slice(-MAX_SESSION_MESSAGES) }
+      ? {
+          ...session,
+          summary,
+          messages: (session.messages as any[]).slice(-MAX_SESSION_MESSAGES),
+        }
       : session;
     return new Response(
-      JSON.stringify({ user, session: trimmedSession, summary }),
+      JSON.stringify({ user, session: trimmedSession }),
       { status: 200 }
     );
   } catch (error) {


### PR DESCRIPTION
## Summary
- Serve `session.summary` from the database instead of a Redis lookup
- Mirror the session summary to Redis as a cache and include it in the trimmed session response

## Testing
- `npx prisma generate`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e05fd10548333a3370acc39c37064