### PR TITLE
cast reserved labels to string array

### DIFF
--- a/app/api/chatwoot-status-webhook/route.ts
+++ b/app/api/chatwoot-status-webhook/route.ts
@@ -51,15 +51,10 @@ export async function POST(request: Request) {
 
     try {
       const current = await getConversationLabels(accountId, conversationId);
+      const reserved = Object.values(CONVO_LABELS) as string[];
       const labels = Array.isArray((current as any)?.payload)
         ? (current as any).payload.filter(
-            (l: string) =>
-              ![
-                CONVO_LABELS.assigned,
-                CONVO_LABELS.waiting,
-                CONVO_LABELS.awaiting,
-                CONVO_LABELS.expired,
-              ].includes(l)
+            (l: string) => !reserved.includes(l)
           )
         : [];
       await setConversationLabels(accountId, conversationId, labels);


### PR DESCRIPTION
## Summary
- ensure reserved labels are typed as `string[]` before filtering in chatwoot status webhook

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3bb05e60c83339f75c735752c734a