### PR TITLE
refactor: move conversation label helpers

### DIFF
--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -10,10 +10,12 @@ import {
   sendBotMessage,
   assignConversation,
   toggleConversationStatus,
+} from "@/lib/chatwootBot";
+import {
+  getConversation,
   setConversationLabels,
   getConversationLabels,
-} from "@/lib/chatwootBot";
-import { getConversation } from "@/lib/chatwoot";
+} from "@/lib/chatwoot";
 import { CONVO_LABELS } from "@/lib/constants";
 import { getProvider } from "@/lib/providers";
 import { INBOX_MODE } from "@/config/inboxMode";
@@ -78,101 +80,116 @@ export async function POST(request: Request) {
 
           const request = await dequeueRequest();
           if (request) {
-          if (handoffStrategy.value === "confirm") {
-            try {
-              const current = await getConversationLabels(
-                accountId,
-                request.conversationId
-              );
-              const labels = Array.isArray((current as any)?.payload)
-                ? Array.from(
-                    new Set([
-                      ...(current as any).payload,
-                      CONVO_LABELS.awaiting,
-                    ])
-                  )
-                : [CONVO_LABELS.awaiting];
-              await setConversationLabels(
-                accountId,
-                request.conversationId,
-                labels
-              );
-              await sendBotMessage(
-                accountId,
-                request.conversationId,
-                "An agent is now available—reply within 2 minutes to connect."
-              );
-              setTimeout(async () => {
+            if (handoffStrategy.value === "confirm") {
+              try {
+                let labels = [CONVO_LABELS.awaiting];
                 try {
-                  const current = await prisma.handoffRequest.findUnique({
-                    where: { conversationId: request.conversationId },
-                  });
-                  if (current?.status === "awaiting_confirmation") {
-                    await updateRequest(request.conversationId, {
-                      status: "expired",
-                      agentId: null,
+                  const current = await getConversationLabels(
+                    accountId,
+                    request.conversationId
+                  );
+                  labels = Array.isArray((current as any)?.payload)
+                    ? Array.from(
+                        new Set([
+                          ...(current as any).payload,
+                          CONVO_LABELS.awaiting,
+                        ])
+                      )
+                    : [CONVO_LABELS.awaiting];
+                } catch (err) {
+                  console.error("fetch awaiting label error", err);
+                }
+                try {
+                  await setConversationLabels(
+                    accountId,
+                    request.conversationId,
+                    labels
+                  );
+                } catch (err) {
+                  console.error("set awaiting label error", err);
+                }
+                await sendBotMessage(
+                  accountId,
+                  request.conversationId,
+                  "An agent is now available—reply within 2 minutes to connect."
+                );
+                setTimeout(async () => {
+                  try {
+                    const current = await prisma.handoffRequest.findUnique({
+                      where: { conversationId: request.conversationId },
                     });
-                    const existing = await getConversationLabels(
-                      accountId,
-                      request.conversationId
-                    );
-                    const labels = Array.isArray((existing as any)?.payload)
-                      ? Array.from(
-                          new Set(
-                            [
-                              ...(existing as any).payload.filter(
-                                (l: string) => l !== CONVO_LABELS.awaiting
-                              ),
-                              CONVO_LABELS.expired,
-                            ]
+                    if (current?.status === "awaiting_confirmation") {
+                      await updateRequest(request.conversationId, {
+                        status: "expired",
+                        agentId: null,
+                      });
+                      const existing = await getConversationLabels(
+                        accountId,
+                        request.conversationId
+                      );
+                      const labels = Array.isArray((existing as any)?.payload)
+                        ? Array.from(
+                            new Set(
+                              [
+                                ...(existing as any).payload.filter(
+                                  (l: string) => l !== CONVO_LABELS.awaiting
+                                ),
+                                CONVO_LABELS.expired,
+                              ]
+                            )
                           )
-                        )
-                      : [CONVO_LABELS.expired];
-                    await setConversationLabels(
+                        : [CONVO_LABELS.expired];
+                      await setConversationLabels(
+                        accountId,
+                        request.conversationId,
+                        labels
+                      );
+                    }
+                  } catch (err) {
+                    console.error("handoff confirmation timeout", err);
+                  }
+                }, 2 * 60 * 1000);
+              } catch (err) {
+                console.error("handoff confirmation message error", err);
+              }
+            } else {
+                try {
+                  const agent = await getNextAgent(accountId);
+                  if (agent) {
+                    try {
+                      await setConversationLabels(
+                        accountId,
+                        request.conversationId,
+                        [CONVO_LABELS.assigned]
+                      );
+                    } catch (err) {
+                      console.error("set assigned label error", err);
+                    }
+                    await toggleConversationStatus(
                       accountId,
                       request.conversationId,
-                      labels
+                      "open"
+                    );
+                    await assignConversation(
+                      accountId,
+                      request.conversationId,
+                      agent.id
+                    );
+                    await setActiveConversation(agent.id, request.conversationId);
+                    await updateRequest(request.conversationId, {
+                      status: "assigned",
+                      agentId: agent.id,
+                    });
+                    await sendBotMessage(
+                      accountId,
+                      request.conversationId,
+                      "A human agent will join shortly."
                     );
                   }
                 } catch (err) {
-                  console.error("handoff confirmation timeout", err);
+                  console.error("handoff queue processing error", err);
                 }
-              }, 2 * 60 * 1000);
-            } catch (err) {
-              console.error("handoff confirmation message error", err);
-            }
-          } else {
-              try {
-                const agent = await getNextAgent(accountId);
-                if (agent) {
-                  await setConversationLabels(accountId, request.conversationId, [
-                    CONVO_LABELS.assigned,
-                  ]);
-                  await toggleConversationStatus(
-                    accountId,
-                    request.conversationId,
-                    "open"
-                  );
-                  await assignConversation(
-                    accountId,
-                    request.conversationId,
-                    agent.id
-                  );
-                  await setActiveConversation(agent.id, request.conversationId);
-                  await updateRequest(request.conversationId, {
-                    status: "assigned",
-                    agentId: agent.id,
-                  });
-                  await sendBotMessage(
-                    accountId,
-                    request.conversationId,
-                    "A human agent will join shortly."
-                  );
-                }
-              } catch (err) {
-                console.error("handoff queue processing error", err);
               }
-            }
           }
         } catch (err) {
           console.error("conversation status change handling error", err);
@@ -271,44 +288,53 @@ export async function POST(request: Request) {
               "A human agent will join shortly."
             );
             console.info("handoff", "message sent");
-            console.info("handoff", {
-              step: "get-labels",
-              accountId,
-              conversationId,
-            });
-            const current = await getConversationLabels(
-              accountId,
-              conversationId
-            );
-            console.info(
-              "handoff",
-              "labels fetched",
-              (current as any)?.payload
-            );
-            const labels = Array.isArray((current as any)?.payload)
-              ? Array.from(
-                  new Set(
-                    [
-                      ...(current as any).payload.filter(
-                        (l: string) => l !== CONVO_LABELS.awaiting
-                      ),
-                      CONVO_LABELS.assigned,
-                    ]
-                  )
-                )
-              : [CONVO_LABELS.assigned];
-            console.info("handoff", {
-              step: "set-labels",
-              accountId,
-              conversationId,
-            });
-            await setConversationLabels(accountId, conversationId, labels);
-            console.info("handoff", "labels set", labels);
-            return NextResponse.json({ status: "handoff_confirmed" });
+              let labels = [CONVO_LABELS.assigned];
+              try {
+                console.info("handoff", {
+                  step: "get-labels",
+                  accountId,
+                  conversationId,
+                });
+                const current = await getConversationLabels(
+                  accountId,
+                  conversationId
+                );
+                console.info(
+                  "handoff",
+                  "labels fetched",
+                  (current as any)?.payload
+                );
+                labels = Array.isArray((current as any)?.payload)
+                  ? Array.from(
+                      new Set(
+                        [
+                          ...(current as any).payload.filter(
+                            (l: string) => l !== CONVO_LABELS.awaiting
+                          ),
+                          CONVO_LABELS.assigned,
+                        ]
+                      )
+                    )
+                  : [CONVO_LABELS.assigned];
+              } catch (err) {
+                console.error("handoff fetch labels error", err);
+              }
+              console.info("handoff", {
+                step: "set-labels",
+                accountId,
+                conversationId,
+              });
+              try {
+                await setConversationLabels(accountId, conversationId, labels);
+                console.info("handoff", "labels set", labels);
+              } catch (err) {
+                console.error("handoff set labels error", err);
+              }
+              return NextResponse.json({ status: "handoff_confirmed" });
+            }
+          } catch (err) {
+            console.error("handoff confirmation error", err);
           }
-        } catch (err) {
-          console.error("handoff confirmation error", err);
-        }
       } else {
         console.info("handoff", { step: "update-request", conversationId });
         await updateRequest(conversationId, {
@@ -316,28 +342,37 @@ export async function POST(request: Request) {
           agentId: null,
         });
         console.info("handoff", "request updated");
-        console.info("handoff", { step: "get-labels", accountId, conversationId });
-        const current = await getConversationLabels(accountId, conversationId);
-        console.info(
-          "handoff",
-          "labels fetched",
-          (current as any)?.payload
-        );
-        const labels = Array.isArray((current as any)?.payload)
-          ? Array.from(
-              new Set(
-                [
-                  ...(current as any).payload.filter(
-                    (l: string) => l !== CONVO_LABELS.awaiting
-                  ),
-                  CONVO_LABELS.expired,
-                ]
+        let labels = [CONVO_LABELS.expired];
+        try {
+          console.info("handoff", { step: "get-labels", accountId, conversationId });
+          const current = await getConversationLabels(accountId, conversationId);
+          console.info(
+            "handoff",
+            "labels fetched",
+            (current as any)?.payload
+          );
+          labels = Array.isArray((current as any)?.payload)
+            ? Array.from(
+                new Set(
+                  [
+                    ...(current as any).payload.filter(
+                      (l: string) => l !== CONVO_LABELS.awaiting
+                    ),
+                    CONVO_LABELS.expired,
+                  ]
+                )
               )
-            )
-          : [CONVO_LABELS.expired];
+            : [CONVO_LABELS.expired];
+        } catch (err) {
+          console.error("handoff fetch labels error", err);
+        }
         console.info("handoff", { step: "set-labels", accountId, conversationId });
-        await setConversationLabels(accountId, conversationId, labels);
-        console.info("handoff", "labels set", labels);
+        try {
+          await setConversationLabels(accountId, conversationId, labels);
+          console.info("handoff", "labels set", labels);
+        } catch (err) {
+          console.error("handoff set labels error", err);
+        }
       }
     }
 
@@ -406,31 +441,39 @@ export async function POST(request: Request) {
             "A human agent will join shortly."
           );
           console.info("handoff", "message sent");
-          const labels = [CONVO_LABELS.assigned];
-          console.info("handoff", {
-            step: "set-labels",
-            accountId,
-            conversationId,
-          });
-          await setConversationLabels(accountId, conversationId, labels);
-          console.info("handoff", "labels set", labels);
+            const labels = [CONVO_LABELS.assigned];
+            console.info("handoff", {
+              step: "set-labels",
+              accountId,
+              conversationId,
+            });
+            try {
+              await setConversationLabels(accountId, conversationId, labels);
+              console.info("handoff", "labels set", labels);
+            } catch (err) {
+              console.error("handoff set labels error", err);
+            }
         } else {
           console.info("handoff", { step: "enqueue", conversationId });
           await enqueueRequest(conversationId);
           console.info("handoff", "request enqueued");
-          const labels = [CONVO_LABELS.waiting];
-          console.info("handoff", {
-            step: "set-labels",
-            accountId,
-            conversationId,
-          });
-          await setConversationLabels(accountId, conversationId, labels);
-          console.info("handoff", "labels set", labels);
-          console.info("handoff", {
-            step: "send-message",
-            accountId,
-            conversationId,
-          });
+            const labels = [CONVO_LABELS.waiting];
+            console.info("handoff", {
+              step: "set-labels",
+              accountId,
+              conversationId,
+            });
+            try {
+              await setConversationLabels(accountId, conversationId, labels);
+              console.info("handoff", "labels set", labels);
+            } catch (err) {
+              console.error("handoff set labels error", err);
+            }
+            console.info("handoff", {
+              step: "send-message",
+              accountId,
+              conversationId,
+            });
           await sendBotMessage(
             accountId,
             conversationId,

--- a/lib/chatwoot.ts
+++ b/lib/chatwoot.ts
@@ -65,11 +65,38 @@ export async function listAgents(accountId: number) {
   });
 }
 
+export async function setConversationLabels(
+  accountId: number,
+  conversationId: number,
+  labels: string[]
+) {
+  return chatwootFetch(
+    `/api/v1/accounts/${accountId}/conversations/${conversationId}/labels`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ labels }),
+    }
+  );
+}
+
+export async function getConversationLabels(
+  accountId: number,
+  conversationId: number
+) {
+  return chatwootFetch(
+    `/api/v1/accounts/${accountId}/conversations/${conversationId}/labels`,
+    { method: "GET" }
+  );
+}
+
 const chatwoot = {
   getConversation,
   sendMessage,
   updateConversation,
   listAgents,
+  setConversationLabels,
+  getConversationLabels,
 };
 export default chatwoot;
 

--- a/lib/chatwootBot.ts
+++ b/lib/chatwootBot.ts
@@ -75,36 +75,9 @@ export async function toggleConversationStatus(
   );
 }
 
-export async function setConversationLabels(
-  accountId: number,
-  conversationId: number,
-  labels: string[]
-) {
-  return chatwootBotFetch(
-    `/api/v1/accounts/${accountId}/conversations/${conversationId}/labels`,
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ labels }),
-    }
-  );
-}
-
-export async function getConversationLabels(
-  accountId: number,
-  conversationId: number
-) {
-  return chatwootBotFetch(
-    `/api/v1/accounts/${accountId}/conversations/${conversationId}/labels`,
-    { method: "GET" }
-  );
-}
-
 const chatwootBot = {
   sendBotMessage,
   assignConversation,
   toggleConversationStatus,
-  setConversationLabels,
-  getConversationLabels,
 };
 export default chatwootBot;


### PR DESCRIPTION
## Summary
- move conversation label helpers to Chatwoot client using app token
- update webhook to import helpers from Chatwoot client and isolate label calls

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1c1c729f0833381e10f2c2641ad4f