### PR TITLE
Document Docker Compose port mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ Feel free to customize this demo to suit your specific use case.
 
 Copy [`.env.ai`](./.env.ai) and adjust credentials or port mappings as needed. This file is used when running the container.
 
+The easiest way to run the entire stack with the baked-in port mappings is:
+
+```bash
+docker compose -f docker-compose.agent.yml up --build
+```
+
+The steps below show how to build and run each container manually.
+
 1. **Build the image**
 
    ```bash
@@ -61,12 +69,6 @@ Copy [`.env.ai`](./.env.ai) and adjust credentials or port mappings as needed. T
    docker run --rm -p 3001:3001 --network support-net --env-file .env.ai \
      -e DATABASE_URL=postgresql://postgres:postgres@demo-db:5432/support_agent_demo \
      -e REDIS_URL=redis://demo-redis:6379 ai-agent
-   ```
-
-4. **Alternatively, use Docker Compose**
-
-   ```bash
-   docker compose -f docker-compose.agent.yml up --build
    ```
 
 ## Troubleshooting

--- a/docker-compose.agent.yml
+++ b/docker-compose.agent.yml
@@ -7,7 +7,7 @@ services:
       - .env.ai
     ports:
       - '3001:3001'
-    depends_on:
+    depends_on: # services reference each other via these container names
       - postgres
       - redis
       - ollama
@@ -20,7 +20,7 @@ services:
     container_name: demo-db
     restart: always
     ports:
-      - '5434:5432'
+      - '5434:5432' # use host port 5434 to avoid conflicts with local Postgres on 5432
     volumes:
       - postgres_data:/var/lib/postgresql/data
     environment:
@@ -34,7 +34,7 @@ services:
     image: redis:alpine
     restart: always
     ports:
-      - '6380:6379'
+      - '6380:6379' # use host port 6380 to avoid conflicts with local Redis on 6379
     volumes:
       - redis_data:/data
     container_name: demo-redis


### PR DESCRIPTION
## Summary
- explain cross-service name resolution in `docker-compose.agent.yml`
- document alternative host ports to avoid conflicts with local 5432/6379
- highlight `docker compose -f docker-compose.agent.yml up --build` as the simplest way to start the stack

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac4b2ba1908333884c68cccb4517b8