### PR TITLE
feat: add Docker setup for ai-agent

### DIFF
--- a/.env.ai
+++ b/.env.ai
@@ -1,0 +1,13 @@
+OPENAI_API_KEY=<your-openai-api-key>
+PORT=3001
+DATABASE_URL=postgresql://postgres:postgres@postgres:5432/postgres?schema=public
+REDIS_PASSWORD=<redis-password>
+REDIS_URL=redis://:${REDIS_PASSWORD}@redis:6379
+OLLAMA_MODEL=llama3.2
+OLLAMA_NUM_CTX=32768
+OLLAMA_HOST=http://ollama:11434
+OLLAMA_OPENAI_BASE_URL=http://ollama:11434/v1
+OLLAMA_OPENAI_API_KEY=ollama
+SESSION_RETENTION_DAYS=30
+CHATWOOT_URL=http://rails:3000
+CHATWOOT_APP_TOKEN=<chatwoot-app-token>

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ yarn-error.log*
 # env files (can opt-in for committing if needed)
 .env*
 !.env.example
+!.env.ai
 
 # vercel
 .vercel

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+ENV PORT=3001
+EXPOSE 3001
+CMD ["npm", "run", "start"]

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Feel free to customize this demo to suit your specific use case.
    `SESSION_RETENTION_DAYS` controls how long ended sessions are kept before cleanup (defaults to 30 days).
    Session messages cached in Redis are retained indefinitely until the session is cleaned up.
    The Chatwoot variables configure the webhook endpoint to send automated replies back to your Chatwoot instance.
+   When Chatwoot and the AI service run inside the same Docker Compose network, use `http://ai-agent:3001/api/chatwoot-webhook` as the webhook endpoint.
 
 3. **Run database migrations:**
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,82 @@
+version: '3.8'
+services:
+  base: &base
+    image: chatwoot/chatwoot:latest
+    env_file: .env
+    volumes:
+      - storage_data:/app/storage
+
+  rails:
+    <<: *base
+    depends_on:
+      - postgres
+      - redis
+    ports:
+      - '0.0.0.0:3000:3000'
+    environment:
+      - NODE_ENV=production
+      - RAILS_ENV=production
+      - INSTALLATION_ENV=docker
+      - ALLOWED_HOSTS=e245e7cb03bc.ngrok-free.app
+    entrypoint: docker/entrypoints/rails.sh
+    command: ['bundle', 'exec', 'rails', 's', '-p', '3000', '-b', '0.0.0.0']
+    restart: always
+
+  sidekiq:
+    <<: *base
+    depends_on:
+      - postgres
+      - redis
+    environment:
+      - NODE_ENV=production
+      - RAILS_ENV=production
+      - INSTALLATION_ENV=docker
+    command: ['bundle', 'exec', 'sidekiq', '-C', 'config/sidekiq.yml']
+    restart: always
+
+  ai-agent:
+    build: .
+    env_file:
+      - .env.ai
+    ports:
+      - '3001:3001'
+    depends_on:
+      - rails
+      - postgres
+      - redis
+      - ollama
+
+  postgres:
+    image: pgvector/pgvector:pg16
+    restart: always
+    ports:
+      - '127.0.0.1:5433:5432'
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_DB=chatwoot
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+
+  redis:
+    image: redis:alpine
+    restart: always
+    command: ["sh", "-c", "redis-server --requirepass \"$REDIS_PASSWORD\""]
+    env_file: .env
+    volumes:
+      - redis_data:/data
+    ports:
+      - '127.0.0.1:6379:6379'
+
+  ollama:
+    image: ollama/ollama:latest
+    ports:
+      - '11434:11434'
+    volumes:
+      - ollama:/root/.ollama
+
+volumes:
+  storage_data:
+  postgres_data:
+  redis_data:
+  ollama:


### PR DESCRIPTION
## Summary
- use single-stage Docker image listening on port 3001
- combine Chatwoot and ai-agent services in docker-compose
- document compose webhook usage and update environment template

## Testing
- `REDIS_URL=redis://localhost:6379 npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa330595288333ab4f5c16e1e85f7a