### PR TITLE
feat: add Chatwoot webhook types

### DIFF
--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -1,5 +1,10 @@
 import { NextResponse } from "next/server";
 import { getProvider } from "@/lib/providers";
+import type {
+  ChatwootEvent,
+  Conversation,
+  Message,
+} from "@/types/chatwoot";
 
 /**
  * Handle Chatwoot webhook payloads and generate automated replies.
@@ -7,17 +12,19 @@ import { getProvider } from "@/lib/providers";
  */
 export async function POST(request: Request) {
   try {
-    const payload = await request.json();
+    const payload = (await request.json()) as ChatwootEvent;
 
-    const message = payload.message || payload;
+    const message: Message = payload.message || (payload as Message);
     const messageType = message.message_type || message.type;
     if (messageType && messageType !== "incoming") {
       return NextResponse.json({ status: "ignored" });
     }
 
     const content = message.content;
-    const conversation = message.conversation || payload.conversation;
-    const account = message.account || payload.account || conversation?.account;
+    const conversation: Conversation =
+      message.conversation || payload.conversation!;
+    const account =
+      message.account || payload.account || conversation?.account;
 
     if (!content || !conversation || !account) {
       return NextResponse.json({ error: "Invalid payload" }, { status: 400 });

--- a/types/chatwoot.ts
+++ b/types/chatwoot.ts
@@ -1,0 +1,29 @@
+interface Account {
+  id?: number;
+  account_id?: number;
+  [key: string]: any;
+}
+
+export interface Conversation {
+  id: number;
+  account?: Account;
+  [key: string]: any;
+}
+
+export interface Message {
+  id?: number;
+  content: string;
+  message_type?: string;
+  type?: string;
+  conversation?: Conversation;
+  account?: Account;
+  [key: string]: any;
+}
+
+export interface ChatwootEvent {
+  message?: Message;
+  conversation?: Conversation;
+  account?: Account;
+  [key: string]: any;
+}
+


### PR DESCRIPTION
## Summary
- define Chatwoot interfaces for events, conversations, and messages
- use these types in Chatwoot webhook handler for better type safety

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa1d1956b48333a61ba85c0ef8b0d7