### PR TITLE
Use agent tokens for Chatwoot availability updates

### DIFF
--- a/app/api/chatwoot-status-webhook/route.ts
+++ b/app/api/chatwoot-status-webhook/route.ts
@@ -4,7 +4,6 @@ import prisma from "@/lib/prisma";
 import { setActiveConversation, clearActiveConversation } from "@/lib/agentRotation";
 import {
   getConversation,
-  getAgent,
   getConversationLabels,
   updateAgentAvailability,
   updateConversation,
@@ -13,6 +12,7 @@ import {
 import { sendBotMessage } from "@/lib/chatwootBot";
 import { CONVO_LABELS } from "@/lib/constants";
 import { dequeueRequest, updateRequest } from "@/lib/handoffQueue";
+import { getAgentToken } from "@/config/agentTokens";
 
 export async function POST(request: Request) {
   try {
@@ -83,24 +83,22 @@ export async function POST(request: Request) {
 
       if (freedAgentId) {
         await clearActiveConversation(freedAgentId);
-        let role: "agent" | "administrator" = "agent";
-        try {
-          const agent = await getAgent(accountId, freedAgentId);
-          role = agent.role === "administrator" ? "administrator" : "agent";
-        } catch (err) {
-          console.error("fetch agent role error", err);
+        const freedAgentToken = getAgentToken(freedAgentId);
+        if (!freedAgentToken) {
+          console.error("agent token not found", freedAgentId);
+          await setActiveConversation(freedAgentId, conversationId);
+          return NextResponse.json({ error: "Agent token missing" }, { status: 500 });
         }
         try {
           const response = await updateAgentAvailability(
-            accountId,
-            freedAgentId,
-            "online",
-            role
+            freedAgentToken,
+            "online"
           );
           console.info("set agent available response", response);
         } catch (err) {
           console.error("set agent available error", err);
           await setActiveConversation(freedAgentId, conversationId);
+          return NextResponse.json({ error: "Agent availability update failed" }, { status: 500 });
         }
 
         const request = await dequeueRequest();
@@ -117,17 +115,22 @@ export async function POST(request: Request) {
             assignee_id: freedAgentId,
           });
           await setActiveConversation(freedAgentId, request.conversationId);
+          const busyToken = getAgentToken(freedAgentId);
+          if (!busyToken) {
+            console.error("agent token not found", freedAgentId);
+            await clearActiveConversation(freedAgentId);
+            return NextResponse.json({ error: "Agent token missing" }, { status: 500 });
+          }
           try {
             const response = await updateAgentAvailability(
-              accountId,
-              freedAgentId,
-              "busy",
-              role
+              busyToken,
+              "busy"
             );
             console.info("set agent busy response", response);
           } catch (err) {
             console.error("set agent busy error", err);
             await clearActiveConversation(freedAgentId);
+            return NextResponse.json({ error: "Agent availability update failed" }, { status: 500 });
           }
           await updateRequest(request.conversationId, {
             status: "assigned",

--- a/lib/handoff.ts
+++ b/lib/handoff.ts
@@ -1,21 +1,41 @@
-import { assignConversation, toggleConversationStatus, sendBotMessage } from "@/lib/chatwootBot";
+import {
+  assignConversation,
+  toggleConversationStatus,
+  sendBotMessage,
+} from "@/lib/chatwootBot";
 import { updateAgentAvailability } from "@/lib/chatwoot";
+import { getAgentToken } from "@/config/agentTokens";
 
 export async function handOff(
   accountId: number,
   conversationId: number,
   agentId: number,
-  role: "agent" | "administrator" = "agent"
+  _role: "agent" | "administrator" = "agent"
 ): Promise<boolean> {
+  void _role;
+  const agentToken = getAgentToken(agentId);
+  if (!agentToken) {
+    console.error("Agent token not found", agentId);
+    try {
+      await sendBotMessage(
+        accountId,
+        conversationId,
+        "We're unable to connect you to a human agent right now. Please try again later."
+      );
+    } catch (error) {
+      console.error("send fallback message error", error);
+    }
+    return false;
+  }
   try {
     await toggleConversationStatus(accountId, conversationId, "open");
     await assignConversation(accountId, conversationId, agentId);
-    await updateAgentAvailability(accountId, agentId, "busy", role);
+    await updateAgentAvailability(agentToken, "busy");
     return true;
   } catch (err) {
     console.error("handoff error", err);
     try {
-      await updateAgentAvailability(accountId, agentId, "online", role);
+      await updateAgentAvailability(agentToken, "online");
     } catch (error) {
       console.error("rollback availability error", error);
     }


### PR DESCRIPTION
## Summary
- Retrieve Chatwoot agent tokens via `getAgentToken` in handoff flow and status webhook
- Pass tokens to `updateAgentAvailability` and log/rollback when missing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b59095146c833398baebaf700d20e7