### PR TITLE
Ensure responses API uses EasyInputMessage

### DIFF
--- a/lib/server/summarizeSession.ts
+++ b/lib/server/summarizeSession.ts
@@ -1,4 +1,5 @@
 import OpenAI from "openai";
+import type { EasyInputMessage } from "openai/resources/responses";
 import cleanMarkdown from "../cleanMarkdown";
 
 type SummaryMessage = {
@@ -30,16 +31,15 @@ export async function summarizeSession(messages: any[]): Promise<string> {
       };
     });
 
+  const extraPrompt: EasyInputMessage = {
+    type: "message",
+    role: "user",
+    content: [{ type: "input_text", text: prompt }],
+  };
+
   const response = await openai.responses.create({
     model: "gpt-4o-mini",
-    input: [
-      ...filteredMessages,
-      {
-        type: "message",
-        role: "user",
-        content: [{ type: "input_text", text: prompt }],
-      },
-    ],
+    input: [...filteredMessages, extraPrompt] as EasyInputMessage[],
   });
 
   const text = response.output_text ?? "";

--- a/types/openai-responses.d.ts
+++ b/types/openai-responses.d.ts
@@ -1,0 +1,3 @@
+declare module "openai/resources/responses" {
+  export * from "openai/resources/responses/responses";
+}


### PR DESCRIPTION
## Summary
- import EasyInputMessage from OpenAI responses resource and cast summarized messages when calling the Responses API
- add module declaration to re-export EasyInputMessage type for TypeScript resolution

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm test` *(fails: PrismaClientInitializationError: Prisma Client could not locate the Query Engine for runtime "debian-openssl-3.0.x")*

------
https://chatgpt.com/codex/tasks/task_e_689f7bdd3bc08333b5df441d451128eb