### PR TITLE
feat: summarize session with bullet cleanup

### DIFF
--- a/lib/server/summarizeSession.ts
+++ b/lib/server/summarizeSession.ts
@@ -1,4 +1,5 @@
 import OpenAI from "openai";
+import cleanMarkdown from "../cleanMarkdown";
 
 export async function summarizeSession(messages: any[]): Promise<string> {
   const openai = new OpenAI();
@@ -7,9 +8,18 @@ export async function summarizeSession(messages: any[]): Promise<string> {
 
   const response = await openai.responses.create({
     model: "gpt-4o-mini",
-    input: [...(Array.isArray(messages) ? messages : []), { role: "user", content: prompt }],
+    input: [
+      ...(Array.isArray(messages) ? messages : []),
+      { role: "user", content: prompt },
+    ],
   });
 
-  return response.output_text ?? "";
+  const text = response.output_text ?? "";
+  const lines = text.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+  const cleaned = lines
+    .map((line) => line.replace(/^[-*•]\s*/, ""))
+    .map((line) => `- ${cleanMarkdown(line).trim()}`);
+
+  return cleaned.join("\n");
 }
 


### PR DESCRIPTION
## Summary
- implement `summarizeSession` helper using OpenAI responses API
- normalize bullet lists and strip markdown for clean summaries

## Testing
- `npm test` *(fails: PrismaClientInitializationError: Prisma Client could not locate the Query Engine for runtime "debian-openssl-3.0.x")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f0faaca648333bc5f881979556f00