### PR TITLE
refactor: use NextResponse for summarize API

### DIFF
--- a/app/api/summarize-text/route.ts
+++ b/app/api/summarize-text/route.ts
@@ -1,15 +1,19 @@
+import { NextResponse } from "next/server";
 import { summarizeText } from "@/lib/server/summarizeText";
 
 export async function POST(request: Request) {
   try {
     const { text, maxTokens } = await request.json();
     if (typeof text !== "string") {
-      return new Response("Invalid text", { status: 400 });
+      return NextResponse.json({ error: "Invalid text" }, { status: 400 });
     }
     const summary = await summarizeText(text, maxTokens);
-    return Response.json({ summary });
+    return NextResponse.json({ summary });
   } catch (error) {
     console.error("Error summarizing text:", error);
-    return new Response("Failed to summarize text", { status: 500 });
+    return NextResponse.json(
+      { error: "Failed to summarize text" },
+      { status: 500 }
+    );
   }
 }

--- a/lib/assistant.ts
+++ b/lib/assistant.ts
@@ -154,6 +154,7 @@ async function trimMessagesToTokenLimit(
     // Limit text sent for summarization to avoid excessively large payloads.
     const truncated = removedText.slice(0, MAX_REMOVED_CHARS);
 
+    // Ask the server to summarize instead of importing server modules in the browser.
     const resp = await fetch("/api/summarize-text", {
       method: "POST",
       headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary
- switch summarize-text endpoint to NextResponse helpers
- document client-side summary fetching to avoid importing server modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8a722653c8333ad9c5d129b029d1b