### PR TITLE
chore: log ollama chat errors

### DIFF
--- a/lib/providers/ollama.ts
+++ b/lib/providers/ollama.ts
@@ -74,22 +74,31 @@ const converted = convertMessages(messages);
     console.log("ollama.chat payload", payload);
     stream = await ollama.chat(payload);
   } catch (error) {
-    console.error("ollama.chat failed", error, "finalText length", 0);
+    const message =
+      error instanceof Error ? error.message : String(error);
+    console.error(
+      "ollama.chat failed",
+      message,
+      error,
+      "finalText length",
+      0
+    );
     yield {
       event: "error",
-      data: { message: (error as Error).message },
+      data: { message },
     } as ProviderEvent;
     return;
   }
 
   const calls = new Map<string, { type: string; name?: string; args: string }>();
 
-  for await (const chunk of stream) {
-    console.log(
-      "Stream chunk:",
-      JSON.stringify(chunk).slice(0, 80),
-      "tool calls detected:",
-      (chunk.message?.tool_calls || []).length > 0
+  try {
+    for await (const chunk of stream) {
+      console.log(
+        "Stream chunk:",
+        JSON.stringify(chunk).slice(0, 80),
+        "tool calls detected:",
+        (chunk.message?.tool_calls || []).length > 0
     );
     const content = chunk.message?.content ?? "";
     if (content) {
@@ -218,6 +227,12 @@ const converted = convertMessages(messages);
         yield { event: "response.output_text.done", data: {} } as ProviderEvent;
       }
     }
+  }
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : String(error);
+    console.error("ollama.chat stream error", message, error);
+    yield { event: "error", data: { message } } as ProviderEvent;
   }
 }
 

--- a/lib/providers/ollama_openai.ts
+++ b/lib/providers/ollama_openai.ts
@@ -221,6 +221,9 @@ export async function* ollamaOpenAIProvider(
       }
     }
   } catch (error) {
-    yield { event: "error", data: { message: (error as Error).message } } as ProviderEvent;
+    const message =
+      error instanceof Error ? error.message : String(error);
+    console.error("ollamaOpenAI.chat failed", message, error);
+    yield { event: "error", data: { message } } as ProviderEvent;
   }
 }


### PR DESCRIPTION
## Summary
- log message and error details when ollama.chat fails
- report errors from streaming ollama.chat responses
- log failures from Ollama's OpenAI-compatible provider

## Testing
- `npm test`
- `ollama serve` *(fails: command not found)*
- `ollama pull llama3.2` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8ddb5d2c83339be9fc06f138e573