### PR TITLE
Cache session summary in Redis after DB lookup

### DIFF
--- a/app/api/sessions/start/route.ts
+++ b/app/api/sessions/start/route.ts
@@ -30,11 +30,10 @@ export async function POST(request: Request) {
       });
     }
     let summary = session?.summary;
-    if (!summary) {
-      summary = await redis.get(identifier);
-    }
     if (summary) {
       await redis.set(identifier, summary);
+    } else {
+      summary = await redis.get(identifier);
     }
     const trimmedSession = session
       ? {


### PR DESCRIPTION
## Summary
- Prioritize session summary from database and only fall back to Redis when absent
- Cache DB session summaries back into Redis

## Testing
- `npm test` *(fails: Prisma Client could not locate the Query Engine for runtime "debian-openssl-3.0.x")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e37c4c63883339abfb8a73a9de361