### PR TITLE
Use bot API to assign and open conversations

### DIFF
--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -1,7 +1,11 @@
 import { NextResponse } from "next/server";
 import type { ChatwootEvent, Message, Conversation } from "@/types/chatwoot";
-import { listAgents, updateConversation } from "@/lib/chatwoot";
-import { sendBotMessage } from "@/lib/chatwootBot";
+import { listAgents } from "@/lib/chatwoot";
+import {
+  sendBotMessage,
+  assignConversation,
+  toggleConversationStatus,
+} from "@/lib/chatwootBot";
 import { getProvider } from "@/lib/providers";
 import { INBOX_MODE } from "@/config/inboxMode";
 import { tools } from "@/lib/tools/tools";
@@ -56,10 +60,8 @@ export async function POST(request: Request) {
           (a: any) => a.availability_status === "available"
         );
         if (onlineAgent) {
-          await updateConversation(accountId, conversationId, {
-            status: "open",
-            assignee_id: onlineAgent.id,
-          });
+          await toggleConversationStatus(accountId, conversationId, "open");
+          await assignConversation(accountId, conversationId, onlineAgent.id);
           await sendBotMessage(
             accountId,
             conversationId,

--- a/lib/chatwootBot.ts
+++ b/lib/chatwootBot.ts
@@ -30,5 +30,39 @@ export async function sendBotMessage(
   );
 }
 
-const chatwootBot = { sendBotMessage };
+export async function assignConversation(
+  accountId: number,
+  conversationId: number,
+  assigneeId: number
+) {
+  return chatwootBotFetch(
+    `/api/v1/accounts/${accountId}/conversations/${conversationId}/assignments`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ assignee_id: assigneeId })
+    }
+  );
+}
+
+export async function toggleConversationStatus(
+  accountId: number,
+  conversationId: number,
+  status: string
+) {
+  return chatwootBotFetch(
+    `/api/v1/accounts/${accountId}/conversations/${conversationId}/toggle_status`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status })
+    }
+  );
+}
+
+const chatwootBot = {
+  sendBotMessage,
+  assignConversation,
+  toggleConversationStatus
+};
 export default chatwootBot;


### PR DESCRIPTION
## Summary
- add assignConversation and toggleConversationStatus helpers using Chatwoot bot token
- escalate webhook requests using new helpers when online agent detected

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae078bb2ac833388d2e76c9d6f76fa