### PR TITLE
Remove session message cache TTL

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Feel free to customize this demo to suit your specific use case.
    ```
 
    `SESSION_RETENTION_DAYS` controls how long ended sessions are kept before cleanup (defaults to 30 days).
+   Session messages cached in Redis are retained indefinitely until the session is cleaned up.
 
 3. **Run database migrations:**
 

--- a/app/api/sessions/start/route.ts
+++ b/app/api/sessions/start/route.ts
@@ -2,7 +2,7 @@ import prisma from "@/lib/prisma";
 import redis from "@/lib/redis";
 import { MAX_SESSION_MESSAGES } from "@/config/constants";
 
-const MESSAGE_CACHE_TTL = 60 * 60; // 1 hour
+// Session message caches are kept indefinitely until sessions are cleaned up.
 
 export async function POST(request: Request) {
   try {
@@ -45,9 +45,7 @@ export async function POST(request: Request) {
       });
       await redis.set(
         `session:${session.id}:messages`,
-        JSON.stringify([]),
-        "EX",
-        MESSAGE_CACHE_TTL
+        JSON.stringify([])
       );
     }
 
@@ -63,9 +61,7 @@ export async function POST(request: Request) {
       messages = (sessionWithMessages?.messages as any[]) || [];
       await redis.set(
         `session:${session.id}:messages`,
-        JSON.stringify(messages),
-        "EX",
-        MESSAGE_CACHE_TTL
+        JSON.stringify(messages)
       );
     }
 

--- a/lib/server/saveSessionMessages.ts
+++ b/lib/server/saveSessionMessages.ts
@@ -1,7 +1,8 @@
 import prisma from "@/lib/prisma";
 import redis from "@/lib/redis";
 
-const MESSAGE_CACHE_TTL = 60 * 60; // 1 hour
+// Cached session messages no longer have an expiry and are retained
+// until the associated session is cleaned up.
 
 export async function saveSessionMessages(
   session_id: string,
@@ -31,9 +32,7 @@ export async function saveSessionMessages(
 
     await redis.set(
       `session:${session_id}:messages`,
-      JSON.stringify(updatedMessages),
-      "EX",
-      MESSAGE_CACHE_TTL
+      JSON.stringify(updatedMessages)
     );
 
     return { success: true };


### PR DESCRIPTION
## Summary
- Keep cached session messages in Redis indefinitely
- Apply indefinite message cache in session start API
- Document that session message cache does not expire

## Testing
- `npm test` (fails: 1 failing test)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f81681ea4833385008682c5b07182