### PR TITLE
Use online availability status for agent rotation

### DIFF
--- a/app/api/chatwoot-status-webhook/route.ts
+++ b/app/api/chatwoot-status-webhook/route.ts
@@ -94,9 +94,9 @@ export async function POST(request: Request) {
             freedAgentToken,
             "online"
           );
-          console.info("set agent available response", response);
+          console.info("set agent online response", response);
         } catch (err) {
-          console.error("set agent available error", err);
+          console.error("set agent online error", err);
           await setActiveConversation(freedAgentId, conversationId);
           return NextResponse.json({ error: "Agent availability update failed" }, { status: 500 });
         }

--- a/lib/agentRotation.ts
+++ b/lib/agentRotation.ts
@@ -3,7 +3,7 @@ import { listAgents } from "./chatwoot";
 
 export interface AgentRecord {
   id: number;
-  availability_status: string;
+  availability_status: "online" | "busy" | "offline";
   role?: "agent" | "administrator";
   [key: string]: any;
 }
@@ -12,25 +12,25 @@ export async function getNextAgent(
   accountId: number
 ): Promise<AgentRecord | null> {
   const agents: AgentRecord[] = await listAgents(accountId, "online");
-  // Double-check the API response to ensure only available agents are considered
-  const availableAgents = agents.filter(
+  // Double-check the API response to ensure only online agents are considered
+  const onlineAgents = agents.filter(
     (a) => a.availability_status === "online"
   );
   console.info(
     "[agentRotation] fetched agents",
-    { accountId, agents: availableAgents.map((a) => ({ id: a.id, availability_status: a.availability_status })) }
+    { accountId, agents: onlineAgents.map((a) => ({ id: a.id, availability_status: a.availability_status })) }
   );
-  if (availableAgents.length === 0) {
+  if (onlineAgents.length === 0) {
     return null;
   }
 
   const existing = await prisma.agentAssignment.findMany({
     where: { inboxId: accountId },
   });
-  const availableIds = new Set(availableAgents.map((a) => a.id));
+  const onlineIds = new Set(onlineAgents.map((a) => a.id));
   const existingIds = new Set(existing.map((a) => a.agentId));
 
-  const newAgents = availableAgents.filter((a) => !existingIds.has(a.id));
+  const newAgents = onlineAgents.filter((a) => !existingIds.has(a.id));
   if (newAgents.length > 0) {
     await prisma.agentAssignment.createMany({
       data: newAgents.map((a) => ({
@@ -42,7 +42,7 @@ export async function getNextAgent(
   }
 
   const offlineIds = existing
-    .filter((a) => !availableIds.has(a.agentId))
+    .filter((a) => !onlineIds.has(a.agentId))
     .map((a) => a.agentId);
   if (offlineIds.length > 0) {
     await prisma.agentAssignment.deleteMany({
@@ -61,7 +61,7 @@ export async function getNextAgent(
     return null;
   }
 
-  const nextAgent = availableAgents.find(
+  const nextAgent = onlineAgents.find(
     (a) => a.id === nextAssignment.agentId
   );
   if (!nextAgent) {

--- a/lib/chatwoot.ts
+++ b/lib/chatwoot.ts
@@ -45,7 +45,7 @@ export async function updateConversation(
 
 export async function listAgents(
   accountId: number,
-  availability?: string
+  availability?: "online" | "busy" | "offline"
 ) {
   const query = availability ? `?availability_status=${availability}` : "";
   return chatwootFetch(


### PR DESCRIPTION
## Summary
- query only online agents when rotating to next agent
- restrict agent availability types to `online | busy | offline`
- align status webhook logs with online availability

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b59628e7cc8333baf9cca6d1cd05ab