### PR TITLE
Use bot token for label updates and clean up queue labels

### DIFF
--- a/app/api/chatwoot-status-webhook/route.ts
+++ b/app/api/chatwoot-status-webhook/route.ts
@@ -4,12 +4,12 @@ import prisma from "@/lib/prisma";
 import { setActiveConversation, clearActiveConversation } from "@/lib/agentRotation";
 import {
   getConversation,
-  setConversationLabels,
   getConversationLabels,
   updateAgentAvailability,
   sendMessage,
   updateConversation,
 } from "@/lib/chatwoot";
+import { setConversationLabels } from "@/lib/chatwootBot";
 import { CONVO_LABELS } from "@/lib/constants";
 import { dequeueRequest, updateRequest } from "@/lib/handoffQueue";
 
@@ -53,7 +53,13 @@ export async function POST(request: Request) {
       const current = await getConversationLabels(accountId, conversationId);
       const labels = Array.isArray((current as any)?.payload)
         ? (current as any).payload.filter(
-            (l: string) => l !== CONVO_LABELS.assigned
+            (l: string) =>
+              ![
+                CONVO_LABELS.assigned,
+                CONVO_LABELS.waiting,
+                CONVO_LABELS.awaiting,
+                CONVO_LABELS.expired,
+              ].includes(l)
           )
         : [];
       await setConversationLabels(accountId, conversationId, labels);

--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -6,10 +6,10 @@ import {
   sendBotMessage,
   assignConversation,
   toggleConversationStatus,
+  setConversationLabels,
 } from "@/lib/chatwootBot";
 import {
   getConversation,
-  setConversationLabels,
   getConversationLabels,
   updateAgentAvailability,
 } from "@/lib/chatwoot";

--- a/lib/chatwoot.ts
+++ b/lib/chatwoot.ts
@@ -83,21 +83,6 @@ export async function updateAgentAvailability(
   });
 }
 
-export async function setConversationLabels(
-  accountId: number,
-  conversationId: number,
-  labels: string[]
-) {
-  return chatwootFetch(
-    `/api/v1/accounts/${accountId}/conversations/${conversationId}/labels`,
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ labels }),
-    }
-  );
-}
-
 export async function getConversationLabels(
   accountId: number,
   conversationId: number
@@ -114,7 +99,6 @@ const chatwoot = {
   updateConversation,
   listAgents,
   updateAgentAvailability,
-  setConversationLabels,
   getConversationLabels,
 };
 export default chatwoot;

--- a/lib/chatwootBot.ts
+++ b/lib/chatwootBot.ts
@@ -60,6 +60,21 @@ export async function assignConversation(
   );
 }
 
+export async function setConversationLabels(
+  accountId: number,
+  conversationId: number,
+  labels: string[]
+) {
+  return chatwootBotFetch(
+    `/api/v1/accounts/${accountId}/conversations/${conversationId}/labels`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ labels }),
+    }
+  );
+}
+
 export async function toggleConversationStatus(
   accountId: number,
   conversationId: number,
@@ -78,6 +93,7 @@ export async function toggleConversationStatus(
 const chatwootBot = {
   sendBotMessage,
   assignConversation,
+  setConversationLabels,
   toggleConversationStatus,
 };
 export default chatwootBot;


### PR DESCRIPTION
## Summary
- Tag conversations with `agent-assigned` when assigning an agent
- Remove `agent-assigned` and queue labels when status becomes pending or resolved
- Move label updates to bot-authenticated POST requests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3ae3b653c8333b91149bfdd9556ee