### PR TITLE
Handle conversation fetch during escalation

### DIFF
--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -350,6 +350,30 @@ export async function POST(request: Request) {
 
     const triggerPattern = /\b(human|agent|representative)\b/i;
     if (triggerPattern.test(content)) {
+      console.info("handoff", {
+        step: "get-conversation",
+        accountId,
+        conversationId,
+      });
+      let currentConversation;
+      try {
+        currentConversation = await getConversation(accountId, conversationId);
+        console.info("handoff", "conversation fetched", currentConversation);
+      } catch (err) {
+        console.error("handoff", "conversation fetch error", err);
+        return NextResponse.json(
+          { error: "Failed to fetch conversation for escalation" },
+          { status: 500 }
+        );
+      }
+      if (!currentConversation) {
+        console.error("handoff", "conversation not found");
+        return NextResponse.json(
+          { error: "Conversation not found" },
+          { status: 404 }
+        );
+      }
+
       try {
         const agent = await getNextAgent(inboxId);
         if (agent) {


### PR DESCRIPTION
## Summary
- Fetch Chatwoot conversation data when escalation is triggered and log the result
- Abort escalation and return an error response when conversation lookup fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0c26c970c8333ae1540e8f9f2d9f6