### PR TITLE
Prune summarized session messages

### DIFF
--- a/app/api/sessions/[session_id]/end/route.ts
+++ b/app/api/sessions/[session_id]/end/route.ts
@@ -39,14 +39,22 @@ export async function POST(
 
     await redis.set(`session:${session_id}:summary`, summary);
 
+    const remainingMessages: any[] = sessionMessages.slice(
+      startIndex + newMessages.length
+    );
     await prisma.chatSession.update({
       where: { id: session_id },
       data: {
         endedAt: new Date(),
         summary,
-        lastSummarizedIndex: sessionMessages.length,
+        lastSummarizedIndex: 0,
+        messages: remainingMessages,
       },
     });
+    await redis.set(
+      `session:${session_id}:messages`,
+      JSON.stringify(remainingMessages)
+    );
 
     const longSummaryFragment = await summarizeSession({
       priorSummary: (session as any)?.user?.longSummary ?? null,

--- a/config/constants.ts
+++ b/config/constants.ts
@@ -40,3 +40,9 @@ export const DEFAULT_SEARCH_LIMIT = 10;
 
 // Maximum number of past session messages to return to the client
 export const MAX_SESSION_MESSAGES = 10;
+
+// Maximum number of unsummarized messages to retain per session
+export const MAX_UNSUMMARIZED_MESSAGES = parseInt(
+  process.env.MAX_UNSUMMARIZED_MESSAGES || "50",
+  10
+);

--- a/lib/server/saveSessionMessages.ts
+++ b/lib/server/saveSessionMessages.ts
@@ -1,5 +1,7 @@
 import prisma from "@/lib/prisma";
 import redis from "@/lib/redis";
+import { summarizeSession } from "@/lib/server/summarizeSession";
+import { MAX_UNSUMMARIZED_MESSAGES } from "@/config/constants";
 
 // Cached session messages no longer have an expiry and are retained
 // until the associated session is cleaned up.
@@ -14,15 +16,21 @@ export async function saveSessionMessages(
   try {
     const session = await prisma.chatSession.findUnique({
       where: { id: session_id },
-      include: { user: true },
+      select: {
+        messages: true,
+        summary: true,
+        lastSummarizedIndex: true,
+      },
     });
     if (!session) {
       return { error: "Session not found" };
     }
 
+    const lastSummarizedIndex = (session as any)?.lastSummarizedIndex ?? 0;
     const existingMessages = Array.isArray(session.messages)
-      ? (session.messages as any[])
+      ? (session.messages as any[]).slice(lastSummarizedIndex)
       : [];
+    let summary = (session as any)?.summary ?? null;
 
     const existingIds = new Set(
       existingMessages.map((m: any) => m.id).filter(Boolean)
@@ -52,11 +60,31 @@ export async function saveSessionMessages(
       }
     }
 
-    const updatedMessages = [...existingMessages, ...dedupedMessages];
+    let updatedMessages = [...existingMessages, ...dedupedMessages];
+
+    if (updatedMessages.length > MAX_UNSUMMARIZED_MESSAGES) {
+      const overflow =
+        updatedMessages.length - MAX_UNSUMMARIZED_MESSAGES;
+      const messagesToSummarize = updatedMessages.slice(0, overflow);
+      const summaryFragment = await summarizeSession({
+        priorSummary: summary,
+        newMessages: messagesToSummarize,
+      });
+      summary = [summary, summaryFragment].filter(Boolean).join("\n");
+      updatedMessages = updatedMessages.slice(-MAX_UNSUMMARIZED_MESSAGES);
+      await redis.set(
+        `session:${session_id}:summary`,
+        summary
+      );
+    }
 
     await prisma.chatSession.update({
       where: { id: session_id },
-      data: { messages: updatedMessages },
+      data: {
+        messages: updatedMessages,
+        summary,
+        lastSummarizedIndex: 0,
+      },
     });
 
     await redis.set(

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "test": "cross-env TS_NODE_COMPILER_OPTIONS=\"{\\\"module\\\":\\\"CommonJS\\\",\\\"moduleResolution\\\":\\\"node\\\"}\" node -r ts-node/register/transpile-only -r tsconfig-paths/register --test",
-    "cleanup:sessions": "cross-env TS_NODE_COMPILER_OPTIONS=\"{\\\"module\\\":\\\"CommonJS\\\",\\\"moduleResolution\\\":\\\"node\\\"}\" node -r ts-node/register/transpile-only -r tsconfig-paths/register scripts/cleanupSessions.ts"
+    "cleanup:sessions": "cross-env TS_NODE_COMPILER_OPTIONS=\"{\\\"module\\\":\\\"CommonJS\\\",\\\"moduleResolution\\\":\\\"node\\\"}\" node -r ts-node/register/transpile-only -r tsconfig-paths/register scripts/cleanupSessions.ts",
+    "prune:sessions": "cross-env TS_NODE_COMPILER_OPTIONS=\"{\\\"module\\\":\\\"CommonJS\\\",\\\"moduleResolution\\\":\\\"node\\\"}\" node -r ts-node/register/transpile-only -r tsconfig-paths/register scripts/pruneSessionMessages.ts"
   },
   "dependencies": {
     "@npmcli/fs": "^4.0.0",

--- a/scripts/pruneSessionMessages.ts
+++ b/scripts/pruneSessionMessages.ts
@@ -1,0 +1,43 @@
+import "dotenv/config";
+import prisma from "@/lib/prisma";
+import { summarizeSession } from "@/lib/server/summarizeSession";
+import { MAX_UNSUMMARIZED_MESSAGES } from "@/config/constants";
+
+async function run() {
+  const sessions = await prisma.chatSession.findMany();
+  for (const s of sessions) {
+    const messages = Array.isArray(s.messages) ? (s.messages as any[]) : [];
+    const startIndex = (s as any)?.lastSummarizedIndex ?? 0;
+    let summary = (s as any)?.summary ?? null;
+    let unsummarized = messages.slice(startIndex);
+    if (startIndex > 0 || unsummarized.length > MAX_UNSUMMARIZED_MESSAGES) {
+      if (unsummarized.length > MAX_UNSUMMARIZED_MESSAGES) {
+        const toSummarize = unsummarized.slice(
+          0,
+          unsummarized.length - MAX_UNSUMMARIZED_MESSAGES
+        );
+        if (toSummarize.length > 0) {
+          const fragment = await summarizeSession({
+            priorSummary: summary,
+            newMessages: toSummarize,
+          });
+          summary = [summary, fragment].filter(Boolean).join("\n");
+          unsummarized = unsummarized.slice(-MAX_UNSUMMARIZED_MESSAGES);
+        }
+      }
+      await prisma.chatSession.update({
+        where: { id: s.id },
+        data: { messages: unsummarized, summary, lastSummarizedIndex: 0 },
+      });
+    }
+  }
+}
+
+run()
+  .catch((err) => {
+    console.error("Prune failed", err);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/tests/sessionPrune.test.js
+++ b/tests/sessionPrune.test.js
@@ -1,0 +1,96 @@
+const assert = require('assert');
+const test = require('node:test');
+const { mock } = test;
+
+const constants = require('../config/constants');
+constants.MAX_UNSUMMARIZED_MESSAGES = 3;
+
+const user = { id: 'u1', longSummary: null };
+const session = {
+  id: 's1',
+  userId: 'u1',
+  messages: [],
+  summary: null,
+  lastSummarizedIndex: 0,
+  user,
+};
+
+const prismaMock = {
+  chatSession: {
+    findUnique: async () => session,
+    update: async ({ data }) => {
+      Object.assign(session, data);
+      return session;
+    },
+    findMany: async () => [session], // for potential calls
+  },
+  user: {
+    update: async ({ data }) => {
+      Object.assign(user, data);
+      return user;
+    },
+  },
+};
+
+const redisMock = { set: async () => {}, get: async () => null };
+
+const summarizeSession = mock.fn(async ({ priorSummary, newMessages }) => {
+  const text = newMessages
+    .map((m) => m.content?.[0]?.text || '')
+    .join(' ')
+    .trim();
+  return text;
+});
+
+require.cache[require.resolve('../lib/prisma.ts')] = { exports: prismaMock };
+require.cache[require.resolve('../lib/redis.ts')] = { exports: redisMock };
+require.cache[require.resolve('../lib/server/summarizeSession.ts')] = {
+  exports: { summarizeSession },
+};
+
+const { saveSessionMessages } = require('../lib/server/saveSessionMessages.ts');
+
+function reset() {
+  session.messages = [];
+  session.summary = null;
+  session.lastSummarizedIndex = 0;
+  user.longSummary = null;
+  summarizeSession.mock.resetCalls();
+}
+
+test('saveSessionMessages prunes old unsummarized messages', async () => {
+  reset();
+  const msgs = [
+    { id: '1', role: 'user', content: [{ type: 'input_text', text: 'm1' }] },
+    { id: '2', role: 'assistant', content: [{ type: 'output_text', text: 'm2' }] },
+    { id: '3', role: 'user', content: [{ type: 'input_text', text: 'm3' }] },
+    { id: '4', role: 'assistant', content: [{ type: 'output_text', text: 'm4' }] },
+    { id: '5', role: 'user', content: [{ type: 'input_text', text: 'm5' }] },
+  ];
+  await saveSessionMessages('s1', msgs);
+  assert.strictEqual(session.summary, 'm1 m2');
+  assert.strictEqual(session.lastSummarizedIndex, 0);
+  assert.deepStrictEqual(
+    session.messages.map((m) => m.content[0].text),
+    ['m3', 'm4', 'm5']
+  );
+  assert.strictEqual(summarizeSession.mock.calls.length, 1);
+});
+
+test('end session removes messages after summarization', async () => {
+  reset();
+  session.messages = [
+    { role: 'user', content: [{ type: 'input_text', text: 'hi' }] },
+    { role: 'assistant', content: [{ type: 'output_text', text: 'there' }] },
+  ];
+  const { POST } = await import('../app/api/sessions/[session_id]/end/route.ts');
+  const req = new Request('http://test', {
+    method: 'POST',
+    body: JSON.stringify({ messages: [] }),
+    headers: { 'Content-Type': 'application/json' },
+  });
+  await POST(req, { params: Promise.resolve({ session_id: 's1' }) });
+  assert.deepStrictEqual(session.messages, []);
+  assert.strictEqual(session.summary, 'hi there');
+  assert.strictEqual(session.lastSummarizedIndex, 0);
+});

--- a/tests/sessionSummary.test.js
+++ b/tests/sessionSummary.test.js
@@ -77,7 +77,7 @@ test('session summary only includes new messages and updates long summary', asyn
     { role: 'user', content: [{ type: 'input_text', text: 'hello' }] },
   ]);
   assert.strictEqual(session.summary, 'hello');
-  assert.strictEqual(session.lastSummarizedIndex, 1);
+  assert.strictEqual(session.lastSummarizedIndex, 0);
   assert.strictEqual(user.longSummary, 'hello');
   assert.strictEqual(summarizeSession.mock.calls.length, 2);
   assert.deepStrictEqual(
@@ -97,7 +97,7 @@ test('session summary only includes new messages and updates long summary', asyn
     { role: 'assistant', content: [{ type: 'output_text', text: 'there' }] },
   ]);
   assert.strictEqual(session.summary, 'hello\nthere');
-  assert.strictEqual(session.lastSummarizedIndex, 2);
+  assert.strictEqual(session.lastSummarizedIndex, 0);
   assert.strictEqual(user.longSummary, 'hello\nthere');
   assert.strictEqual(summarizeSession.mock.calls.length, 4);
   assert.deepStrictEqual(


### PR DESCRIPTION
## Summary
- Trim stored messages after session summarization to keep only unsummarized entries
- Bound unsummarized message history and roll excess into the session summary
- Add maintenance script and tests for pruning behavior

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a377a62a70833398aae97aa3f45703