### PR TITLE
Limit text size before summarization

### DIFF
--- a/lib/assistant.ts
+++ b/lib/assistant.ts
@@ -150,10 +150,14 @@ async function trimMessagesToTokenLimit(
       )
       .join(" ");
 
+    const MAX_REMOVED_CHARS = 100_000;
+    // Limit text sent for summarization to avoid excessively large payloads.
+    const truncated = removedText.slice(0, MAX_REMOVED_CHARS);
+
     const resp = await fetch("/api/summarize-text", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ text: removedText }),
+      body: JSON.stringify({ text: truncated }),
     });
     const { summary: cachedSummary } = await resp.json();
 

--- a/lib/server/summarizeText.ts
+++ b/lib/server/summarizeText.ts
@@ -5,9 +5,15 @@ import redis from "@/lib/redis";
 /**
  * Summarize arbitrary text to roughly the given number of tokens.
  * Results are cached in Redis for 24 hours for reuse.
+ *
+ * Large inputs can cause hashing/summarization to be expensive, so the text is
+ * truncated to a maximum of 100k characters before any processing.
  */
 export async function summarizeText(text: string, maxTokens = 200): Promise<string> {
-  const hash = crypto.createHash("sha256").update(text).digest("hex");
+  const MAX_INPUT_CHARS = 100_000;
+  const truncated = text.slice(0, MAX_INPUT_CHARS);
+
+  const hash = crypto.createHash("sha256").update(truncated).digest("hex");
   const key = `summary:${hash}`;
   try {
     const cached = await redis.get(key);
@@ -24,7 +30,7 @@ export async function summarizeText(text: string, maxTokens = 200): Promise<stri
       input: [
         {
           role: "user",
-          content: [{ type: "input_text", text: `${prompt}\n\n${text}` }],
+          content: [{ type: "input_text", text: `${prompt}\n\n${truncated}` }],
         },
       ],
       max_output_tokens: maxTokens,
@@ -40,6 +46,6 @@ export async function summarizeText(text: string, maxTokens = 200): Promise<stri
   } catch (err) {
     console.error("summarizeText error:", err);
     const maxChars = maxTokens * 4;
-    return text.slice(0, maxChars);
+    return truncated.slice(0, maxChars);
   }
 }


### PR DESCRIPTION
## Summary
- cap removed conversation text at 100k characters before requesting a summary
- truncate input inside `summarizeText` and document strategy to avoid expensive processing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4e0fe5d188333996af602a19dda25