### PR TITLE
feat: prevent duplicate session messages

### DIFF
--- a/app/api/sessions/[session_id]/end/route.ts
+++ b/app/api/sessions/[session_id]/end/route.ts
@@ -12,7 +12,12 @@ export async function POST(
     const { messages = [], identifier } = await request.json();
 
     if (Array.isArray(messages) && messages.length > 0) {
-      await saveSessionMessages(session_id, messages);
+      const result = await saveSessionMessages(session_id, messages);
+      if (result && "error" in result) {
+        return new Response(JSON.stringify({ error: result.error }), {
+          status: 400,
+        });
+      }
     }
 
     const session = await prisma.chatSession.findUnique({

--- a/lib/server/saveSessionMessages.ts
+++ b/lib/server/saveSessionMessages.ts
@@ -20,10 +20,39 @@ export async function saveSessionMessages(
       return { error: "Session not found" };
     }
 
-    const updatedMessages = [
-      ...((session.messages as any[]) || []),
-      ...messages,
-    ];
+    const existingMessages = Array.isArray(session.messages)
+      ? (session.messages as any[])
+      : [];
+
+    const existingIds = new Set(
+      existingMessages.map((m: any) => m.id).filter(Boolean)
+    );
+
+    const dedupedMessages: any[] = [];
+    let lastMessage = existingMessages[existingMessages.length - 1];
+    let duplicateDetected = false;
+
+    for (const msg of messages) {
+      if (msg.id && existingIds.has(msg.id)) {
+        duplicateDetected = true;
+        continue;
+      }
+      if (
+        lastMessage &&
+        msg.role === lastMessage.role &&
+        JSON.stringify(msg.content) === JSON.stringify(lastMessage.content)
+      ) {
+        duplicateDetected = true;
+        continue;
+      }
+      dedupedMessages.push(msg);
+      lastMessage = msg;
+      if (msg.id) {
+        existingIds.add(msg.id);
+      }
+    }
+
+    const updatedMessages = [...existingMessages, ...dedupedMessages];
 
     await prisma.chatSession.update({
       where: { id: session_id },
@@ -34,6 +63,10 @@ export async function saveSessionMessages(
       `session:${session_id}:messages`,
       JSON.stringify(updatedMessages)
     );
+
+    if (duplicateDetected) {
+      return { error: "Duplicate messages detected" };
+    }
 
     return { success: true };
   } catch (error) {


### PR DESCRIPTION
## Summary
- ignore repeat session messages by ID or by matching the last stored entry's role and content
- surface duplicate message errors via session end API

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f83b210e88333a5d7545641f4c504