### PR TITLE
Add 24h expiration to Redis caches

### DIFF
--- a/app/api/sessions/[session_id]/end/route.ts
+++ b/app/api/sessions/[session_id]/end/route.ts
@@ -38,7 +38,7 @@ export async function POST(
       .filter(Boolean)
       .join("\n");
 
-    await redis.set(`session:${session_id}:summary`, summary);
+    await redis.set(`session:${session_id}:summary`, summary, "EX", 86400);
 
     const limit =
       (session as any)?.unsummarizedLimit ?? MAX_UNSUMMARIZED_MESSAGES;
@@ -57,7 +57,9 @@ export async function POST(
     });
     await redis.set(
       `session:${session_id}:messages`,
-      JSON.stringify(remainingMessages)
+      JSON.stringify(remainingMessages),
+      "EX",
+      86400
     );
 
     const longSummaryFragment = await summarizeSession({
@@ -79,7 +81,7 @@ export async function POST(
     });
 
     if (identifier) {
-      await redis.set(identifier, summary);
+      await redis.set(identifier, summary, "EX", 86400);
     }
 
     return new Response(JSON.stringify({ success: true, summary, longSummary }), {

--- a/app/api/sessions/start/route.ts
+++ b/app/api/sessions/start/route.ts
@@ -3,7 +3,7 @@ import redis from "@/lib/redis";
 import { MAX_SESSION_MESSAGES } from "@/config/constants";
 import { summarizeSession } from "@/lib/server/summarizeSession";
 
-// Session message caches are kept indefinitely until sessions are cleaned up.
+// Session message caches expire after 24 hours for cleanup.
 
 export async function POST(request: Request) {
   try {
@@ -48,7 +48,9 @@ export async function POST(request: Request) {
       });
       await redis.set(
         `session:${session.id}:messages`,
-        JSON.stringify([])
+        JSON.stringify([]),
+        "EX",
+        86400
       );
     }
 
@@ -64,7 +66,9 @@ export async function POST(request: Request) {
       messages = (sessionWithMessages?.messages as any[]) || [];
       await redis.set(
         `session:${session.id}:messages`,
-        JSON.stringify(messages)
+        JSON.stringify(messages),
+        "EX",
+        86400
       );
     }
 
@@ -88,12 +92,17 @@ export async function POST(request: Request) {
         where: { id: session.id },
         data: { summary, lastSummarizedIndex },
       });
-      await redis.set(`session:${session.id}:summary`, summary);
-      await redis.set(`session:${session.id}:messages`, JSON.stringify(messages));
+      await redis.set(`session:${session.id}:summary`, summary, "EX", 86400);
+      await redis.set(
+        `session:${session.id}:messages`,
+        JSON.stringify(messages),
+        "EX",
+        86400
+      );
     }
 
     if (summary) {
-      await redis.set(identifier, summary);
+      await redis.set(identifier, summary, "EX", 86400);
     } else {
       summary = await redis.get(identifier);
     }

--- a/lib/server/saveSessionMessages.ts
+++ b/lib/server/saveSessionMessages.ts
@@ -6,8 +6,7 @@ import {
   LARGE_MESSAGE_THRESHOLD,
 } from "@/config/constants";
 
-// Cached session messages no longer have an expiry and are retained
-// until the associated session is cleaned up.
+// Cached session messages expire after 24 hours to allow cleanup.
 
 export async function saveSessionMessages(
   session_id: string,
@@ -93,7 +92,9 @@ export async function saveSessionMessages(
       updatedMessages = updatedMessages.slice(-unsummarizedLimit);
       await redis.set(
         `session:${session_id}:summary`,
-        summary
+        summary,
+        "EX",
+        86400
       );
     }
 
@@ -109,7 +110,9 @@ export async function saveSessionMessages(
 
     await redis.set(
       `session:${session_id}:messages`,
-      JSON.stringify(updatedMessages)
+      JSON.stringify(updatedMessages),
+      "EX",
+      86400
     );
 
     if (duplicateDetected) {

--- a/lib/server/summarizeText.ts
+++ b/lib/server/summarizeText.ts
@@ -4,7 +4,7 @@ import redis from "@/lib/redis";
 
 /**
  * Summarize arbitrary text to roughly the given number of tokens.
- * Results are cached in Redis for reuse.
+ * Results are cached in Redis for 24 hours for reuse.
  */
 export async function summarizeText(text: string, maxTokens = 200): Promise<string> {
   const hash = crypto.createHash("sha256").update(text).digest("hex");
@@ -32,7 +32,7 @@ export async function summarizeText(text: string, maxTokens = 200): Promise<stri
 
     const summary = response.output_text ?? "";
     try {
-      await redis.set(key, summary);
+      await redis.set(key, summary, "EX", 86400);
     } catch (err) {
       console.error("Redis set error:", err);
     }


### PR DESCRIPTION
## Summary
- expire all Redis set operations after 24 hours
- document cache duration for summarizeText

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4d88df664833392a2bbc1c5638684