### PR TITLE
feat: surface long user summaries

### DIFF
--- a/app/api/sessions/start/route.ts
+++ b/app/api/sessions/start/route.ts
@@ -104,7 +104,12 @@ export async function POST(request: Request) {
     };
 
     return new Response(
-      JSON.stringify({ user, session: trimmedSession }),
+      JSON.stringify({
+        user,
+        session: trimmedSession,
+        summary,
+        longSummary: user.longSummary ?? null,
+      }),
       { status: 200 }
     );
   } catch (error) {

--- a/config/functions.ts
+++ b/config/functions.ts
@@ -347,8 +347,13 @@ export const start_chat_session = async ({
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ email: identifier, ticket_id, name, phone, address }),
     }).then((res) => res.json());
-    const { setCustomerDetails, setContact, setSummary, setSessionId } =
-      useDataStore.getState();
+    const {
+      setCustomerDetails,
+      setContact,
+      setSummary,
+      setSessionId,
+      setLongSummary,
+    } = useDataStore.getState();
     const { setConversationItems } =
       useConversationStore.getState();
     if (res.session?.id) {
@@ -380,14 +385,15 @@ export const start_chat_session = async ({
           contactId: identifier,
         });
       }
-      setSummary(res.session?.summary || null);
+      setSummary(res.summary ?? res.session?.summary || null);
+      setLongSummary(res.longSummary ?? res.user?.longSummary ?? null);
     }
     return {
       user: res.user,
       session: { id: res.session?.id },
-      summary: res.session?.summary,
+      summary: res.summary ?? res.session?.summary,
       unsummarizedMessages: res.session?.messages || [],
-      longSummary: res.user?.longSummary ?? null,
+      longSummary: res.longSummary ?? res.user?.longSummary ?? null,
     };
   } catch (error) {
     console.error(error);

--- a/lib/assistant.ts
+++ b/lib/assistant.ts
@@ -171,10 +171,21 @@ export const handleTurn = async (
   model?: string
 ) => {
   try {
-    const { contactType, contactId, summary, sessionId } =
+    const { contactType, contactId, summary, sessionId, longSummary } =
       useDataStore.getState();
     const session_id = sessionId;
     const systemMessages: any[] = [];
+    if (longSummary) {
+      systemMessages.push({
+        role: "system",
+        content: [
+          {
+            type: "input_text",
+            text: `Customer summary: ${longSummary}`,
+          },
+        ],
+      });
+    }
     if (summary) {
       systemMessages.push({
         role: "system",

--- a/stores/useDataStore.ts
+++ b/stores/useDataStore.ts
@@ -50,6 +50,7 @@ interface DataState {
   contactId: string | null;
   sessionId: string | null;
   summary: string | null;
+  longSummary: string | null;
   emailRefused: boolean;
   setCustomerDetails: (details: CustomerDetails) => void;
   setFAQExtracts: (searchResults: any[], provider?: string) => void;
@@ -62,6 +63,7 @@ interface DataState {
   ) => void;
   setSessionId: (id: string | null) => void;
   setSummary: (summary: string | null) => void;
+  setLongSummary: (longSummary: string | null) => void;
   setEmailRefused: (refused: boolean) => void;
 }
 
@@ -85,6 +87,7 @@ const useDataStore = create<DataState>((set) => ({
   contactId: null,
   sessionId: null,
   summary: null,
+  longSummary: null,
   emailRefused: false,
   setCustomerDetails: (details) => set({ customerDetails: details }),
   setFAQExtracts: (searchResults, provider?: string) => {
@@ -131,6 +134,7 @@ const useDataStore = create<DataState>((set) => ({
     }),
   setSessionId: (id) => set({ sessionId: id }),
   setSummary: (summary) => set({ summary }),
+  setLongSummary: (longSummary) => set({ longSummary }),
   setEmailRefused: (refused) => set({ emailRefused: refused }),
 }));
 

--- a/tests/assistant.test.js
+++ b/tests/assistant.test.js
@@ -128,6 +128,7 @@ test('handleTurn prefixes ticket system message', async () => {
       contactType: 'ticket',
       contactId: 'TICK123',
       summary: null,
+      longSummary: null,
     });
     const messages = [
       { role: 'user', content: [{ type: 'input_text', text: 'hello' }] },
@@ -137,7 +138,12 @@ test('handleTurn prefixes ticket system message', async () => {
     assert.match(body.messages[0].content[0].text, /TICK123/);
   } finally {
     global.fetch = originalFetch;
-    useDataStore.setState({ contactType: null, contactId: null, summary: null });
+    useDataStore.setState({
+      contactType: null,
+      contactId: null,
+      summary: null,
+      longSummary: null,
+    });
   }
 });
 
@@ -158,6 +164,7 @@ test('handleTurn prefixes summary before ticket message', async () => {
       contactType: 'ticket',
       contactId: 'TICK123',
       summary: 'old summary',
+      longSummary: null,
     });
     const messages = [
       { role: 'user', content: [{ type: 'input_text', text: 'hello' }] },
@@ -172,7 +179,50 @@ test('handleTurn prefixes summary before ticket message', async () => {
     assert.match(body.messages[1].content[0].text, /TICK123/);
   } finally {
     global.fetch = originalFetch;
-    useDataStore.setState({ contactType: null, contactId: null, summary: null });
+    useDataStore.setState({
+      contactType: null,
+      contactId: null,
+      summary: null,
+      longSummary: null,
+    });
+  }
+});
+
+test('handleTurn includes long summary before session summary and ticket message', async () => {
+  const { handleTurn } = require('../lib/assistant');
+  const useDataStore = require('../stores/useDataStore').default;
+  const originalFetch = global.fetch;
+  let body;
+  global.fetch = async (_url, options) => {
+    body = JSON.parse(options.body);
+    return new Response('data: [DONE]\n\n', {
+      headers: { 'Content-Type': 'text/plain' },
+      status: 200,
+    });
+  };
+  try {
+    useDataStore.setState({
+      contactType: 'ticket',
+      contactId: 'TICK123',
+      summary: 'old summary',
+      longSummary: 'prefs',
+    });
+    const messages = [
+      { role: 'user', content: [{ type: 'input_text', text: 'hello' }] },
+    ];
+    await handleTurn(messages, () => {});
+    assert.strictEqual(body.messages[0].role, 'system');
+    assert.match(body.messages[0].content[0].text, /prefs/);
+    assert.match(body.messages[1].content[0].text, /old summary/);
+    assert.match(body.messages[2].content[0].text, /TICK123/);
+  } finally {
+    global.fetch = originalFetch;
+    useDataStore.setState({
+      contactType: null,
+      contactId: null,
+      summary: null,
+      longSummary: null,
+    });
   }
 });
 
@@ -212,6 +262,7 @@ test('create_ticket sends empty body when using placeholder ID', async () => {
       contactId: null,
       emailRefused: false,
       customerDetails: { id: CUSTOMER_DETAILS.id },
+      longSummary: null,
     });
     useConversationStore.setState({
       conversationItems: [
@@ -260,6 +311,7 @@ test('create_ticket still sends empty body when profile updated', async () => {
       contactId: null,
       emailRefused: false,
       customerDetails: { id: 'cus_real' },
+      longSummary: null,
     });
     useConversationStore.setState({
       conversationItems: [
@@ -297,7 +349,12 @@ test('start_chat_session triggered by ticket ID', async () => {
   };
 
   try {
-    useDataStore.setState({ contactType: null, contactId: null, summary: null });
+    useDataStore.setState({
+      contactType: null,
+      contactId: null,
+      summary: null,
+      longSummary: null,
+    });
     useConversationStore.setState({
       conversationItems: [
         { role: 'user', content: '#12345/2024-01-01' },
@@ -314,7 +371,12 @@ test('start_chat_session triggered by ticket ID', async () => {
     assert.strictEqual(state.summary, 'old summary');
   } finally {
     global.fetch = originalFetch;
-    useDataStore.setState({ contactType: null, contactId: null, summary: null });
+    useDataStore.setState({
+      contactType: null,
+      contactId: null,
+      summary: null,
+      longSummary: null,
+    });
   }
 });
 
@@ -335,5 +397,7 @@ test('start_chat_session returns long summary', async () => {
     assert.strictEqual(res.longSummary, 'prefs');
   } finally {
     global.fetch = originalFetch;
+    const useDataStore = require('../stores/useDataStore').default;
+    useDataStore.setState({ longSummary: null });
   }
 });


### PR DESCRIPTION
## Summary
- track long-term user summaries in client data store
- include long summary in chat session start payloads
- prime conversation turns with customer summary

## Testing
- `npx prisma migrate deploy` *(fails: Environment variable not found: DATABASE_URL)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a36b103f448333ab05cf54ad058450