### PR TITLE
feat: cache session messages in redis

### DIFF
--- a/app/api/sessions/start/route.ts
+++ b/app/api/sessions/start/route.ts
@@ -2,6 +2,8 @@ import prisma from "@/lib/prisma";
 import redis from "@/lib/redis";
 import { MAX_SESSION_MESSAGES } from "@/config/constants";
 
+const MESSAGE_CACHE_TTL = 60 * 60; // 1 hour
+
 export async function POST(request: Request) {
   try {
     const { email, ticket_id, name, phone, address } = await request.json();
@@ -20,28 +22,66 @@ export async function POST(request: Request) {
       create: { email: identifier, name, phone, address },
       include: { orders: true },
     });
+
+    const sessionSelect = {
+      id: true,
+      userId: true,
+      createdAt: true,
+      updatedAt: true,
+      endedAt: true,
+      summary: true,
+    } as const;
+
     let session = await prisma.chatSession.findFirst({
       where: { userId: user.id },
       orderBy: { createdAt: "desc" },
+      select: sessionSelect,
     });
+
     if (!session) {
       session = await prisma.chatSession.create({
         data: { userId: user.id, messages: [] },
+        select: sessionSelect,
       });
+      await redis.set(
+        `session:${session.id}:messages`,
+        JSON.stringify([]),
+        "EX",
+        MESSAGE_CACHE_TTL
+      );
     }
-    let summary = session?.summary;
+
+    let messages: any[] = [];
+    const cachedMessages = await redis.get(`session:${session.id}:messages`);
+    if (cachedMessages) {
+      messages = JSON.parse(cachedMessages);
+    } else {
+      const sessionWithMessages = await prisma.chatSession.findUnique({
+        where: { id: session.id },
+        select: { messages: true },
+      });
+      messages = (sessionWithMessages?.messages as any[]) || [];
+      await redis.set(
+        `session:${session.id}:messages`,
+        JSON.stringify(messages),
+        "EX",
+        MESSAGE_CACHE_TTL
+      );
+    }
+
+    let summary = session.summary;
     if (summary) {
       await redis.set(identifier, summary);
     } else {
       summary = await redis.get(identifier);
     }
-    const trimmedSession = session
-      ? {
-          ...session,
-          summary,
-          messages: (session.messages as any[]).slice(-MAX_SESSION_MESSAGES),
-        }
-      : session;
+
+    const trimmedSession = {
+      ...session,
+      summary,
+      messages: messages.slice(-MAX_SESSION_MESSAGES),
+    };
+
     return new Response(
       JSON.stringify({ user, session: trimmedSession }),
       { status: 200 }

--- a/lib/server/saveSessionMessages.ts
+++ b/lib/server/saveSessionMessages.ts
@@ -1,4 +1,7 @@
 import prisma from "@/lib/prisma";
+import redis from "@/lib/redis";
+
+const MESSAGE_CACHE_TTL = 60 * 60; // 1 hour
 
 export async function saveSessionMessages(
   session_id: string,
@@ -25,6 +28,14 @@ export async function saveSessionMessages(
       where: { id: session_id },
       data: { messages: updatedMessages },
     });
+
+    await redis.set(
+      `session:${session_id}:messages`,
+      JSON.stringify(updatedMessages),
+      "EX",
+      MESSAGE_CACHE_TTL
+    );
+
     return { success: true };
   } catch (error) {
     console.error("Error saving session messages:", error);


### PR DESCRIPTION
## Summary
- cache session messages in Redis after persistence to Prisma
- retrieve session messages from Redis before hitting Prisma, populating cache on miss

## Testing
- `REDIS_URL=redis://localhost:6379 DATABASE_URL=postgresql://user:pass@localhost:5432/db OPENAI_API_KEY=dummy npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f32591c088333bb8867ad999bf02c