### PR TITLE
Use structured user message content for provider calls

### DIFF
--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -81,7 +81,12 @@ export async function POST(request: Request) {
     try {
       let replyText = "";
       const events = getProvider(undefined)(
-        [{ role: "user", content }],
+        [
+          {
+            role: "user",
+            content: [{ type: "input_text", text: content }],
+          },
+        ],
         undefined,
         {}
       );

--- a/app/api/turn_response/route.ts
+++ b/app/api/turn_response/route.ts
@@ -22,9 +22,16 @@ export async function POST(request: Request) {
     console.log("Received messages:", messages);
 
     const normalizedMessages = Array.isArray(messages)
-      ? messages.map((m: any) =>
-          m?.type === "message" ? { role: m.role, content: m.content } : m
-        )
+      ? messages.map((m: any) => {
+          if (m?.type === "message") {
+            const content =
+              m.role === "user" && typeof m.content === "string"
+                ? [{ type: "input_text", text: m.content }]
+                : m.content;
+            return { role: m.role, content };
+          }
+          return m;
+        })
       : [];
 
     const lastMessage =


### PR DESCRIPTION
## Summary
- Ensure Chatwoot webhook sends user messages as structured `input_text` content
- Normalize incoming messages in turn response API to convert user strings into `input_text` items

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acb9a448808333bfc75c7f22dd20d9