### PR TITLE
feat: capture assistant output in session summaries

### DIFF
--- a/lib/server/summarizeSession.ts
+++ b/lib/server/summarizeSession.ts
@@ -5,7 +5,7 @@ import cleanMarkdown from "../cleanMarkdown";
 type SummaryMessage = {
   type: "message";
   role: "user" | "assistant";
-  content: [{ type: "input_text"; text: string }];
+  content: [{ type: "input_text" | "output_text"; text: string }];
 };
 
 export async function summarizeSession(messages: any[]): Promise<string> {
@@ -27,7 +27,9 @@ export async function summarizeSession(messages: any[]): Promise<string> {
       return {
         type: "message",
         role,
-        content: [{ type: "input_text", text: textContent }],
+        content: [
+          { type: role === "user" ? "input_text" : "output_text", text: textContent },
+        ],
       };
     });
 


### PR DESCRIPTION
## Summary
- allow `SummarizeSession` to differentiate user input and assistant output
- map user messages to `input_text` and assistant replies to `output_text`

## Testing
- `npm test` *(fails: PrismaClientInitializationError: Query Engine for runtime "debian-openssl-3.0.x" could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_689f8d50d9ec83338126e049a8e334f4