### PR TITLE
feat: track dynamic unsummarized limit

### DIFF
--- a/app/api/sessions/[session_id]/end/route.ts
+++ b/app/api/sessions/[session_id]/end/route.ts
@@ -2,6 +2,7 @@ import prisma from "@/lib/prisma";
 import redis from "@/lib/redis";
 import { saveSessionMessages } from "@/lib/server/saveSessionMessages";
 import { summarizeSession } from "@/lib/server/summarizeSession";
+import { MAX_UNSUMMARIZED_MESSAGES } from "@/config/constants";
 
 export async function POST(
   request: Request,
@@ -39,9 +40,11 @@ export async function POST(
 
     await redis.set(`session:${session_id}:summary`, summary);
 
-    const remainingMessages: any[] = sessionMessages.slice(
-      startIndex + newMessages.length
-    );
+    const limit =
+      (session as any)?.unsummarizedLimit ?? MAX_UNSUMMARIZED_MESSAGES;
+    const remainingMessages: any[] = sessionMessages
+      .slice(startIndex + newMessages.length)
+      .slice(-limit);
     await prisma.chatSession.update({
       where: { id: session_id },
       data: {

--- a/app/api/sessions/start/route.ts
+++ b/app/api/sessions/start/route.ts
@@ -32,6 +32,7 @@ export async function POST(request: Request) {
       endedAt: true,
       summary: true,
       lastSummarizedIndex: true,
+      unsummarizedLimit: true,
     } as const;
 
     let session = await prisma.chatSession.findFirst({

--- a/config/constants.ts
+++ b/config/constants.ts
@@ -46,3 +46,10 @@ export const MAX_UNSUMMARIZED_MESSAGES = parseInt(
   process.env.MAX_UNSUMMARIZED_MESSAGES || "50",
   10
 );
+
+// Character length beyond which a message is considered large. Consecutive
+// large messages trigger a reduction in the unsummarized message cap.
+export const LARGE_MESSAGE_THRESHOLD = parseInt(
+  process.env.LARGE_MESSAGE_THRESHOLD || "8000",
+  10
+);

--- a/lib/generated/prisma/schema.prisma
+++ b/lib/generated/prisma/schema.prisma
@@ -46,6 +46,7 @@ model ChatSession {
   messages            Json // or a separate Message model
   summary             String?   @db.Text
   lastSummarizedIndex Int       @default(0)
+  unsummarizedLimit   Int       @default(50)
 }
 
 model Ticket {

--- a/lib/server/saveSessionMessages.ts
+++ b/lib/server/saveSessionMessages.ts
@@ -1,7 +1,10 @@
 import prisma from "@/lib/prisma";
 import redis from "@/lib/redis";
 import { summarizeSession } from "@/lib/server/summarizeSession";
-import { MAX_UNSUMMARIZED_MESSAGES } from "@/config/constants";
+import {
+  MAX_UNSUMMARIZED_MESSAGES,
+  LARGE_MESSAGE_THRESHOLD,
+} from "@/config/constants";
 
 // Cached session messages no longer have an expiry and are retained
 // until the associated session is cleaned up.
@@ -20,6 +23,7 @@ export async function saveSessionMessages(
         messages: true,
         summary: true,
         lastSummarizedIndex: true,
+        unsummarizedLimit: true,
       },
     });
     if (!session) {
@@ -31,6 +35,8 @@ export async function saveSessionMessages(
       ? (session.messages as any[]).slice(lastSummarizedIndex)
       : [];
     let summary = (session as any)?.summary ?? null;
+    let unsummarizedLimit =
+      (session as any)?.unsummarizedLimit ?? MAX_UNSUMMARIZED_MESSAGES;
 
     const existingIds = new Set(
       existingMessages.map((m: any) => m.id).filter(Boolean)
@@ -39,6 +45,15 @@ export async function saveSessionMessages(
     const dedupedMessages: any[] = [];
     let lastMessage = existingMessages[existingMessages.length - 1];
     let duplicateDetected = false;
+
+    const messageSize = (msg: any) =>
+      Array.isArray(msg?.content)
+        ? msg.content.reduce(
+            (t: number, c: any) => t + (c.text ? c.text.length : 0),
+            0
+          )
+        : 0;
+    let lastSize = lastMessage ? messageSize(lastMessage) : 0;
 
     for (const msg of messages) {
       if (msg.id && existingIds.has(msg.id)) {
@@ -53,8 +68,13 @@ export async function saveSessionMessages(
         duplicateDetected = true;
         continue;
       }
+      const size = messageSize(msg);
+      if (lastSize > LARGE_MESSAGE_THRESHOLD && size > LARGE_MESSAGE_THRESHOLD) {
+        unsummarizedLimit = Math.max(1, unsummarizedLimit - 1);
+      }
       dedupedMessages.push(msg);
       lastMessage = msg;
+      lastSize = size;
       if (msg.id) {
         existingIds.add(msg.id);
       }
@@ -62,16 +82,15 @@ export async function saveSessionMessages(
 
     let updatedMessages = [...existingMessages, ...dedupedMessages];
 
-    if (updatedMessages.length > MAX_UNSUMMARIZED_MESSAGES) {
-      const overflow =
-        updatedMessages.length - MAX_UNSUMMARIZED_MESSAGES;
+    if (updatedMessages.length > unsummarizedLimit) {
+      const overflow = updatedMessages.length - unsummarizedLimit;
       const messagesToSummarize = updatedMessages.slice(0, overflow);
       const summaryFragment = await summarizeSession({
         priorSummary: summary,
         newMessages: messagesToSummarize,
       });
       summary = [summary, summaryFragment].filter(Boolean).join("\n");
-      updatedMessages = updatedMessages.slice(-MAX_UNSUMMARIZED_MESSAGES);
+      updatedMessages = updatedMessages.slice(-unsummarizedLimit);
       await redis.set(
         `session:${session_id}:summary`,
         summary
@@ -84,6 +103,7 @@ export async function saveSessionMessages(
         messages: updatedMessages,
         summary,
         lastSummarizedIndex: 0,
+        unsummarizedLimit,
       },
     });
 

--- a/prisma/migrations/20251201000000_add_unsummarized_limit/migration.sql
+++ b/prisma/migrations/20251201000000_add_unsummarized_limit/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "ChatSession" ADD COLUMN "unsummarizedLimit" INTEGER NOT NULL DEFAULT 50;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -46,6 +46,7 @@ model ChatSession {
   messages  Json // or a separate Message model
   summary   String?  @db.Text
   lastSummarizedIndex Int @default(0)
+  unsummarizedLimit   Int @default(50)
 }
 
 model Ticket {

--- a/scripts/pruneSessionMessages.ts
+++ b/scripts/pruneSessionMessages.ts
@@ -10,19 +10,18 @@ async function run() {
     const startIndex = (s as any)?.lastSummarizedIndex ?? 0;
     let summary = (s as any)?.summary ?? null;
     let unsummarized = messages.slice(startIndex);
-    if (startIndex > 0 || unsummarized.length > MAX_UNSUMMARIZED_MESSAGES) {
-      if (unsummarized.length > MAX_UNSUMMARIZED_MESSAGES) {
-        const toSummarize = unsummarized.slice(
-          0,
-          unsummarized.length - MAX_UNSUMMARIZED_MESSAGES
-        );
+    const limit =
+      (s as any)?.unsummarizedLimit ?? MAX_UNSUMMARIZED_MESSAGES;
+    if (startIndex > 0 || unsummarized.length > limit) {
+      if (unsummarized.length > limit) {
+        const toSummarize = unsummarized.slice(0, unsummarized.length - limit);
         if (toSummarize.length > 0) {
           const fragment = await summarizeSession({
             priorSummary: summary,
             newMessages: toSummarize,
           });
           summary = [summary, fragment].filter(Boolean).join("\n");
-          unsummarized = unsummarized.slice(-MAX_UNSUMMARIZED_MESSAGES);
+          unsummarized = unsummarized.slice(-limit);
         }
       }
       await prisma.chatSession.update({

--- a/tests/sessionPrune.test.js
+++ b/tests/sessionPrune.test.js
@@ -4,6 +4,7 @@ const { mock } = test;
 
 const constants = require('../config/constants');
 constants.MAX_UNSUMMARIZED_MESSAGES = 3;
+constants.LARGE_MESSAGE_THRESHOLD = 50;
 
 const user = { id: 'u1', longSummary: null };
 const session = {
@@ -12,6 +13,7 @@ const session = {
   messages: [],
   summary: null,
   lastSummarizedIndex: 0,
+  unsummarizedLimit: constants.MAX_UNSUMMARIZED_MESSAGES,
   user,
 };
 
@@ -54,6 +56,7 @@ function reset() {
   session.messages = [];
   session.summary = null;
   session.lastSummarizedIndex = 0;
+  session.unsummarizedLimit = constants.MAX_UNSUMMARIZED_MESSAGES;
   user.longSummary = null;
   summarizeSession.mock.resetCalls();
 }
@@ -74,6 +77,7 @@ test('saveSessionMessages prunes old unsummarized messages', async () => {
     session.messages.map((m) => m.content[0].text),
     ['m3', 'm4', 'm5']
   );
+  assert.strictEqual(session.unsummarizedLimit, 3);
   assert.strictEqual(summarizeSession.mock.calls.length, 1);
 });
 
@@ -93,4 +97,28 @@ test('end session removes messages after summarization', async () => {
   assert.deepStrictEqual(session.messages, []);
   assert.strictEqual(session.summary, 'hi there');
   assert.strictEqual(session.lastSummarizedIndex, 0);
+});
+
+test('unsummarized limit shrinks after repeated large messages and prunes', async () => {
+  reset();
+  const large1 = { id: 'l1', role: 'assistant', content: [{ type: 'output_text', text: 'x'.repeat(60) }] };
+  const large2 = { id: 'l2', role: 'assistant', content: [{ type: 'output_text', text: 'y'.repeat(60) }] };
+  const large3 = { id: 'l3', role: 'assistant', content: [{ type: 'output_text', text: 'z'.repeat(60) }] };
+  await saveSessionMessages('s1', [large1]);
+  assert.strictEqual(session.unsummarizedLimit, 3);
+  await saveSessionMessages('s1', [large2]);
+  assert.strictEqual(session.unsummarizedLimit, 2);
+  await saveSessionMessages('s1', [large3]);
+  assert.strictEqual(session.unsummarizedLimit, 1);
+  await saveSessionMessages('s1', [
+    { id: '4', role: 'user', content: [{ type: 'input_text', text: 'ok' }] },
+  ]);
+  assert.strictEqual(session.unsummarizedLimit, 1);
+  assert.ok(session.summary.includes('x'));
+  assert.ok(session.summary.includes('y'));
+  assert.ok(session.summary.includes('z'));
+  assert.deepStrictEqual(
+    session.messages.map((m) => m.content[0].text),
+    ['ok']
+  );
 });


### PR DESCRIPTION
## Summary
- add `unsummarizedLimit` column to chat sessions and expose a `LARGE_MESSAGE_THRESHOLD` constant
- shrink per-session unsummarized limit when consecutive large messages arrive and respect this cap when pruning
- update session pruning script and end route to honor dynamic limits, with tests for limit shrinking and pruning

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a451ffb9608333bb4f4ff655b613d5