### PR TITLE
Sanitize messages before summarization

### DIFF
--- a/lib/server/summarizeSession.ts
+++ b/lib/server/summarizeSession.ts
@@ -6,12 +6,24 @@ export async function summarizeSession(messages: any[]): Promise<string> {
   const prompt =
     "Summarize the conversation in 3–5 bullet points, capturing the user's issue, actions taken, and pending follow-ups.";
 
+  const filteredMessages = (Array.isArray(messages) ? messages : [])
+    .filter((m) => m && (m.role === "user" || m.role === "assistant"))
+    .map(({ role, content }) => {
+      const textContent = Array.isArray(content)
+        ? content
+            .map((part: any) =>
+              typeof part === "string" ? part : part?.text ?? ""
+            )
+            .join(" ")
+        : typeof content === "string"
+        ? content
+        : content?.text ?? String(content ?? "");
+      return { role, content: textContent };
+    });
+
   const response = await openai.responses.create({
     model: "gpt-4o-mini",
-    input: [
-      ...(Array.isArray(messages) ? messages : []),
-      { role: "user", content: prompt },
-    ],
+    input: [...filteredMessages, { role: "user", content: prompt }],
   });
 
   const text = response.output_text ?? "";


### PR DESCRIPTION
## Summary
- Filter session messages to keep only user and assistant roles and strip non-standard fields
- Convert complex message content into plain text before summarization

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f271ee1288333b69e4f3825584d2e