### PR TITLE
Fix Chatwoot agent availability check

### DIFF
--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -52,8 +52,8 @@ export async function POST(request: Request) {
     if (triggerPattern.test(content)) {
       try {
         const agents = await listAgents(accountId);
-        const onlineAgent = agents?.data?.find(
-          (a: any) => a.availability_status === "online"
+        const onlineAgent = agents.find(
+          (a: any) => a.availability_status === "available"
         );
         if (onlineAgent) {
           await updateConversation(accountId, conversationId, {


### PR DESCRIPTION
## Summary
- Handle `listAgents` as array instead of data payload
- Look for agents with `availability_status === "available"`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae058201708333ae084a1d2d3b7d5c