### PR TITLE
Reset unsummarized limit when ending session

### DIFF
--- a/app/api/sessions/[session_id]/end/route.ts
+++ b/app/api/sessions/[session_id]/end/route.ts
@@ -52,6 +52,7 @@ export async function POST(
         summary,
         lastSummarizedIndex: 0,
         messages: remainingMessages,
+        unsummarizedLimit: MAX_UNSUMMARIZED_MESSAGES,
       },
     });
     await redis.set(

--- a/tests/sessionPrune.test.js
+++ b/tests/sessionPrune.test.js
@@ -81,8 +81,9 @@ test('saveSessionMessages prunes old unsummarized messages', async () => {
   assert.strictEqual(summarizeSession.mock.calls.length, 1);
 });
 
-test('end session removes messages after summarization', async () => {
+test('end session removes messages after summarization and resets limit', async () => {
   reset();
+  session.unsummarizedLimit = 1;
   session.messages = [
     { role: 'user', content: [{ type: 'input_text', text: 'hi' }] },
     { role: 'assistant', content: [{ type: 'output_text', text: 'there' }] },
@@ -97,6 +98,10 @@ test('end session removes messages after summarization', async () => {
   assert.deepStrictEqual(session.messages, []);
   assert.strictEqual(session.summary, 'hi there');
   assert.strictEqual(session.lastSummarizedIndex, 0);
+  assert.strictEqual(
+    session.unsummarizedLimit,
+    constants.MAX_UNSUMMARIZED_MESSAGES
+  );
 });
 
 test('unsummarized limit shrinks after repeated large messages and prunes', async () => {


### PR DESCRIPTION
## Summary
- reset `unsummarizedLimit` to `MAX_UNSUMMARIZED_MESSAGES` after summarizing a session
- verify limit reset in session end test

## Testing
- `npm test tests/sessionPrune.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a476f763f48333a4a5e637b925db34