### PR TITLE
feat: update agent availability helper

### DIFF
--- a/app/api/chatwoot-status-webhook/route.ts
+++ b/app/api/chatwoot-status-webhook/route.ts
@@ -70,9 +70,15 @@ export async function POST(request: Request) {
       if (freedAgentId) {
         await clearActiveConversation(freedAgentId);
         try {
-          await updateAgentAvailability(freedAgentId, "online");
+          const response = await updateAgentAvailability(
+            accountId,
+            freedAgentId,
+            "online"
+          );
+          console.info("set agent online response", response);
         } catch (err) {
           console.error("set agent online error", err);
+          await setActiveConversation(freedAgentId, conversationId);
         }
 
         const request = await dequeueRequest();
@@ -90,9 +96,15 @@ export async function POST(request: Request) {
           });
           await setActiveConversation(freedAgentId, request.conversationId);
           try {
-            await updateAgentAvailability(freedAgentId, "busy");
+            const response = await updateAgentAvailability(
+              accountId,
+              freedAgentId,
+              "busy"
+            );
+            console.info("set agent busy response", response);
           } catch (err) {
             console.error("set agent busy error", err);
+            await clearActiveConversation(freedAgentId);
           }
           await updateRequest(request.conversationId, {
             status: "assigned",

--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -1,7 +1,11 @@
 import { NextResponse } from "next/server";
 import type { ChatwootEvent, Message, Conversation } from "@/types/chatwoot";
 import prisma from "@/lib/prisma";
-import { getNextAgent, setActiveConversation } from "@/lib/agentRotation";
+import {
+  getNextAgent,
+  setActiveConversation,
+  clearActiveConversation,
+} from "@/lib/agentRotation";
 import {
   sendBotMessage,
   assignConversation,
@@ -112,9 +116,15 @@ export async function POST(request: Request) {
             });
             await setActiveConversation(agent.id, conversationId);
             try {
-              await updateAgentAvailability(agent.id, "busy");
+              const response = await updateAgentAvailability(
+                accountId,
+                agent.id,
+                "busy"
+              );
+              console.info("set agent busy response", response);
             } catch (err) {
               console.error("set agent busy error", err);
+              await clearActiveConversation(agent.id);
             }
             console.info("handoff", "active set", agent.id);
             console.info("handoff", {
@@ -280,9 +290,15 @@ export async function POST(request: Request) {
           });
           await setActiveConversation(agent.id, conversationId);
           try {
-            await updateAgentAvailability(agent.id, "busy");
+            const response = await updateAgentAvailability(
+              accountId,
+              agent.id,
+              "busy"
+            );
+            console.info("set agent busy response", response);
           } catch (err) {
             console.error("set agent busy error", err);
+            await clearActiveConversation(agent.id);
           }
           console.info("handoff", "active set", agent.id);
           console.info("handoff", {

--- a/lib/chatwoot.ts
+++ b/lib/chatwoot.ts
@@ -57,21 +57,18 @@ export async function listAgents(
 }
 
 export async function updateAgentAvailability(
+  accountId: number,
   agentId: number,
-  availability_status: string
+  availability_status: "available" | "busy" | "offline"
 ) {
-  console.info(
-    "[chatwoot] patch availability using CHATWOOT_APP_TOKEN",
-    { agentId, availability_status }
+  return chatwootFetch(
+    `/api/v1/accounts/${accountId}/agents/${agentId}`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ role: "agent", availability_status }),
+    }
   );
-  return chatwootFetch(`/platform/api/v1/users/${agentId}`, {
-    method: "PATCH",
-    headers: {
-      "Content-Type": "application/json",
-      api_access_token: CHATWOOT_TOKEN,
-    },
-    body: JSON.stringify({ availability_status }),
-  });
 }
 
 export async function getConversationLabels(


### PR DESCRIPTION
## Summary
- add account-scoped updateAgentAvailability helper
- log responses and roll back local state on API failure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4986216548333ad09df7bd6105ea4