### PR TITLE
Add Chatwoot bot token support

### DIFF
--- a/.env.ai
+++ b/.env.ai
@@ -8,5 +8,6 @@ OLLAMA_HOST=http://ollama:11434
 OLLAMA_OPENAI_BASE_URL=http://ollama:11434/v1
 OLLAMA_OPENAI_API_KEY=ollama
 SESSION_RETENTION_DAYS=30
-CHATWOOT_URL=http://rails:3000
+CHATWOOT_URL=https://e245e7cb03bc.ngrok-free.app
 CHATWOOT_APP_TOKEN=<chatwoot-app-token>
+CHATWOOT_BOT_TOKEN=<bot access token>

--- a/.env.example
+++ b/.env.example
@@ -9,5 +9,6 @@ OLLAMA_OPENAI_API_KEY=ollama
 # Redis connection URL
 REDIS_URL=redis://localhost:6379
 SESSION_RETENTION_DAYS=30 # Controls automatic cleanup of ended sessions
-CHATWOOT_URL=http://localhost:3000
+CHATWOOT_URL=https://e245e7cb03bc.ngrok-free.app
 CHATWOOT_APP_TOKEN=<chatwoot-app-token>
+CHATWOOT_BOT_TOKEN=<bot access token>

--- a/README.md
+++ b/README.md
@@ -94,9 +94,10 @@ The steps below show how to build and run each container manually.
    DATABASE_URL="postgresql://<user>:<password>@localhost:5432/<dbname>"
    REDIS_URL=redis://localhost:6379
    SESSION_RETENTION_DAYS=30 # How many days to retain ended sessions
-   CHATWOOT_URL=http://<chatwoot-host>:<port>
+   CHATWOOT_URL=https://e245e7cb03bc.ngrok-free.app
    CHATWOOT_APP_TOKEN=<chatwoot-app-token>
-   ```
+   CHATWOOT_BOT_TOKEN=<bot access token>
+  ```
 
    If Redis runs on a dynamically mapped port (e.g. `docker port` or `docker compose port`), first determine the host port and then point `REDIS_URL` to it:
 

--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import type { ChatwootEvent, Message, Conversation } from "@/types/chatwoot";
-import { sendMessage, listAgents, updateConversation } from "@/lib/chatwoot";
+import { listAgents, updateConversation } from "@/lib/chatwoot";
+import { sendBotMessage } from "@/lib/chatwootBot";
 import { getProvider } from "@/lib/providers";
 import { INBOX_MODE } from "@/config/inboxMode";
 
@@ -57,13 +58,13 @@ export async function POST(request: Request) {
             status: "open",
             assignee_id: onlineAgent.id,
           });
-          await sendMessage(
+          await sendBotMessage(
             accountId,
             conversationId,
             "A human agent will join shortly."
           );
         } else {
-          await sendMessage(
+          await sendBotMessage(
             accountId,
             conversationId,
             "No human agents are currently available."
@@ -92,7 +93,7 @@ export async function POST(request: Request) {
           replyText += data.delta;
         }
       }
-      await sendMessage(accountId, conversationId, replyText, {
+      await sendBotMessage(accountId, conversationId, replyText, {
         private: mode !== "auto",
       });
     } catch (err) {

--- a/lib/chatwootBot.ts
+++ b/lib/chatwootBot.ts
@@ -1,0 +1,34 @@
+const CHATWOOT_URL = (process.env.CHATWOOT_URL || "").replace(/\/$/, "");
+const CHATWOOT_BOT_TOKEN = process.env.CHATWOOT_BOT_TOKEN || "";
+
+async function chatwootBotFetch(path: string, init: RequestInit = {}) {
+  const url = `${CHATWOOT_URL}${path}`;
+  const headers = {
+    api_access_token: CHATWOOT_BOT_TOKEN,
+    ...(init.headers || {}),
+  } as Record<string, string>;
+  const res = await fetch(url, { ...init, headers });
+  if (!res.ok) {
+    throw new Error(`Chatwoot bot request failed: ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function sendBotMessage(
+  accountId: number,
+  conversationId: number,
+  content: string,
+  options: Record<string, any> = {}
+) {
+  return chatwootBotFetch(
+    `/api/v1/accounts/${accountId}/conversations/${conversationId}/messages`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content, ...options }),
+    }
+  );
+}
+
+const chatwootBot = { sendBotMessage };
+export default chatwootBot;


### PR DESCRIPTION
## Summary
- update sample env files with Chatwoot URL and bot token
- add Chatwoot bot client and use it in webhook handler
- document new Chatwoot variables

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aca2ef58d8833380177788d95c7adb