### PR TITLE
chore: document summary cache expiration

### DIFF
--- a/lib/server/summarizeText.ts
+++ b/lib/server/summarizeText.ts
@@ -4,13 +4,17 @@ import redis from "@/lib/redis";
 
 /**
  * Summarize arbitrary text to roughly the given number of tokens.
- * Results are cached in Redis for 24 hours for reuse.
+ *
+ * Summaries are cached in Redis with a 24 hour TTL ("EX" 86400) to avoid
+ * recomputation of identical inputs.
  *
  * Large inputs can cause hashing/summarization to be expensive, so the text is
  * truncated to a maximum of 100k characters before any processing.
  */
 export async function summarizeText(text: string, maxTokens = 200): Promise<string> {
   const MAX_INPUT_CHARS = 100_000;
+  // Cache summaries for 24 hours to keep them relatively fresh.
+  const CACHE_TTL_SECONDS = 60 * 60 * 24; // 24h
   const truncated = text.slice(0, MAX_INPUT_CHARS);
 
   const hash = crypto.createHash("sha256").update(truncated).digest("hex");
@@ -38,7 +42,7 @@ export async function summarizeText(text: string, maxTokens = 200): Promise<stri
 
     const summary = response.output_text ?? "";
     try {
-      await redis.set(key, summary, "EX", 86400);
+      await redis.set(key, summary, "EX", CACHE_TTL_SECONDS);
     } catch (err) {
       console.error("Redis set error:", err);
     }


### PR DESCRIPTION
## Summary
- document and enforce 24h TTL for cached text summaries
- add constant for summary cache expiration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a76344fdf88333a8356ef4a80b04e2