### PR TITLE
use API endpoints for summarization and search

### DIFF
--- a/app/api/search-knowledge-base/route.ts
+++ b/app/api/search-knowledge-base/route.ts
@@ -1,0 +1,12 @@
+import { search_knowledge_base } from "@/lib/server/searchFiles";
+
+export async function POST(request: Request) {
+  try {
+    const params = await request.json();
+    const result = await search_knowledge_base(params);
+    return Response.json(result);
+  } catch (error) {
+    console.error("Error searching knowledge base:", error);
+    return new Response("Failed to search knowledge base", { status: 500 });
+  }
+}

--- a/config/functions.ts
+++ b/config/functions.ts
@@ -3,10 +3,10 @@
 // Parameters for a tool call are passed as an object to the corresponding function
 import useDataStore from "@/stores/useDataStore";
 import useConversationStore from "@/stores/useConversationStore";
-import {
-  search_knowledge_base as serverSearchKnowledgeBase,
-  type SearchKnowledgeBaseResponse,
-} from "@/lib/server/searchFiles";
+interface SearchKnowledgeBaseResponse {
+  results?: any[] | string[];
+  error?: string;
+}
 
 // simple in-memory cache for file search results
 const fileSearchCache = new Map<string, SearchKnowledgeBaseResponse["results"]>();
@@ -459,14 +459,21 @@ export const search_knowledge_base = async ({
       return { results: cached };
     }
 
-    const result = await serverSearchKnowledgeBase({
-      query,
-      queries,
-      provider,
-      limit: limitNum,
-      threshold: thresholdNum,
-      topKOnly,
-    });
+    const result: SearchKnowledgeBaseResponse = await fetch(
+      "/api/search-knowledge-base",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          query,
+          queries,
+          provider,
+          limit: limitNum,
+          threshold: thresholdNum,
+          topKOnly,
+        }),
+      }
+    ).then((res) => res.json());
     if (result.results) {
       setFAQExtracts(result.results, provider);
       setLastSearchQuery(queryKey);


### PR DESCRIPTION
## Summary
- add `/api/search-knowledge-base` endpoint to run knowledge base lookups on the server
- update client `search_knowledge_base` helper to call the new endpoint instead of importing server code

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6df899d4c8333a1d713de40116bd4