### PR TITLE
Handle session summary within start_chat_session

### DIFF
--- a/config/functions.ts
+++ b/config/functions.ts
@@ -380,9 +380,9 @@ export const start_chat_session = async ({
           contactId: identifier,
         });
       }
-      setSummary(res.summary || null);
+      setSummary(res.session?.summary || null);
     }
-    return res;
+    return { session: res.session, user: res.user };
   } catch (error) {
     console.error(error);
     return { error: "Failed to start chat session" };

--- a/tests/assistant.test.js
+++ b/tests/assistant.test.js
@@ -282,7 +282,7 @@ test('start_chat_session triggered by ticket ID', async () => {
   global.fetch = async (url, options = {}) => {
     if (url === '/api/sessions/start') {
       sessionBody = options.body;
-      return new Response('{"user":{},"summary":"old summary"}', {
+      return new Response('{"user":{},"session":{"summary":"old summary"}}', {
         headers: { 'Content-Type': 'application/json' },
         status: 200,
       });


### PR DESCRIPTION
## Summary
- Pull chat session summary from `session` object and drop top-level summary from return payload
- Update tests to expect summary inside `session`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e0b4cd3f0833394df8dcd5628f1b3