### PR TITLE
feat: update agent availability via app token

### DIFF
--- a/app/api/chatwoot-status-webhook/route.ts
+++ b/app/api/chatwoot-status-webhook/route.ts
@@ -5,14 +5,13 @@ import { setActiveConversation, clearActiveConversation } from "@/lib/agentRotat
 import {
   getConversation,
   getConversationLabels,
-  updateAgentAvailability,
+  setAgentAvailability,
   updateConversation,
   setConversationLabels,
 } from "@/lib/chatwoot";
 import { sendBotMessage } from "@/lib/chatwootBot";
 import { CONVO_LABELS } from "@/lib/constants";
 import { dequeueRequest, updateRequest } from "@/lib/handoffQueue";
-import { getAgentToken } from "@/config/agentTokens";
 
 export async function POST(request: Request) {
   try {
@@ -83,15 +82,10 @@ export async function POST(request: Request) {
 
       if (freedAgentId) {
         await clearActiveConversation(freedAgentId);
-        const freedAgentToken = getAgentToken(freedAgentId);
-        if (!freedAgentToken) {
-          console.error("agent token not found", freedAgentId);
-          await setActiveConversation(freedAgentId, conversationId);
-          return NextResponse.json({ error: "Agent token missing" }, { status: 500 });
-        }
         try {
-          const response = await updateAgentAvailability(
-            freedAgentToken,
+          const response = await setAgentAvailability(
+            accountId,
+            freedAgentId,
             "online"
           );
           console.info("set agent online response", response);
@@ -115,15 +109,10 @@ export async function POST(request: Request) {
             assignee_id: freedAgentId,
           });
           await setActiveConversation(freedAgentId, request.conversationId);
-          const busyToken = getAgentToken(freedAgentId);
-          if (!busyToken) {
-            console.error("agent token not found", freedAgentId);
-            await clearActiveConversation(freedAgentId);
-            return NextResponse.json({ error: "Agent token missing" }, { status: 500 });
-          }
           try {
-            const response = await updateAgentAvailability(
-              busyToken,
+            const response = await setAgentAvailability(
+              accountId,
+              freedAgentId,
               "busy"
             );
             console.info("set agent busy response", response);

--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -257,6 +257,10 @@ export async function POST(request: Request) {
               role
             );
             if (!success) {
+              await updateRequest(conversationId, {
+                status: "pending",
+                agentId: null,
+              });
               return NextResponse.json({ status: "handoff_failed" });
             }
             await setActiveConversation(agent.id, conversationId);

--- a/lib/chatwoot.ts
+++ b/lib/chatwoot.ts
@@ -63,21 +63,31 @@ export async function getAgent(accountId: number, agentId: number) {
   );
 }
 
-export async function updateAgentAvailability(
-  agentToken: string,
+export async function setAgentAvailability(
+  accountId: number,
+  agentId: number,
   availability: "online" | "busy" | "offline"
 ) {
-  return chatwootFetch(
-    `/api/v1/profile/availability`,
-    {
+  const path = `/api/v1/accounts/${accountId}/agents/${agentId}`;
+  try {
+    return await chatwootFetch(path, {
       method: "PATCH",
-      headers: {
-        "api_access_token": agentToken,
-        "Content-Type": "application/json",
-      },
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ availability }),
+    });
+  } catch (err) {
+    if (err instanceof Error && err.message.includes("404")) {
+      const url = `${CHATWOOT_URL}${path}`;
+      console.error("[chatwoot] setAgentAvailability 404", {
+        url,
+        body: { availability },
+      });
+      console.error(
+        "[chatwoot] ensure Chatwoot version supports PATCH /api/v1/accounts/{accountId}/agents/{agentId}"
+      );
     }
-  );
+    throw err;
+  }
 }
 
 export async function getConversationLabels(
@@ -110,7 +120,7 @@ const chatwoot = {
   updateConversation,
   listAgents,
   getAgent,
-  updateAgentAvailability,
+  setAgentAvailability,
   getConversationLabels,
   setConversationLabels,
 };

--- a/lib/handoff.ts
+++ b/lib/handoff.ts
@@ -3,8 +3,7 @@ import {
   toggleConversationStatus,
   sendBotMessage,
 } from "@/lib/chatwootBot";
-import { updateAgentAvailability } from "@/lib/chatwoot";
-import { getAgentToken } from "@/config/agentTokens";
+import { setAgentAvailability, updateConversation } from "@/lib/chatwoot";
 
 export async function handOff(
   accountId: number,
@@ -13,31 +12,25 @@ export async function handOff(
   _role: "agent" | "administrator" = "agent"
 ): Promise<boolean> {
   void _role;
-  const agentToken = getAgentToken(agentId);
-  if (!agentToken) {
-    console.error("Agent token not found", agentId);
-    try {
-      await sendBotMessage(
-        accountId,
-        conversationId,
-        "We're unable to connect you to a human agent right now. Please try again later."
-      );
-    } catch (error) {
-      console.error("send fallback message error", error);
-    }
-    return false;
-  }
   try {
     await toggleConversationStatus(accountId, conversationId, "open");
     await assignConversation(accountId, conversationId, agentId);
-    await updateAgentAvailability(agentToken, "busy");
+    await setAgentAvailability(accountId, agentId, "busy");
     return true;
   } catch (err) {
     console.error("handoff error", err);
     try {
-      await updateAgentAvailability(agentToken, "online");
+      await setAgentAvailability(accountId, agentId, "online");
     } catch (error) {
       console.error("rollback availability error", error);
+    }
+    try {
+      await updateConversation(accountId, conversationId, {
+        status: "pending",
+        assignee_id: null,
+      });
+    } catch (error) {
+      console.error("rollback conversation error", error);
     }
     try {
       await sendBotMessage(


### PR DESCRIPTION
## Summary
- patch agent availability with app token and log 404s for missing endpoint
- use new helper throughout handoff flow and revert state on failures
- clean up queue when handoff fails

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5cd82be488333ba4eafc0db0d0fee