### PR TITLE
cache summary when trimming messages

### DIFF
--- a/lib/assistant.ts
+++ b/lib/assistant.ts
@@ -123,7 +123,7 @@ export function estimateMessageTokens(
   return total;
 }
 
-function trimMessagesToTokenLimit(
+async function trimMessagesToTokenLimit(
   allMessages: any[],
   limit: number,
   summary: string | null,
@@ -149,12 +149,16 @@ function trimMessagesToTokenLimit(
           : m.content ?? ""
       )
       .join(" ");
+
+    const { summarizeText } = await import("./server/summarizeText");
+    const cachedSummary = await summarizeText(removedText);
+
     trimmed.unshift({
       role: "system",
       content: [
         {
           type: "input_text",
-          text: `Previous conversation summary: ${removedText}`,
+          text: `Previous conversation summary: ${cachedSummary}`,
         },
       ],
     });
@@ -211,7 +215,7 @@ export const handleTurn = async (
     const messagesWithTicket =
       systemMessages.length > 0 ? [...systemMessages, ...messages] : messages;
 
-    const limitedMessages = trimMessagesToTokenLimit(
+    const limitedMessages = await trimMessagesToTokenLimit(
       messagesWithTicket,
       TOKEN_THRESHOLD,
       summary,

--- a/lib/server/summarizeText.ts
+++ b/lib/server/summarizeText.ts
@@ -1,0 +1,28 @@
+import OpenAI from "openai";
+import crypto from "crypto";
+import redis from "@/lib/redis";
+
+/**
+ * Summarize arbitrary text to roughly the given number of tokens.
+ * Results are cached in Redis for reuse.
+ */
+export async function summarizeText(text: string, maxTokens = 200): Promise<string> {
+  const hash = crypto.createHash("sha256").update(text).digest("hex");
+  const key = `summary:${hash}`;
+  const cached = await redis.get(key);
+  if (cached) return cached as string;
+
+  const openai = new OpenAI();
+  const prompt = `Summarize the following text in about ${maxTokens} tokens:`;
+  const response = await openai.responses.create({
+    model: "gpt-4o-mini",
+    input: [
+      { role: "user", content: [{ type: "input_text", text: `${prompt}\n\n${text}` }] },
+    ],
+    max_output_tokens: maxTokens,
+  });
+
+  const summary = response.output_text ?? "";
+  await redis.set(key, summary);
+  return summary;
+}


### PR DESCRIPTION
## Summary
- summarize pruned conversation history to ~200 tokens and cache in Redis
- inject cached summary into system prompt when trimming messages

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4c92dec7083338663aafaf474821b