### PR TITLE
Handle missing Redis and summary errors

### DIFF
--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -1,10 +1,29 @@
 import Redis from "ioredis";
 
 const url = process.env.REDIS_URL;
-if (!url) {
-  throw new Error("REDIS_URL env variable not set");
+
+const createNoop = () => ({
+  async get() {
+    return null;
+  },
+  async set() {
+    return null;
+  },
+  async ping() {
+    return "PONG";
+  },
+  async quit() {
+    return;
+  },
+});
+
+const redis = url
+  ? new Redis(url, { lazyConnect: true, maxRetriesPerRequest: 0 })
+  : createNoop();
+
+if (url && typeof (redis as any).on === "function") {
+  (redis as any).on("error", () => {});
+  (redis as any).connect().catch(() => {});
 }
 
-const redis = new Redis(url);
-
-export default redis;
+export default redis as any;

--- a/lib/server/summarizeText.ts
+++ b/lib/server/summarizeText.ts
@@ -9,20 +9,37 @@ import redis from "@/lib/redis";
 export async function summarizeText(text: string, maxTokens = 200): Promise<string> {
   const hash = crypto.createHash("sha256").update(text).digest("hex");
   const key = `summary:${hash}`;
-  const cached = await redis.get(key);
-  if (cached) return cached as string;
+  try {
+    const cached = await redis.get(key);
+    if (cached) return cached as string;
+  } catch (err) {
+    console.error("Redis get error:", err);
+  }
 
-  const openai = new OpenAI();
-  const prompt = `Summarize the following text in about ${maxTokens} tokens:`;
-  const response = await openai.responses.create({
-    model: "gpt-4o-mini",
-    input: [
-      { role: "user", content: [{ type: "input_text", text: `${prompt}\n\n${text}` }] },
-    ],
-    max_output_tokens: maxTokens,
-  });
+  try {
+    const openai = new OpenAI();
+    const prompt = `Summarize the following text in about ${maxTokens} tokens:`;
+    const response = await openai.responses.create({
+      model: "gpt-4o-mini",
+      input: [
+        {
+          role: "user",
+          content: [{ type: "input_text", text: `${prompt}\n\n${text}` }],
+        },
+      ],
+      max_output_tokens: maxTokens,
+    });
 
-  const summary = response.output_text ?? "";
-  await redis.set(key, summary);
-  return summary;
+    const summary = response.output_text ?? "";
+    try {
+      await redis.set(key, summary);
+    } catch (err) {
+      console.error("Redis set error:", err);
+    }
+    return summary;
+  } catch (err) {
+    console.error("summarizeText error:", err);
+    const maxChars = maxTokens * 4;
+    return text.slice(0, maxChars);
+  }
 }


### PR DESCRIPTION
## Summary
- Wrap Redis and OpenAI operations in try/catch when summarizing text, falling back to truncated input on failure
- Export a no-op Redis client when `REDIS_URL` is not provided to avoid throwing at startup

## Testing
- `REDIS_URL= node -r ts-node/register/transpile-only -r tsconfig-paths/register --test tests/sessionSummary.test.js` *(fails: Object.getPackageJSONURL...)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d28c27e48333894f1da04a43b960