### PR TITLE
Sync Chatwoot agent availability after assignments

### DIFF
--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -15,6 +15,7 @@ import {
   getConversation,
   setConversationLabels,
   getConversationLabels,
+  updateAgentAvailability,
 } from "@/lib/chatwoot";
 import { CONVO_LABELS } from "@/lib/constants";
 import { getProvider } from "@/lib/providers";
@@ -76,6 +77,11 @@ export async function POST(request: Request) {
           });
           if (assignment?.agentId) {
             await clearActiveConversation(assignment.agentId);
+            try {
+              await updateAgentAvailability(assignment.agentId, "online");
+            } catch (err) {
+              console.error("set agent online error", err);
+            }
           }
 
           const request = await dequeueRequest();
@@ -176,6 +182,11 @@ export async function POST(request: Request) {
                       agent.id
                     );
                     await setActiveConversation(agent.id, request.conversationId);
+                    try {
+                      await updateAgentAvailability(agent.id, "busy");
+                    } catch (err) {
+                      console.error("set agent busy error", err);
+                    }
                     await updateRequest(request.conversationId, {
                       status: "assigned",
                       agentId: agent.id,
@@ -284,6 +295,11 @@ export async function POST(request: Request) {
               conversationId,
             });
             await setActiveConversation(agent.id, conversationId);
+            try {
+              await updateAgentAvailability(agent.id, "busy");
+            } catch (err) {
+              console.error("set agent busy error", err);
+            }
             console.info("handoff", "active set", agent.id);
             console.info("handoff", {
               step: "update-request",
@@ -447,6 +463,11 @@ export async function POST(request: Request) {
             conversationId,
           });
           await setActiveConversation(agent.id, conversationId);
+          try {
+            await updateAgentAvailability(agent.id, "busy");
+          } catch (err) {
+            console.error("set agent busy error", err);
+          }
           console.info("handoff", "active set", agent.id);
           console.info("handoff", {
             step: "send-message",

--- a/lib/agentRotation.ts
+++ b/lib/agentRotation.ts
@@ -10,15 +10,14 @@ export interface AgentRecord {
 export async function getNextAgent(
   accountId: number
 ): Promise<AgentRecord | null> {
-  const agents: AgentRecord[] = await listAgents(accountId);
-  // Log agent availability to verify Chatwoot's status strings
-  console.info(
-    "[agentRotation] fetched agents",
-    { accountId, agents: agents.map((a) => ({ id: a.id, availability_status: a.availability_status })) }
-  );
-  // Chatwoot marks active agents with "online" rather than "available"
+  const agents: AgentRecord[] = await listAgents(accountId, "online");
+  // Double-check the API response to ensure only online agents are considered
   const onlineAgents = agents.filter(
     (a) => a.availability_status === "online"
+  );
+  console.info(
+    "[agentRotation] fetched agents",
+    { accountId, agents: onlineAgents.map((a) => ({ id: a.id, availability_status: a.availability_status })) }
   );
   if (onlineAgents.length === 0) {
     return null;

--- a/lib/chatwoot.ts
+++ b/lib/chatwoot.ts
@@ -59,9 +59,27 @@ export async function updateConversation(
   );
 }
 
-export async function listAgents(accountId: number) {
-  return chatwootFetch(`/api/v1/accounts/${accountId}/agents`, {
-    method: "GET",
+export async function listAgents(
+  accountId: number,
+  availability?: string
+) {
+  const query = availability ? `?availability_status=${availability}` : "";
+  return chatwootFetch(
+    `/api/v1/accounts/${accountId}/agents${query}`,
+    {
+      method: "GET",
+    }
+  );
+}
+
+export async function updateAgentAvailability(
+  agentId: number,
+  availability_status: string
+) {
+  return chatwootFetch(`/platform/api/v1/users/${agentId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ availability_status }),
   });
 }
 
@@ -95,6 +113,7 @@ const chatwoot = {
   sendMessage,
   updateConversation,
   listAgents,
+  updateAgentAvailability,
   setConversationLabels,
   getConversationLabels,
 };


### PR DESCRIPTION
## Summary
- Update Chatwoot helpers to patch user availability and filter agent listing by status
- Mark agents busy on assignment and set back online when conversation ends
- Fetch next agent only from online pool

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3947775e08333ba51a99146d26d4c