### PR TITLE
Add configurable handoff strategy with confirmation toggle

### DIFF
--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -21,6 +21,7 @@ import {
   dequeueRequest,
   updateRequest,
 } from "@/lib/handoffQueue";
+import { handoffStrategy } from "@/config/handoffStrategy";
 
 export async function POST(request: Request) {
   try {
@@ -63,39 +64,61 @@ export async function POST(request: Request) {
 
           const request = await dequeueRequest();
           if (request) {
-            try {
-              const nextConv = await getConversation(
-                accountId,
-                request.conversationId
-              );
-              const nextInboxId = nextConv?.inbox_id;
-              if (nextInboxId !== undefined) {
-                const agent = await getNextAgent(nextInboxId);
-                if (agent) {
-                  await toggleConversationStatus(
-                    accountId,
-                    request.conversationId,
-                    "open"
-                  );
-                  await assignConversation(
-                    accountId,
-                    request.conversationId,
-                    agent.id
-                  );
-                  await setActiveConversation(agent.id, request.conversationId);
-                  await updateRequest(request.conversationId, {
-                    status: "assigned",
-                    agentId: agent.id,
-                  });
-                  await sendBotMessage(
-                    accountId,
-                    request.conversationId,
-                    "A human agent will join shortly."
-                  );
-                }
+            if (handoffStrategy.value === "confirm") {
+              try {
+                await sendBotMessage(
+                  accountId,
+                  request.conversationId,
+                  "A human agent is available. Reply 'yes' within 2 minutes to connect."
+                );
+                setTimeout(async () => {
+                  try {
+                    await updateRequest(request.conversationId, {
+                      status: "pending",
+                      agentId: null,
+                    });
+                  } catch (err) {
+                    console.error("handoff confirmation timeout", err);
+                  }
+                }, 2 * 60 * 1000);
+              } catch (err) {
+                console.error("handoff confirmation message error", err);
               }
-            } catch (err) {
-              console.error("handoff queue processing error", err);
+            } else {
+              try {
+                const nextConv = await getConversation(
+                  accountId,
+                  request.conversationId
+                );
+                const nextInboxId = nextConv?.inbox_id;
+                if (nextInboxId !== undefined) {
+                  const agent = await getNextAgent(nextInboxId);
+                  if (agent) {
+                    await toggleConversationStatus(
+                      accountId,
+                      request.conversationId,
+                      "open"
+                    );
+                    await assignConversation(
+                      accountId,
+                      request.conversationId,
+                      agent.id
+                    );
+                    await setActiveConversation(agent.id, request.conversationId);
+                    await updateRequest(request.conversationId, {
+                      status: "assigned",
+                      agentId: agent.id,
+                    });
+                    await sendBotMessage(
+                      accountId,
+                      request.conversationId,
+                      "A human agent will join shortly."
+                    );
+                  }
+                }
+              } catch (err) {
+                console.error("handoff queue processing error", err);
+              }
             }
           }
         } catch (err) {
@@ -140,6 +163,40 @@ export async function POST(request: Request) {
       !content
     ) {
       return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+    }
+
+    const existingRequest = await prisma.handoffRequest.findUnique({
+      where: { conversationId },
+    });
+    if (
+      handoffStrategy.value === "confirm" &&
+      existingRequest?.status === "awaiting_confirmation"
+    ) {
+      const confirmPattern = /\b(yes|y|sure|confirm|ok)\b/i;
+      if (confirmPattern.test(content)) {
+        try {
+          const agent = await getNextAgent(inboxId);
+          if (agent) {
+            await toggleConversationStatus(accountId, conversationId, "open");
+            await assignConversation(accountId, conversationId, agent.id);
+            await setActiveConversation(agent.id, conversationId);
+            await updateRequest(conversationId, {
+              status: "assigned",
+              agentId: agent.id,
+            });
+            await sendBotMessage(
+              accountId,
+              conversationId,
+              "A human agent will join shortly."
+            );
+            return NextResponse.json({ status: "handoff_confirmed" });
+          }
+        } catch (err) {
+          console.error("handoff confirmation error", err);
+        }
+      } else {
+        await updateRequest(conversationId, { status: "pending", agentId: null });
+      }
     }
 
     const triggerPattern = /\b(human|agent|representative)\b/i;

--- a/components/HandoffStrategyToggle.tsx
+++ b/components/HandoffStrategyToggle.tsx
@@ -1,0 +1,21 @@
+import useHandoffStrategy from "@/stores/useHandoffStrategy";
+
+const HandoffStrategyToggle = () => {
+  const { value, setStrategy } = useHandoffStrategy();
+
+  return (
+    <div className="flex items-center gap-2">
+      <span>Handoff Strategy:</span>
+      <select
+        className="border rounded px-2 py-1"
+        value={value}
+        onChange={(e) => setStrategy(e.target.value as "confirm" | "auto")}
+      >
+        <option value="confirm">Confirm</option>
+        <option value="auto">Auto</option>
+      </select>
+    </div>
+  );
+};
+
+export default HandoffStrategyToggle;

--- a/config/handoffStrategy.ts
+++ b/config/handoffStrategy.ts
@@ -1,0 +1,4 @@
+export const handoffStrategy: { value: "confirm" | "auto" } = {
+  value: "confirm",
+};
+export type HandoffStrategy = typeof handoffStrategy.value;

--- a/stores/useHandoffStrategy.ts
+++ b/stores/useHandoffStrategy.ts
@@ -1,0 +1,17 @@
+import { create } from "zustand";
+import { handoffStrategy } from "@/config/handoffStrategy";
+
+interface HandoffStrategyState {
+  value: "confirm" | "auto";
+  setStrategy: (value: "confirm" | "auto") => void;
+}
+
+const useHandoffStrategy = create<HandoffStrategyState>((set) => ({
+  value: handoffStrategy.value,
+  setStrategy: (value) => {
+    handoffStrategy.value = value;
+    set({ value });
+  },
+}));
+
+export default useHandoffStrategy;


### PR DESCRIPTION
## Summary
- add handoff strategy config and Zustand store
- add toggle component to switch strategies
- update Chatwoot webhook to handle confirm and auto strategies

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af889b18c08333b1d113cb46638326