### PR TITLE
feat: update agent availability helper

### DIFF
--- a/app/api/chatwoot-status-webhook/route.ts
+++ b/app/api/chatwoot-status-webhook/route.ts
@@ -8,6 +8,7 @@ import {
   updateAgentAvailability,
   updateConversation,
   setConversationLabels,
+  listAgents,
 } from "@/lib/chatwoot";
 import { sendBotMessage } from "@/lib/chatwootBot";
 import { CONVO_LABELS } from "@/lib/constants";
@@ -68,11 +69,29 @@ export async function POST(request: Request) {
       });
       const freedAgentId = assignment?.agentId;
       if (freedAgentId) {
+        let role = "agent";
+        try {
+          const agents = await listAgents(accountId);
+          const freedAgent = agents.find((a: any) => a.id === freedAgentId);
+          if (freedAgent?.role === "administrator") {
+            role = "administrator";
+          }
+        } catch (err) {
+          console.error("fetch agent role error", err);
+        }
+
         await clearActiveConversation(freedAgentId);
         try {
-          await updateAgentAvailability(freedAgentId, "online");
+          const response = await updateAgentAvailability(
+            accountId,
+            freedAgentId,
+            "available",
+            role
+          );
+          console.info("set agent available response", response);
         } catch (err) {
-          console.error("set agent online error", err);
+          console.error("set agent available error", err);
+          await setActiveConversation(freedAgentId, conversationId);
         }
 
         const request = await dequeueRequest();
@@ -90,9 +109,16 @@ export async function POST(request: Request) {
           });
           await setActiveConversation(freedAgentId, request.conversationId);
           try {
-            await updateAgentAvailability(freedAgentId, "busy");
+            const response = await updateAgentAvailability(
+              accountId,
+              freedAgentId,
+              "busy",
+              role
+            );
+            console.info("set agent busy response", response);
           } catch (err) {
             console.error("set agent busy error", err);
+            await clearActiveConversation(freedAgentId);
           }
           await updateRequest(request.conversationId, {
             status: "assigned",

--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -1,7 +1,11 @@
 import { NextResponse } from "next/server";
 import type { ChatwootEvent, Message, Conversation } from "@/types/chatwoot";
 import prisma from "@/lib/prisma";
-import { getNextAgent, setActiveConversation } from "@/lib/agentRotation";
+import {
+  getNextAgent,
+  setActiveConversation,
+  clearActiveConversation,
+} from "@/lib/agentRotation";
 import {
   sendBotMessage,
   assignConversation,
@@ -112,9 +116,18 @@ export async function POST(request: Request) {
             });
             await setActiveConversation(agent.id, conversationId);
             try {
-              await updateAgentAvailability(agent.id, "busy");
+              const role =
+                agent.role === "administrator" ? "administrator" : "agent";
+              const response = await updateAgentAvailability(
+                accountId,
+                agent.id,
+                "busy",
+                role
+              );
+              console.info("set agent busy response", response);
             } catch (err) {
               console.error("set agent busy error", err);
+              await clearActiveConversation(agent.id);
             }
             console.info("handoff", "active set", agent.id);
             console.info("handoff", {
@@ -280,9 +293,18 @@ export async function POST(request: Request) {
           });
           await setActiveConversation(agent.id, conversationId);
           try {
-            await updateAgentAvailability(agent.id, "busy");
+            const role =
+              agent.role === "administrator" ? "administrator" : "agent";
+            const response = await updateAgentAvailability(
+              accountId,
+              agent.id,
+              "busy",
+              role
+            );
+            console.info("set agent busy response", response);
           } catch (err) {
             console.error("set agent busy error", err);
+            await clearActiveConversation(agent.id);
           }
           console.info("handoff", "active set", agent.id);
           console.info("handoff", {

--- a/lib/agentRotation.ts
+++ b/lib/agentRotation.ts
@@ -4,32 +4,33 @@ import { listAgents } from "./chatwoot";
 export interface AgentRecord {
   id: number;
   availability_status: string;
+  role?: "agent" | "administrator";
   [key: string]: any;
 }
 
 export async function getNextAgent(
   accountId: number
 ): Promise<AgentRecord | null> {
-  const agents: AgentRecord[] = await listAgents(accountId, "online");
-  // Double-check the API response to ensure only online agents are considered
-  const onlineAgents = agents.filter(
-    (a) => a.availability_status === "online"
+  const agents: AgentRecord[] = await listAgents(accountId, "available");
+  // Double-check the API response to ensure only available agents are considered
+  const availableAgents = agents.filter(
+    (a) => a.availability_status === "available"
   );
   console.info(
     "[agentRotation] fetched agents",
-    { accountId, agents: onlineAgents.map((a) => ({ id: a.id, availability_status: a.availability_status })) }
+    { accountId, agents: availableAgents.map((a) => ({ id: a.id, availability_status: a.availability_status })) }
   );
-  if (onlineAgents.length === 0) {
+  if (availableAgents.length === 0) {
     return null;
   }
 
   const existing = await prisma.agentAssignment.findMany({
     where: { inboxId: accountId },
   });
-  const onlineIds = new Set(onlineAgents.map((a) => a.id));
+  const availableIds = new Set(availableAgents.map((a) => a.id));
   const existingIds = new Set(existing.map((a) => a.agentId));
 
-  const newAgents = onlineAgents.filter((a) => !existingIds.has(a.id));
+  const newAgents = availableAgents.filter((a) => !existingIds.has(a.id));
   if (newAgents.length > 0) {
     await prisma.agentAssignment.createMany({
       data: newAgents.map((a) => ({
@@ -41,7 +42,7 @@ export async function getNextAgent(
   }
 
   const offlineIds = existing
-    .filter((a) => !onlineIds.has(a.agentId))
+    .filter((a) => !availableIds.has(a.agentId))
     .map((a) => a.agentId);
   if (offlineIds.length > 0) {
     await prisma.agentAssignment.deleteMany({
@@ -60,7 +61,9 @@ export async function getNextAgent(
     return null;
   }
 
-  const nextAgent = onlineAgents.find((a) => a.id === nextAssignment.agentId);
+  const nextAgent = availableAgents.find(
+    (a) => a.id === nextAssignment.agentId
+  );
   if (!nextAgent) {
     return null;
   }

--- a/lib/chatwoot.ts
+++ b/lib/chatwoot.ts
@@ -57,21 +57,19 @@ export async function listAgents(
 }
 
 export async function updateAgentAvailability(
+  accountId: number,
   agentId: number,
-  availability_status: string
+  availability_status: "available" | "busy" | "offline",
+  role: "agent" | "administrator" = "agent"
 ) {
-  console.info(
-    "[chatwoot] patch availability using CHATWOOT_APP_TOKEN",
-    { agentId, availability_status }
+  return chatwootFetch(
+    `/api/v1/accounts/${accountId}/agents/${agentId}`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ role, availability_status }),
+    }
   );
-  return chatwootFetch(`/platform/api/v1/users/${agentId}`, {
-    method: "PATCH",
-    headers: {
-      "Content-Type": "application/json",
-      api_access_token: CHATWOOT_TOKEN,
-    },
-    body: JSON.stringify({ availability_status }),
-  });
 }
 
 export async function getConversationLabels(


### PR DESCRIPTION
## Summary
- allow admin availability changes via role-aware helper
- track agent roles to update availability when freeing and assigning conversations
- normalize agent rotation to use available status

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4986216548333ad09df7bd6105ea4