### PR TITLE
feat: run prisma migrations on startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ COPY . .
 RUN npm run build
 ENV PORT=3001
 EXPOSE 3001
-CMD ["npm", "run", "start"]
+CMD ["./docker/entrypoints/ai-agent.sh"]

--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -6,4 +6,4 @@ COPY . .
 RUN npm run build
 ENV PORT=3001
 EXPOSE 3001
-CMD ["npm", "run", "start"]
+CMD ["./docker/entrypoints/ai-agent.sh"]

--- a/docker-compose.agent.yml
+++ b/docker-compose.agent.yml
@@ -12,6 +12,7 @@ services:
       - postgres
       - redis
       - ollama
+    entrypoint: docker/entrypoints/ai-agent.sh
 
   postgres:
     image: pgvector/pgvector:pg16

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
       - postgres
       - redis
       - ollama
+    entrypoint: docker/entrypoints/ai-agent.sh
 
   postgres:
     image: pgvector/pgvector:pg16

--- a/docker/entrypoints/ai-agent.sh
+++ b/docker/entrypoints/ai-agent.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+
+npx prisma migrate deploy
+npm run start


### PR DESCRIPTION
## Summary
- add docker/entrypoints/ai-agent.sh to run Prisma migrations then start app
- use entrypoint script as container command in Dockerfiles
- wire up docker compose services to use entrypoint

## Testing
- `npm test` *(fails: connect ECONNREFUSED 127.0.0.1:6379)*
- `npm run lint`
- `docker build -t ai-agent .` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68aa6a47f2e8833395503ead49ccdf7a