### PR TITLE
feat: add chatwoot client and webhook integration

### DIFF
--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import type { ChatwootEvent, Message, Conversation } from "@/types/chatwoot";
+import { sendMessage } from "@/lib/chatwoot";
 
 export async function POST(request: Request) {
   try {
@@ -40,6 +41,14 @@ export async function POST(request: Request) {
       !content
     ) {
       return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+    }
+    // Example of sending an automated reply back to Chatwoot
+    try {
+      await sendMessage(accountId, conversationId, {
+        content: "Received: " + content,
+      });
+    } catch (err) {
+      console.error("sendMessage error", err);
     }
 
     return NextResponse.json({

--- a/lib/chatwoot.ts
+++ b/lib/chatwoot.ts
@@ -1,0 +1,53 @@
+const CHATWOOT_URL = (process.env.CHATWOOT_URL || "").replace(/\/$/, "");
+const CHATWOOT_TOKEN = process.env.CHATWOOT_APP_TOKEN || "";
+
+async function chatwootFetch(path: string, init: RequestInit = {}) {
+  const url = `${CHATWOOT_URL}${path}`;
+  const headers = {
+    "api_access_token": CHATWOOT_TOKEN,
+    ...(init.headers || {}),
+  } as Record<string, string>;
+  const res = await fetch(url, { ...init, headers });
+  if (!res.ok) {
+    throw new Error(`Chatwoot request failed: ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function sendMessage(
+  accountId: number,
+  conversationId: number,
+  body: Record<string, any>
+) {
+  return chatwootFetch(
+    `/api/v1/accounts/${accountId}/conversations/${conversationId}/messages`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+export async function updateConversation(
+  accountId: number,
+  conversationId: number,
+  body: Record<string, any>
+) {
+  return chatwootFetch(
+    `/api/v1/accounts/${accountId}/conversations/${conversationId}`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+export async function listAgents(accountId: number) {
+  return chatwootFetch(`/api/v1/accounts/${accountId}/agents`, {
+    method: "GET",
+  });
+}
+
+export default { sendMessage, updateConversation, listAgents };


### PR DESCRIPTION
## Summary
- add reusable Chatwoot client with message, conversation and agent helpers
- use Chatwoot helper in webhook to send an automated reply

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac5fbdb1ec8333b1c1ebe03a9ab18f