### PR TITLE
refactor: drop identifier from saveSessionMessages

### DIFF
--- a/app/api/sessions/[session_id]/end/route.ts
+++ b/app/api/sessions/[session_id]/end/route.ts
@@ -12,7 +12,7 @@ export async function POST(
     const { messages = [], identifier } = await request.json();
 
     if (Array.isArray(messages) && messages.length > 0) {
-      await saveSessionMessages(session_id, messages, identifier);
+      await saveSessionMessages(session_id, messages);
     }
 
     const session = await prisma.chatSession.findUnique({

--- a/app/api/turn_response/route.ts
+++ b/app/api/turn_response/route.ts
@@ -11,14 +11,8 @@ import { saveSessionMessages } from "@/lib/server/saveSessionMessages";
 export async function POST(request: Request) {
   const start = Date.now();
   try {
-    const {
-      messages,
-      tools,
-      provider,
-      model,
-      session_id,
-      identifier,
-    } = await request.json();
+    const { messages, tools, provider, model, session_id } =
+      await request.json();
     console.log("Received messages:", messages);
 
     const lastMessage =
@@ -105,8 +99,7 @@ export async function POST(request: Request) {
               } as any;
               const result = await saveSessionMessages(
                 session_id,
-                [lastMessage, assistantMessage],
-                identifier
+                [lastMessage, assistantMessage]
               );
               if (result && "error" in result) {
                 console.error("Error saving session messages:", result.error);

--- a/lib/server/saveSessionMessages.ts
+++ b/lib/server/saveSessionMessages.ts
@@ -2,8 +2,7 @@ import prisma from "@/lib/prisma";
 
 export async function saveSessionMessages(
   session_id: string,
-  messages: any[],
-  identifier?: string
+  messages: any[]
 ) {
   if (!Array.isArray(messages)) {
     return { error: "Messages must be an array" };


### PR DESCRIPTION
## Summary
- remove unused `identifier` parameter from `saveSessionMessages`
- adjust session-related routes to call `saveSessionMessages` without `identifier`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f0b0a97a48333a149afb349004bac