### PR TITLE
Ensure message type when summarizing sessions

### DIFF
--- a/lib/server/summarizeSession.ts
+++ b/lib/server/summarizeSession.ts
@@ -1,35 +1,55 @@
 import OpenAI from "openai";
 import cleanMarkdown from "../cleanMarkdown";
 
+type SummaryMessage =
+  | {
+      type: "message";
+      role: "user";
+      content: [{ type: "input_text"; text: string }];
+    }
+  | {
+      type: "message";
+      role: "assistant";
+      content: [{ type: "output_text"; text: string }];
+    };
+
 export async function summarizeSession(messages: any[]): Promise<string> {
   const openai = new OpenAI();
   const prompt =
     "Summarize the conversation in 3–5 bullet points, capturing the user's issue/questions asked, actions taken, and pending follow-ups.";
 
-const filteredMessages = (Array.isArray(messages) ? messages : [])
-  .filter(
-    (m): m is { role: "user" | "assistant"; content: any } =>
-      m && (m.role === "user" || m.role === "assistant"),
-  )
-  .map(({ role, content }) => {
-    const textContent = Array.isArray(content)
-      ? content.map((p: any) => (typeof p === "string" ? p : p?.text ?? "")).join(" ")
-      : typeof content === "string"
-        ? content
-        : content?.text ?? String(content ?? "");
-    return {
-      role,
-      content: [
-        { type: role === "assistant" ? "output_text" : "input_text", text: textContent },
-      ],
-    };
-  });
+  const filteredMessages: SummaryMessage[] = (Array.isArray(messages) ? messages : [])
+    .filter(
+      (m): m is { role: "user" | "assistant"; content: any } =>
+        m && (m.role === "user" || m.role === "assistant"),
+    )
+    .map(({ role, content }): SummaryMessage => {
+      const textContent = Array.isArray(content)
+        ? content.map((p: any) => (typeof p === "string" ? p : p?.text ?? "")).join(" ")
+        : typeof content === "string"
+          ? content
+          : content?.text ?? String(content ?? "");
+      return {
+        type: "message",
+        role,
+        content: [
+          {
+            type: role === "assistant" ? "output_text" : "input_text",
+            text: textContent,
+          },
+        ],
+      };
+    });
 
   const response = await openai.responses.create({
     model: "gpt-4o-mini",
     input: [
       ...filteredMessages,
-      { role: "user", content: [{ type: "input_text", text: prompt }] },
+      {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: prompt }],
+      },
     ],
   });
 


### PR DESCRIPTION
## Summary
- Define `SummaryMessage` union enforcing explicit `user` and `assistant` message shapes
- Include `type: "message"` for all session summary inputs and appended prompt
- Map raw messages into `SummaryMessage` objects and pass to `openai.responses.create`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f6a90175c8333a67ee25a2645cade