### PR TITLE
feat: move conversation fetch to admin chatwoot module

### DIFF
--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -10,10 +10,10 @@ import {
   sendBotMessage,
   assignConversation,
   toggleConversationStatus,
-  getConversation,
   setConversationLabels,
   getConversationLabels,
 } from "@/lib/chatwootBot";
+import { getConversation } from "@/lib/chatwoot";
 import { CONVO_LABELS } from "@/lib/constants";
 import { getProvider } from "@/lib/providers";
 import { INBOX_MODE } from "@/config/inboxMode";

--- a/lib/chatwoot.ts
+++ b/lib/chatwoot.ts
@@ -18,6 +18,16 @@ async function chatwootFetch(path: string, init: RequestInit = {}) {
   return JSON.parse(text || "{}");
 }
 
+export async function getConversation(
+  accountId: number,
+  conversationId: number
+) {
+  return chatwootFetch(
+    `/api/v1/accounts/${accountId}/conversations/${conversationId}`,
+    { method: "GET" }
+  );
+}
+
 export async function sendMessage(
   accountId: number,
   conversationId: number,
@@ -55,5 +65,11 @@ export async function listAgents(accountId: number) {
   });
 }
 
-const chatwoot = { sendMessage, updateConversation, listAgents };
+const chatwoot = {
+  getConversation,
+  sendMessage,
+  updateConversation,
+  listAgents,
+};
 export default chatwoot;
+

--- a/lib/chatwootBot.ts
+++ b/lib/chatwootBot.ts
@@ -1,6 +1,5 @@
 const CHATWOOT_URL = (process.env.CHATWOOT_URL || "").replace(/\/$/, "");
 const CHATWOOT_BOT_TOKEN = process.env.CHATWOOT_BOT_TOKEN || "";
-const CHATWOOT_APP_TOKEN = process.env.CHATWOOT_APP_TOKEN || "";
 
 if (!CHATWOOT_URL) {
   console.warn(
@@ -10,11 +9,6 @@ if (!CHATWOOT_URL) {
 if (!CHATWOOT_BOT_TOKEN) {
   console.warn(
     "CHATWOOT_BOT_TOKEN is not set. Bot messaging and labeling will not work."
-  );
-}
-if (!CHATWOOT_APP_TOKEN) {
-  console.warn(
-    "CHATWOOT_APP_TOKEN is not set. Agent listing will be unavailable."
   );
 }
 
@@ -48,16 +42,6 @@ export async function sendBotMessage(
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ content, message_type: "outgoing", ...options }),
     }
-  );
-}
-
-export async function getConversation(
-  accountId: number,
-  conversationId: number
-) {
-  return chatwootBotFetch(
-    `/api/v1/accounts/${accountId}/conversations/${conversationId}`,
-    { method: "GET" }
   );
 }
 
@@ -118,7 +102,6 @@ export async function getConversationLabels(
 
 const chatwootBot = {
   sendBotMessage,
-  getConversation,
   assignConversation,
   toggleConversationStatus,
   setConversationLabels,


### PR DESCRIPTION
## Summary
- add admin-level `getConversation` helper in `lib/chatwoot.ts`
- remove conversation fetch from bot module and clean up imports
- update webhook route to use admin chatwoot for reads

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b18d3367348333abe36f6d609793bd