### PR TITLE
refactor: return session info from start_chat_session

### DIFF
--- a/config/functions.ts
+++ b/config/functions.ts
@@ -382,7 +382,11 @@ export const start_chat_session = async ({
       }
       setSummary(res.session?.summary || null);
     }
-    return { session: res.session, user: res.user };
+    return {
+      user: res.user,
+      session: { id: res.session?.id },
+      summary: res.session?.summary,
+    };
   } catch (error) {
     console.error(error);
     return { error: "Failed to start chat session" };


### PR DESCRIPTION
## Summary
- ensure start_chat_session stores session summary from the session object
- return session id and summary separately from user data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f15f2b7b88333bb6f1e9f814d0309