### PR TITLE
Handle conversation message content types based on role

### DIFF
--- a/lib/server/summarizeSession.ts
+++ b/lib/server/summarizeSession.ts
@@ -17,7 +17,12 @@ const filteredMessages = (Array.isArray(messages) ? messages : [])
       : typeof content === "string"
         ? content
         : content?.text ?? String(content ?? "");
-    return { role, content: [{ type: "input_text" as const, text: textContent }] };
+    return {
+      role,
+      content: [
+        { type: role === "assistant" ? "output_text" : "input_text", text: textContent },
+      ],
+    };
   });
 
   const response = await openai.responses.create({


### PR DESCRIPTION
## Summary
- Ensure user messages in session summaries use `input_text` and assistant messages use `output_text` for content types

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f5ec2e1f48333afb532984baa0444