### PR TITLE
fix: streamline agent Dockerfile

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -1,9 +1,8 @@
 FROM node:20-alpine
 WORKDIR /app
 COPY package*.json ./
-RUN npm install
+RUN npm ci
 COPY . .
-COPY prisma ./prisma
 RUN npx prisma generate
 COPY docker/entrypoints/ai-agent.sh docker/entrypoints/ai-agent.sh
 RUN chmod +x docker/entrypoints/ai-agent.sh


### PR DESCRIPTION
## Summary
- remove redundant prisma folder copy
- install dependencies with `npm ci` and run prisma generate after source copy

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab719bce548333a048db294009a13e