### PR TITLE
docs: document Chatwoot env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,16 +47,19 @@ Feel free to customize this demo to suit your specific use case.
 
 2. **Configure environment:**
 
-   Create a `.env` file with your database connection string, Redis URL, and session retention setting:
+   Create a `.env` file with your database connection string, Redis URL, session retention setting, and (optionally) Chatwoot credentials:
 
    ```bash
    DATABASE_URL="postgresql://<user>:<password>@localhost:5432/<dbname>"
    REDIS_URL=redis://localhost:6379
    SESSION_RETENTION_DAYS=30 # How many days to retain ended sessions
+   CHATWOOT_URL=http://<chatwoot-host>:<port>
+   CHATWOOT_APP_TOKEN=<chatwoot-app-token>
    ```
 
    `SESSION_RETENTION_DAYS` controls how long ended sessions are kept before cleanup (defaults to 30 days).
    Session messages cached in Redis are retained indefinitely until the session is cleaned up.
+   The Chatwoot variables configure the webhook endpoint to send automated replies back to your Chatwoot instance.
 
 3. **Run database migrations:**
 

--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -7,6 +7,9 @@ import type {
   Message,
 } from "@/types/chatwoot";
 
+const CHATWOOT_URL = process.env.CHATWOOT_URL;
+const CHATWOOT_APP_TOKEN = process.env.CHATWOOT_APP_TOKEN;
+
 /**
  * Handle Chatwoot webhook payloads and generate automated replies.
  * Expects CHATWOOT_URL and CHATWOOT_APP_TOKEN env vars.
@@ -55,23 +58,24 @@ export async function POST(request: Request) {
       }
     }
 
-    const url = process.env.CHATWOOT_URL;
-    const token = process.env.CHATWOOT_APP_TOKEN;
-    if (!url || !token) {
+    if (!CHATWOOT_URL || !CHATWOOT_APP_TOKEN) {
       console.error("CHATWOOT_URL or CHATWOOT_APP_TOKEN not set");
-      return NextResponse.json({ error: "Chatwoot not configured" }, { status: 500 });
+      return NextResponse.json(
+        { error: "Chatwoot not configured" },
+        { status: 500 }
+      );
     }
 
     const accountId = account.id || account.account_id;
     const conversationId = conversation.id;
 
     const chatwootRes = await fetch(
-      `${url}/api/v1/accounts/${accountId}/conversations/${conversationId}/messages`,
+      `${CHATWOOT_URL}/api/v1/accounts/${accountId}/conversations/${conversationId}/messages`,
       {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          api_access_token: token,
+          api_access_token: CHATWOOT_APP_TOKEN,
         },
         body: JSON.stringify(
           mode === "auto"


### PR DESCRIPTION
## Summary
- document Chatwoot URL and app token environment variables in README
- ensure Chatwoot webhook uses `process.env` for configuration

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa30480af08333b5d4c0205faacdd7