### PR TITLE
Use app token for conversation labeling

### DIFF
--- a/app/api/chatwoot-status-webhook/route.ts
+++ b/app/api/chatwoot-status-webhook/route.ts
@@ -8,8 +8,8 @@ import {
   updateAgentAvailability,
   sendMessage,
   updateConversation,
+  setConversationLabels,
 } from "@/lib/chatwoot";
-import { setConversationLabels } from "@/lib/chatwootBot";
 import { CONVO_LABELS } from "@/lib/constants";
 import { dequeueRequest, updateRequest } from "@/lib/handoffQueue";
 

--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -6,12 +6,12 @@ import {
   sendBotMessage,
   assignConversation,
   toggleConversationStatus,
-  setConversationLabels,
 } from "@/lib/chatwootBot";
 import {
   getConversation,
   getConversationLabels,
   updateAgentAvailability,
+  setConversationLabels,
 } from "@/lib/chatwoot";
 import { CONVO_LABELS } from "@/lib/constants";
 import { getProvider } from "@/lib/providers";

--- a/lib/chatwoot.ts
+++ b/lib/chatwoot.ts
@@ -93,6 +93,21 @@ export async function getConversationLabels(
   );
 }
 
+export async function setConversationLabels(
+  accountId: number,
+  conversationId: number,
+  labels: string[]
+) {
+  return chatwootFetch(
+    `/api/v1/accounts/${accountId}/conversations/${conversationId}/labels`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ labels }),
+    }
+  );
+}
+
 const chatwoot = {
   getConversation,
   sendMessage,
@@ -100,6 +115,7 @@ const chatwoot = {
   listAgents,
   updateAgentAvailability,
   getConversationLabels,
+  setConversationLabels,
 };
 export default chatwoot;
 

--- a/lib/chatwootBot.ts
+++ b/lib/chatwootBot.ts
@@ -60,21 +60,6 @@ export async function assignConversation(
   );
 }
 
-export async function setConversationLabels(
-  accountId: number,
-  conversationId: number,
-  labels: string[]
-) {
-  return chatwootBotFetch(
-    `/api/v1/accounts/${accountId}/conversations/${conversationId}/labels`,
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ labels }),
-    }
-  );
-}
-
 export async function toggleConversationStatus(
   accountId: number,
   conversationId: number,
@@ -93,7 +78,6 @@ export async function toggleConversationStatus(
 const chatwootBot = {
   sendBotMessage,
   assignConversation,
-  setConversationLabels,
   toggleConversationStatus,
 };
 export default chatwootBot;


### PR DESCRIPTION
## Summary
- Reintroduce `setConversationLabels` in `lib/chatwoot` using chat app token
- Drop labeling helper from `chatwootBot` to avoid bot token usage
- Update Chatwoot webhook routes to pull labeling helper from `lib/chatwoot`

## Testing
- `node -r ts-node/register/transpile-only -r tsconfig-paths/register -e "process.env.CHATWOOT_URL='https://example.com'; process.env.CHATWOOT_APP_TOKEN='app-token'; global.fetch=async (url, options)=>{ console.log('fetch', url, options); return { ok:true, text:async()=> '{}' };}; const { setConversationLabels } = require('./lib/chatwoot'); setConversationLabels(1,2,['foo','bar']).then(()=>console.log('done')).catch(err=>console.error(err));"`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3b7c26cec83339fd227ee316ffe05