### PR TITLE
Include ai-agent entrypoint script in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ RUN npm install
 COPY . .
 COPY prisma ./prisma
 RUN npx prisma generate
+COPY docker/entrypoints/ai-agent.sh docker/entrypoints/ai-agent.sh
+RUN chmod +x docker/entrypoints/ai-agent.sh
 RUN npm run build
 ENV PORT=3001
 EXPOSE 3001

--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -5,6 +5,8 @@ RUN npm install
 COPY . .
 COPY prisma ./prisma
 RUN npx prisma generate
+COPY docker/entrypoints/ai-agent.sh docker/entrypoints/ai-agent.sh
+RUN chmod +x docker/entrypoints/ai-agent.sh
 RUN npm run build
 ENV PORT=3001
 EXPOSE 3001


### PR DESCRIPTION
## Summary
- add ai-agent entrypoint to Dockerfile and Dockerfile.agent before build

## Testing
- `npm test`
- `docker build --no-cache -t ai-agent .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*
- `docker run --rm ai-agent ls -l docker/entrypoints` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*

------
https://chatgpt.com/codex/tasks/task_e_68aacfbb8b188333bad70f9c7bf239cf