### PR TITLE
Add .dockerignore to exclude host artifacts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+npm-debug.log
+Dockerfile.agent
+Dockerfile


### PR DESCRIPTION
## Summary
- prevent large or platform-specific files from entering Docker build context by ignoring `node_modules`, logs, and Dockerfiles

## Testing
- `npm test`
- `docker build --no-cache -t ai-agent -f Dockerfile.agent .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7027c844833397c7f32713b33f3a