### PR TITLE
Fix vector store file retrieval for OpenAI v5

### DIFF
--- a/app/api/vector_stores/get_file/route.ts
+++ b/app/api/vector_stores/get_file/route.ts
@@ -8,8 +8,8 @@ export async function GET(request: Request) {
   const fileId = searchParams.get("fileId") ?? "";
   try {
     const fileContent = await openai.vectorStores.files.retrieve(
-      vectorStoreId,
-      fileId
+      fileId,
+      { vector_store_id: vectorStoreId }
     );
     return new Response(JSON.stringify(fileContent), { status: 200 });
   } catch (error) {


### PR DESCRIPTION
## Summary
- update vector store file retrieval to include vector store ID parameter per OpenAI v5 API

## Testing
- `npm ls openai`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab6587b5e0833397b3a0d225c847cc