### PR TITLE
feat: default outgoing message type

### DIFF
--- a/lib/chatwoot.ts
+++ b/lib/chatwoot.ts
@@ -25,7 +25,7 @@ export async function sendMessage(
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ content, ...options }),
+      body: JSON.stringify({ content, message_type: "outgoing", ...options }),
     }
   );
 }

--- a/lib/chatwootBot.ts
+++ b/lib/chatwootBot.ts
@@ -25,7 +25,7 @@ export async function sendBotMessage(
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ content, ...options }),
+      body: JSON.stringify({ content, message_type: "outgoing", ...options }),
     }
   );
 }


### PR DESCRIPTION
## Summary
- default Chatwoot messages to `message_type: "outgoing"`
- allow overriding `message_type` via options

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adaf66a6a483339329750fa9e4f99d