### PR TITLE
refactor: remove identifier arg from saveSessionMessages

### DIFF
--- a/app/api/sessions/[session_id]/end/route.ts
+++ b/app/api/sessions/[session_id]/end/route.ts
@@ -12,7 +12,7 @@ export async function POST(
     const { messages = [], identifier } = await request.json();
 
     if (Array.isArray(messages) && messages.length > 0) {
-      await saveSessionMessages(session_id, messages, identifier);
+      await saveSessionMessages(session_id, messages);
     }
 
     const session = await prisma.chatSession.findUnique({

--- a/app/api/turn_response/route.ts
+++ b/app/api/turn_response/route.ts
@@ -17,7 +17,6 @@ export async function POST(request: Request) {
       provider,
       model,
       session_id,
-      identifier,
     } = await request.json();
     console.log("Received messages:", messages);
 
@@ -105,8 +104,7 @@ export async function POST(request: Request) {
               } as any;
               const result = await saveSessionMessages(
                 session_id,
-                [lastMessage, assistantMessage],
-                identifier
+                [lastMessage, assistantMessage]
               );
               if (result && "error" in result) {
                 console.error("Error saving session messages:", result.error);

--- a/components/SessionTimer.tsx
+++ b/components/SessionTimer.tsx
@@ -15,13 +15,17 @@ export default function SessionTimer() {
       timerRef.current = setTimeout(async () => {
         const { pendingMessages, clearPendingMessages } =
           useConversationStore.getState();
-        const sessionId = (useDataStore.getState() as any).sessionId;
+        const { sessionId, contactId } =
+          useDataStore.getState() as any;
         if (sessionId) {
           try {
             await fetch(`/api/sessions/${sessionId}/end`, {
               method: "POST",
               headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ messages: pendingMessages }),
+              body: JSON.stringify({
+                messages: pendingMessages,
+                identifier: contactId,
+              }),
             });
             clearPendingMessages();
           } catch (err) {

--- a/lib/server/saveSessionMessages.ts
+++ b/lib/server/saveSessionMessages.ts
@@ -2,8 +2,7 @@ import prisma from "@/lib/prisma";
 
 export async function saveSessionMessages(
   session_id: string,
-  messages: any[],
-  identifier?: string
+  messages: any[]
 ) {
   if (!Array.isArray(messages)) {
     return { error: "Messages must be an array" };


### PR DESCRIPTION
## Summary
- drop unused `identifier` param in `saveSessionMessages`
- update endpoints to call `saveSessionMessages` without identifier
- ensure session end requests carry identifier from client so Redis summaries update

## Testing
- `npx prisma generate`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f0d4bb4708333ba0d3354440698e3