### PR TITLE
Use file search tools in Chatwoot webhook

### DIFF
--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -4,6 +4,7 @@ import { listAgents, updateConversation } from "@/lib/chatwoot";
 import { sendBotMessage } from "@/lib/chatwootBot";
 import { getProvider } from "@/lib/providers";
 import { INBOX_MODE } from "@/config/inboxMode";
+import { tools } from "@/lib/tools/tools";
 
 export async function POST(request: Request) {
   try {
@@ -87,7 +88,7 @@ export async function POST(request: Request) {
             content: [{ type: "input_text", text: content }],
           },
         ],
-        undefined,
+        tools,
         {}
       );
       for await (const { event, data } of events) {


### PR DESCRIPTION
## Summary
- pass tool definitions to Chatwoot webhook handler so provider can use file_search with configured vector store

## Testing
- `npm test` *(fails: command hung, terminated)*
- `npm run lint`
- `docker compose build ai-agent` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ace82ff6b88333965f3ac33e1f4f44