### PR TITLE
feat: validate Chatwoot env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,11 +95,16 @@ The steps below show how to build and run each container manually.
    REDIS_URL=redis://localhost:6379
    SESSION_RETENTION_DAYS=30 # How many days to retain ended sessions
    CHATWOOT_URL=https://e245e7cb03bc.ngrok-free.app
-   CHATWOOT_APP_TOKEN=<chatwoot-app-token>
-   CHATWOOT_BOT_TOKEN=<bot access token>
-  ```
+CHATWOOT_APP_TOKEN=<chatwoot-app-token>
+CHATWOOT_BOT_TOKEN=<bot access token>
+```
 
-   If Redis runs on a dynamically mapped port (e.g. `docker port` or `docker compose port`), first determine the host port and then point `REDIS_URL` to it:
+When running this service inside Docker, `CHATWOOT_URL` must be a fully
+qualified address reachable from the container (for example, a public
+ngrok or Cloudflare Tunnel URL) so that the agent can resolve the
+Chatwoot instance.
+
+If Redis runs on a dynamically mapped port (e.g. `docker port` or `docker compose port`), first determine the host port and then point `REDIS_URL` to it:
 
    ```bash
    docker compose port redis 6379

--- a/lib/chatwootBot.ts
+++ b/lib/chatwootBot.ts
@@ -1,5 +1,22 @@
 const CHATWOOT_URL = (process.env.CHATWOOT_URL || "").replace(/\/$/, "");
 const CHATWOOT_BOT_TOKEN = process.env.CHATWOOT_BOT_TOKEN || "";
+const CHATWOOT_APP_TOKEN = process.env.CHATWOOT_APP_TOKEN || "";
+
+if (!CHATWOOT_URL) {
+  console.warn(
+    "CHATWOOT_URL is not set. Chatwoot integration will be disabled."
+  );
+}
+if (!CHATWOOT_BOT_TOKEN) {
+  console.warn(
+    "CHATWOOT_BOT_TOKEN is not set. Bot messaging and labeling will not work."
+  );
+}
+if (!CHATWOOT_APP_TOKEN) {
+  console.warn(
+    "CHATWOOT_APP_TOKEN is not set. Agent listing will be unavailable."
+  );
+}
 
 async function chatwootBotFetch(path: string, init: RequestInit = {}) {
   const url = `${CHATWOOT_URL}${path}`;


### PR DESCRIPTION
## Summary
- add startup warnings for missing Chatwoot env vars
- document that Docker deployments need a publicly resolvable CHATWOOT_URL

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b07fa62ff48333802f8c9666d5cecf