### PR TITLE
test: skip Redis ping when unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ Feel free to customize this demo to suit your specific use case.
    CHATWOOT_APP_TOKEN=<chatwoot-app-token>
    ```
 
+   If Redis runs on a dynamically mapped port (e.g. `docker port` or `docker compose port`), first determine the host port and then point `REDIS_URL` to it:
+
+   ```bash
+   docker compose port redis 6379
+   # or: docker port <container_name> 6379
+   # Suppose it prints 0.0.0.0:49153
+   REDIS_URL=redis://localhost:49153
+   ```
+
    `SESSION_RETENTION_DAYS` controls how long ended sessions are kept before cleanup (defaults to 30 days).
    Session messages cached in Redis are retained indefinitely until the session is cleaned up.
    The Chatwoot variables configure the webhook endpoint to send automated replies back to your Chatwoot instance.

--- a/test.ts
+++ b/test.ts
@@ -1,9 +1,22 @@
+const test = require('node:test');
+const assert = require('assert');
 const Redis = require('ioredis');
-const redis = new Redis(process.env.REDIS_URL);
 
-redis.ping()
-  .then((res: any) => {
-    console.log('Redis responded:', res); // should print "PONG"
-    return redis.quit();
-  })
-  .catch((err: any) => console.error('Redis connection failed:', err));
+const url =
+  process.env.REDIS_URL ||
+  (process.env.REDIS_PORT
+    ? `redis://localhost:${process.env.REDIS_PORT}`
+    : 'redis://localhost:6379');
+
+test('Redis responds to ping', async (t) => {
+  const redis = new Redis(url);
+  try {
+    const res = await redis.ping();
+    assert.strictEqual(res, 'PONG');
+  } catch {
+    t.skip('Redis not running');
+  } finally {
+    redis.disconnect();
+  }
+});
+


### PR DESCRIPTION
## Summary
- wrap Redis ping in a `node:test` block and skip when no server is reachable
- document how to set `REDIS_URL` when Redis runs on a dynamic port

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aab89954748333a301514d19a9afaf