### PR TITLE
Route-based text summarization endpoint

### DIFF
--- a/app/api/summarize-text/route.ts
+++ b/app/api/summarize-text/route.ts
@@ -1,0 +1,15 @@
+import { summarizeText } from "@/lib/server/summarizeText";
+
+export async function POST(request: Request) {
+  try {
+    const { text, maxTokens } = await request.json();
+    if (typeof text !== "string") {
+      return new Response("Invalid text", { status: 400 });
+    }
+    const summary = await summarizeText(text, maxTokens);
+    return Response.json({ summary });
+  } catch (error) {
+    console.error("Error summarizing text:", error);
+    return new Response("Failed to summarize text", { status: 500 });
+  }
+}

--- a/lib/assistant.ts
+++ b/lib/assistant.ts
@@ -150,8 +150,12 @@ async function trimMessagesToTokenLimit(
       )
       .join(" ");
 
-    const { summarizeText } = await import("./server/summarizeText");
-    const cachedSummary = await summarizeText(removedText);
+    const resp = await fetch("/api/summarize-text", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: removedText }),
+    });
+    const { summary: cachedSummary } = await resp.json();
 
     trimmed.unshift({
       role: "system",


### PR DESCRIPTION
## Summary
- add `/api/summarize-text` endpoint to wrap `summarizeText`
- client trims conversations by fetching new summary endpoint

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4cdf5e96c8333ba394cc72300b6cd