### PR TITLE
Summarize session after persisting messages

### DIFF
--- a/lib/server/saveSessionMessages.ts
+++ b/lib/server/saveSessionMessages.ts
@@ -1,5 +1,4 @@
 import prisma from "@/lib/prisma";
-import redis from "@/lib/redis";
 
 export async function saveSessionMessages(
   session_id: string,
@@ -27,22 +26,7 @@ export async function saveSessionMessages(
       where: { id: session_id },
       data: { messages: updatedMessages },
     });
-    const last = updatedMessages
-      .slice(-Math.min(updatedMessages.length, 5))
-      .map((m: any) =>
-        Array.isArray(m.content)
-          ? m.content.map((c: any) => c.text ?? "").join(" ")
-          : String(m.content ?? "")
-      )
-      .join(" ");
-    const summary = last.slice(0, 200);
-
-    const key = identifier || session.user.email;
-    if (key) {
-      await redis.set(key, summary);
-    }
-
-    return { success: true, summary };
+    return { success: true };
   } catch (error) {
     console.error("Error saving session messages:", error);
     throw error;


### PR DESCRIPTION
## Summary
- Simplify `saveSessionMessages` to only persist chat logs, leaving summarization to the session end route
- Session end endpoint retrieves messages, calls `summarizeSession`, updates the DB summary, and caches it in Redis

## Testing
- `npm test` *(fails: PrismaClientInitializationError: Query Engine for runtime "debian-openssl-3.0.x" not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f0561343c8333bc7b2cd3d3d85839