### PR TITLE
Ignore open conversations in Chatwoot webhook

### DIFF
--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -237,6 +237,24 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
     }
 
+    let status = conversation?.status;
+    if (!status) {
+      try {
+        const convo = await getConversation(accountId, conversationId);
+        status = convo?.status;
+      } catch (err) {
+        console.error("fetch conversation error", err);
+      }
+    }
+
+    if (status === "open") {
+      return NextResponse.json({ status: "ignored" });
+    }
+
+    if (status !== "pending" && status !== "resolved") {
+      return NextResponse.json({ status: "ignored" });
+    }
+
     const existingRequest = await prisma.handoffRequest.findUnique({
       where: { conversationId },
     });


### PR DESCRIPTION
## Summary
- Retrieve conversation status from Chatwoot for each incoming message
- Skip bot responses when conversation is open and only reply to pending or resolved conversations

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b38f8c8ea48333aac5ef09f77e5c7a