### PR TITLE
Retroactively update user long summaries during pruning

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,10 @@ To prune existing sessions to the current limit, run:
 npm run prune:sessions
 ```
 
+The pruning script also updates each user's `longSummary` retroactively. After a session's message log is reduced and its summary
+is refreshed, that summary is itself summarized and appended to the user's existing long-term summary so historical context
+is preserved.
+
 ## Contributing
 
 You are welcome to open issues or submit PRs to improve this app, however, please note that we may not review all suggestions.

--- a/scripts/pruneSessionMessages.ts
+++ b/scripts/pruneSessionMessages.ts
@@ -4,7 +4,7 @@ import { summarizeSession } from "@/lib/server/summarizeSession";
 import { MAX_UNSUMMARIZED_MESSAGES } from "@/config/constants";
 
 async function run() {
-  const sessions = await prisma.chatSession.findMany();
+  const sessions = await prisma.chatSession.findMany({ include: { user: true } });
   for (const s of sessions) {
     const messages = Array.isArray(s.messages) ? (s.messages as any[]) : [];
     const startIndex = (s as any)?.lastSummarizedIndex ?? 0;
@@ -12,6 +12,7 @@ async function run() {
     let unsummarized = messages.slice(startIndex);
     const limit =
       (s as any)?.unsummarizedLimit ?? MAX_UNSUMMARIZED_MESSAGES;
+    let summaryUpdated = false;
     if (startIndex > 0 || unsummarized.length > limit) {
       if (unsummarized.length > limit) {
         const toSummarize = unsummarized.slice(0, unsummarized.length - limit);
@@ -21,6 +22,7 @@ async function run() {
             newMessages: toSummarize,
           });
           summary = [summary, fragment].filter(Boolean).join("\n");
+          summaryUpdated = true;
           unsummarized = unsummarized.slice(-limit);
         }
       }
@@ -28,6 +30,27 @@ async function run() {
         where: { id: s.id },
         data: { messages: unsummarized, summary, lastSummarizedIndex: 0 },
       });
+      if (summaryUpdated) {
+        const longFragment = await summarizeSession({
+          priorSummary: (s as any)?.user?.longSummary,
+          newMessages: [
+            {
+              role: "assistant",
+              content: [{ type: "output_text", text: summary }],
+            },
+          ],
+        });
+        const longSummary = [
+          (s as any)?.user?.longSummary,
+          longFragment,
+        ]
+          .filter(Boolean)
+          .join("\n");
+        await prisma.user.update({
+          where: { id: s.userId },
+          data: { longSummary },
+        });
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Extend prune script to summarize updated session summaries into each user's long-term summary
- Document how pruning retroactively updates `User.longSummary`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4bd29c65883338a02a5d2707571d2