### PR TITLE
Use admin token for availability updates

### DIFF
--- a/app/api/chatwoot-status-webhook/route.ts
+++ b/app/api/chatwoot-status-webhook/route.ts
@@ -6,10 +6,10 @@ import {
   getConversation,
   getConversationLabels,
   updateAgentAvailability,
-  sendMessage,
   updateConversation,
   setConversationLabels,
 } from "@/lib/chatwoot";
+import { sendBotMessage } from "@/lib/chatwootBot";
 import { CONVO_LABELS } from "@/lib/constants";
 import { dequeueRequest, updateRequest } from "@/lib/handoffQueue";
 
@@ -98,7 +98,7 @@ export async function POST(request: Request) {
             status: "assigned",
             agentId: freedAgentId,
           });
-          await sendMessage(
+          await sendBotMessage(
             accountId,
             request.conversationId,
             "A human agent will join shortly."

--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -363,7 +363,7 @@ export async function POST(request: Request) {
         private: mode !== "auto",
       });
     } catch (err) {
-      console.error("sendMessage error", err);
+      console.error("sendBotMessage error", err);
     }
 
     return NextResponse.json({

--- a/lib/chatwoot.ts
+++ b/lib/chatwoot.ts
@@ -28,22 +28,6 @@ export async function getConversation(
   );
 }
 
-export async function sendMessage(
-  accountId: number,
-  conversationId: number,
-  content: string,
-  options: Record<string, any> = {}
-) {
-  return chatwootFetch(
-    `/api/v1/accounts/${accountId}/conversations/${conversationId}/messages`,
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ content, message_type: "outgoing", ...options }),
-    }
-  );
-}
-
 export async function updateConversation(
   accountId: number,
   conversationId: number,
@@ -76,9 +60,16 @@ export async function updateAgentAvailability(
   agentId: number,
   availability_status: string
 ) {
+  console.info(
+    "[chatwoot] patch availability using CHATWOOT_APP_TOKEN",
+    { agentId, availability_status }
+  );
   return chatwootFetch(`/platform/api/v1/users/${agentId}`, {
     method: "PATCH",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      api_access_token: CHATWOOT_TOKEN,
+    },
     body: JSON.stringify({ availability_status }),
   });
 }
@@ -110,7 +101,6 @@ export async function setConversationLabels(
 
 const chatwoot = {
   getConversation,
-  sendMessage,
   updateConversation,
   listAgents,
   updateAgentAvailability,


### PR DESCRIPTION
## Summary
- ensure agent availability patches use `CHATWOOT_APP_TOKEN`
- route Chatwoot status webhook messages through bot token helpers
- update logging to indicate token used for availability updates

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b41fa71d4c833383ca14800617588a