### PR TITLE
feat: persist session summary

### DIFF
--- a/app/api/sessions/[session_id]/end/route.ts
+++ b/app/api/sessions/[session_id]/end/route.ts
@@ -23,6 +23,8 @@ export async function POST(
       : [];
     const summary = await summarizeSession(sessionMessages);
 
+    await redis.set(`session:${session_id}:summary`, summary);
+
     await prisma.chatSession.update({
       where: { id: session_id },
       data: { endedAt: new Date(), summary },

--- a/app/api/sessions/start/route.ts
+++ b/app/api/sessions/start/route.ts
@@ -70,6 +70,9 @@ export async function POST(request: Request) {
     }
 
     let summary = session.summary;
+    if (!summary) {
+      summary = await redis.get(`session:${session.id}:summary`);
+    }
     if (summary) {
       await redis.set(identifier, summary);
     } else {


### PR DESCRIPTION
## Summary
- cache per-session summaries in Redis after session end
- restore summary from session key when starting a session

## Testing
- `npm test` *(fails: 1 fail)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f35baffd88333956f3301cd33b9a7