### PR TITLE
feat: manage chatwoot conversation labels

### DIFF
--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -11,7 +11,9 @@ import {
   assignConversation,
   toggleConversationStatus,
   getConversation,
+  setConversationLabels,
 } from "@/lib/chatwootBot";
+import { CONVO_LABELS } from "@/lib/constants";
 import { getProvider } from "@/lib/providers";
 import { INBOX_MODE } from "@/config/inboxMode";
 import { tools } from "@/lib/tools/tools";
@@ -54,6 +56,13 @@ export async function POST(request: Request) {
       }
 
       if (status !== "open") {
+        if (status === "resolved") {
+          try {
+            await setConversationLabels(accountId, conversationId, []);
+          } catch (err) {
+            console.error("clear labels error", err);
+          }
+        }
         try {
           const assignment = await prisma.agentAssignment.findFirst({
             where: { activeConversationId: conversationId },
@@ -71,6 +80,9 @@ export async function POST(request: Request) {
                   request.conversationId,
                   "An agent is now available—reply within 2 minutes to connect."
                 );
+                await setConversationLabels(accountId, request.conversationId, [
+                  CONVO_LABELS.awaiting,
+                ]);
                 setTimeout(async () => {
                   try {
                     const current = await prisma.handoffRequest.findUnique({
@@ -81,6 +93,9 @@ export async function POST(request: Request) {
                         status: "expired",
                         agentId: null,
                       });
+                      await setConversationLabels(accountId, request.conversationId, [
+                        CONVO_LABELS.expired,
+                      ]);
                     }
                   } catch (err) {
                     console.error("handoff confirmation timeout", err);
@@ -119,6 +134,9 @@ export async function POST(request: Request) {
                       request.conversationId,
                       "A human agent will join shortly."
                     );
+                    await setConversationLabels(accountId, request.conversationId, [
+                      CONVO_LABELS.assigned,
+                    ]);
                   }
                 }
               } catch (err) {
@@ -194,6 +212,9 @@ export async function POST(request: Request) {
               conversationId,
               "A human agent will join shortly."
             );
+            await setConversationLabels(accountId, conversationId, [
+              CONVO_LABELS.assigned,
+            ]);
             return NextResponse.json({ status: "handoff_confirmed" });
           }
         } catch (err) {
@@ -201,6 +222,9 @@ export async function POST(request: Request) {
         }
       } else {
         await updateRequest(conversationId, { status: "expired", agentId: null });
+        await setConversationLabels(accountId, conversationId, [
+          CONVO_LABELS.expired,
+        ]);
       }
     }
 
@@ -218,6 +242,9 @@ export async function POST(request: Request) {
             conversationId,
             "A human agent will join shortly."
           );
+          await setConversationLabels(accountId, conversationId, [
+            CONVO_LABELS.assigned,
+          ]);
         } else {
           await enqueueRequest(conversationId);
           await sendBotMessage(
@@ -225,6 +252,9 @@ export async function POST(request: Request) {
             conversationId,
             "All human agents are currently busy. Please wait for the next available agent."
           );
+          await setConversationLabels(accountId, conversationId, [
+            CONVO_LABELS.waiting,
+          ]);
         }
       } catch (err) {
         console.error("agent escalation error", err);

--- a/lib/chatwootBot.ts
+++ b/lib/chatwootBot.ts
@@ -58,7 +58,7 @@ export async function assignConversation(
 export async function toggleConversationStatus(
   accountId: number,
   conversationId: number,
-  status: string
+  status: "open" | "resolved"
 ) {
   return chatwootBotFetch(
     `/api/v1/accounts/${accountId}/conversations/${conversationId}/toggle_status`,
@@ -70,10 +70,37 @@ export async function toggleConversationStatus(
   );
 }
 
+export async function setConversationLabels(
+  accountId: number,
+  conversationId: number,
+  labels: string[]
+) {
+  return chatwootBotFetch(
+    `/api/v1/accounts/${accountId}/conversations/${conversationId}/labels`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ labels }),
+    }
+  );
+}
+
+export async function getConversationLabels(
+  accountId: number,
+  conversationId: number
+) {
+  return chatwootBotFetch(
+    `/api/v1/accounts/${accountId}/conversations/${conversationId}/labels`,
+    { method: "GET" }
+  );
+}
+
 const chatwootBot = {
   sendBotMessage,
   getConversation,
   assignConversation,
-  toggleConversationStatus
+  toggleConversationStatus,
+  setConversationLabels,
+  getConversationLabels,
 };
 export default chatwootBot;

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,6 @@
+export const CONVO_LABELS = {
+  waiting: "waiting-agent",
+  awaiting: "awaiting-confirmation",
+  assigned: "agent-assigned",
+  expired: "queue-expired",
+} as const;


### PR DESCRIPTION
## Summary
- add conversation label constants
- expose Chatwoot label helper APIs and restrict status toggle
- manage queue/assignment labels in webhook lifecycle

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b06e6d6f688333b504097779e5aa2e