### PR TITLE
refactor: export chatwoot client as named constant

### DIFF
--- a/lib/chatwoot.ts
+++ b/lib/chatwoot.ts
@@ -50,4 +50,5 @@ export async function listAgents(accountId: number) {
   });
 }
 
-export default { sendMessage, updateConversation, listAgents };
+const chatwootClient = { sendMessage, updateConversation, listAgents };
+export default chatwootClient;


### PR DESCRIPTION
## Summary
- export Chatwoot client via named `chatwootClient` constant

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac648de7fc8333b09bd557c060e488