### PR TITLE
Refactor message formats for OpenAI responses

### DIFF
--- a/app/api/turn_response/route.ts
+++ b/app/api/turn_response/route.ts
@@ -21,9 +21,15 @@ export async function POST(request: Request) {
     } = await request.json();
     console.log("Received messages:", messages);
 
+    const normalizedMessages = Array.isArray(messages)
+      ? messages.map((m: any) =>
+          m?.type === "message" ? { role: m.role, content: m.content } : m
+        )
+      : [];
+
     const lastMessage =
-      Array.isArray(messages) && messages.length > 0
-        ? messages[messages.length - 1]
+      normalizedMessages.length > 0
+        ? normalizedMessages[normalizedMessages.length - 1]
         : null;
 
     let userInput = "";
@@ -31,8 +37,8 @@ export async function POST(request: Request) {
     let relevance = { tripwireTriggered: false };
     let jailbreak = { tripwireTriggered: false };
 
-    if (Array.isArray(messages)) {
-      conversationInput = messages
+    if (Array.isArray(normalizedMessages)) {
+      conversationInput = normalizedMessages
         .filter((m) => m.role !== "developer")
         .map((m) =>
           Array.isArray(m.content)
@@ -70,7 +76,7 @@ export async function POST(request: Request) {
     }
 
     const providerFn = getProvider(provider);
-    const events = providerFn(messages, tools, { model });
+    const events = providerFn(normalizedMessages, tools, { model });
 
     const stream = new ReadableStream({
       async start(controller) {
@@ -173,7 +179,7 @@ export async function POST(request: Request) {
             try {
               const assistantMessage: any = {
                 role: "assistant",
-                content: assistantText,
+                content: [{ type: "output_text", text: assistantText }],
               };
               if (functionCalls.length > 0) {
                 assistantMessage.tool_calls = functionCalls.map((c) => ({

--- a/lib/server/summarizeSession.ts
+++ b/lib/server/summarizeSession.ts
@@ -18,12 +18,16 @@ export async function summarizeSession(messages: any[]): Promise<string> {
         : typeof content === "string"
         ? content
         : content?.text ?? String(content ?? "");
-      return { role, content: textContent };
+      const contentType = role === "assistant" ? "output_text" : "input_text";
+      return { role, content: [{ type: contentType, text: textContent }] };
     });
 
   const response = await openai.responses.create({
     model: "gpt-4o-mini",
-    input: [...filteredMessages, { role: "user", content: prompt }],
+    input: [
+      ...filteredMessages,
+      { role: "user", content: [{ type: "input_text", text: prompt }] },
+    ],
   });
 
   const text = response.output_text ?? "";


### PR DESCRIPTION
## Summary
- strip legacy `type: "message"` wrappers before invoking model providers and persist assistant replies as structured `output_text` content
- convert session summaries to use `input_text`/`output_text` message format and send directly to OpenAI

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f383e11a48333a47d341adbdc94a8