### PR TITLE
Log Chatwoot request context on failure

### DIFF
--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -87,7 +87,13 @@ export async function POST(request: Request) {
 
     if (!chatwootRes.ok) {
       const text = await chatwootRes.text();
-      console.error("Failed to post Chatwoot reply", chatwootRes.status, text);
+      console.error("Failed to post Chatwoot reply", {
+        status: chatwootRes.status,
+        assistantText,
+        accountId,
+        conversationId,
+        body: text,
+      });
       return NextResponse.json({ error: "Failed to send message" }, { status: 500 });
     }
 


### PR DESCRIPTION
## Summary
- Improve Chatwoot webhook error logging
- Log assistant reply, account and conversation IDs, and response body when Chatwoot message posting fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab86b596f88333bea93c17fdfb3b52