### PR TITLE
Recompute token estimate after adding conversation summary

### DIFF
--- a/lib/assistant.ts
+++ b/lib/assistant.ts
@@ -170,6 +170,14 @@ async function trimMessagesToTokenLimit(
         },
       ],
     });
+
+    systemCount++;
+    tokenEstimate = estimateMessageTokens(trimmed, modelName);
+
+    while (tokenEstimate > limit && trimmed.length > systemCount + 1) {
+      trimmed.splice(systemCount, 1);
+      tokenEstimate = estimateMessageTokens(trimmed, modelName);
+    }
   }
 
   return trimmed;


### PR DESCRIPTION
## Summary
- Recalculate token usage after inserting a conversation summary
- Keep removing oldest non-system messages until estimated tokens fit within the limit

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7e85735d4833384da1dce37526de0