### PR TITLE
Use account ID for agent rotation

### DIFF
--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -143,38 +143,31 @@ export async function POST(request: Request) {
             }
           } else {
               try {
-                const nextConv = await getConversation(
-                  accountId,
-                  request.conversationId
-                );
-                const nextInboxId = nextConv?.inbox_id;
-                if (nextInboxId !== undefined) {
-                  const agent = await getNextAgent(nextInboxId);
-                  if (agent) {
-                    await setConversationLabels(accountId, request.conversationId, [
-                      CONVO_LABELS.assigned,
-                    ]);
-                    await toggleConversationStatus(
-                      accountId,
-                      request.conversationId,
-                      "open"
-                    );
-                    await assignConversation(
-                      accountId,
-                      request.conversationId,
-                      agent.id
-                    );
-                    await setActiveConversation(agent.id, request.conversationId);
-                    await updateRequest(request.conversationId, {
-                      status: "assigned",
-                      agentId: agent.id,
-                    });
-                    await sendBotMessage(
-                      accountId,
-                      request.conversationId,
-                      "A human agent will join shortly."
-                    );
-                  }
+                const agent = await getNextAgent(accountId);
+                if (agent) {
+                  await setConversationLabels(accountId, request.conversationId, [
+                    CONVO_LABELS.assigned,
+                  ]);
+                  await toggleConversationStatus(
+                    accountId,
+                    request.conversationId,
+                    "open"
+                  );
+                  await assignConversation(
+                    accountId,
+                    request.conversationId,
+                    agent.id
+                  );
+                  await setActiveConversation(agent.id, request.conversationId);
+                  await updateRequest(request.conversationId, {
+                    status: "assigned",
+                    agentId: agent.id,
+                  });
+                  await sendBotMessage(
+                    accountId,
+                    request.conversationId,
+                    "A human agent will join shortly."
+                  );
                 }
               } catch (err) {
                 console.error("handoff queue processing error", err);
@@ -237,7 +230,7 @@ export async function POST(request: Request) {
       const confirmPattern = /\b(yes|y|sure|confirm|ok)\b/i;
       if (confirmPattern.test(content)) {
         try {
-          const agent = await getNextAgent(inboxId);
+          const agent = await getNextAgent(accountId);
           if (agent) {
             console.info("handoff", { step: "toggle", accountId, conversationId });
             await toggleConversationStatus(accountId, conversationId, "open");
@@ -375,7 +368,7 @@ export async function POST(request: Request) {
       }
 
       try {
-        const agent = await getNextAgent(inboxId);
+        const agent = await getNextAgent(accountId);
         if (agent) {
           console.info("handoff", {
             step: "enqueue",

--- a/lib/agentRotation.ts
+++ b/lib/agentRotation.ts
@@ -8,13 +8,13 @@ export interface AgentRecord {
 }
 
 export async function getNextAgent(
-  inboxId: number
+  accountId: number
 ): Promise<AgentRecord | null> {
-  const agents: AgentRecord[] = await listAgents(inboxId);
+  const agents: AgentRecord[] = await listAgents(accountId);
   // Log agent availability to verify Chatwoot's status strings
   console.info(
     "[agentRotation] fetched agents",
-    agents.map((a) => ({ id: a.id, availability_status: a.availability_status }))
+    { accountId, agents: agents.map((a) => ({ id: a.id, availability_status: a.availability_status })) }
   );
   // Chatwoot marks active agents with "online" rather than "available"
   const onlineAgents = agents.filter(
@@ -25,7 +25,7 @@ export async function getNextAgent(
   }
 
   const existing = await prisma.agentAssignment.findMany({
-    where: { inboxId },
+    where: { inboxId: accountId },
   });
   const onlineIds = new Set(onlineAgents.map((a) => a.id));
   const existingIds = new Set(existing.map((a) => a.agentId));
@@ -34,7 +34,7 @@ export async function getNextAgent(
   if (newAgents.length > 0) {
     await prisma.agentAssignment.createMany({
       data: newAgents.map((a) => ({
-        inboxId,
+        inboxId: accountId,
         agentId: a.id,
         lastAssignedAt: new Date(0),
       })),
@@ -47,14 +47,14 @@ export async function getNextAgent(
   if (offlineIds.length > 0) {
     await prisma.agentAssignment.deleteMany({
       where: {
-        inboxId,
+        inboxId: accountId,
         agentId: { in: offlineIds },
       },
     });
   }
 
   const nextAssignment = await prisma.agentAssignment.findFirst({
-    where: { inboxId },
+    where: { inboxId: accountId },
     orderBy: { lastAssignedAt: "asc" },
   });
   if (!nextAssignment) {
@@ -69,7 +69,7 @@ export async function getNextAgent(
   await prisma.agentAssignment.update({
     where: {
       inboxId_agentId: {
-        inboxId,
+        inboxId: accountId,
         agentId: nextAssignment.agentId,
       },
     },


### PR DESCRIPTION
## Summary
- change `getNextAgent` to accept an `accountId` and fetch agents by account
- update webhook handler to request next agent with `accountId`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1905af844833388a097c96f071cc0