### PR TITLE
Handle Chatwoot conversation resolution webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ If Redis runs on a dynamically mapped port (e.g. `docker port` or `docker compos
    `SESSION_RETENTION_DAYS` controls how long ended sessions are kept before cleanup (defaults to 30 days).
    Session messages cached in Redis are retained indefinitely until the session is cleaned up.
    The Chatwoot variables configure the webhook endpoints to send automated replies and handle status changes in your Chatwoot instance.
-   When Chatwoot and the AI service run inside the same Docker Compose network, use `http://ai-agent:3001/api/chatwoot-webhook` for message events and add another webhook subscribed to `conversation_status_changed` pointing to `http://ai-agent:3001/api/chatwoot-status-webhook`.
+   When Chatwoot and the AI service run inside the same Docker Compose network, use `http://ai-agent:3001/api/chatwoot-webhook` for message events and add another webhook subscribed to `conversation_updated` pointing to `http://ai-agent:3001/api/chatwoot-status-webhook`.
 
    The `AGENT_TOKENS` environment variable supplies per-agent access tokens in JSON form, e.g. `{ "1": "secret" }`. Store these secrets outside of source control (such as a `.env` file or your hosting platform's secret manager). To rotate a token, update the JSON with the new value and redeploy or restart the service so it reads the updated mapping.
 

--- a/app/api/chatwoot-status-webhook/route.ts
+++ b/app/api/chatwoot-status-webhook/route.ts
@@ -1,139 +1,80 @@
 import { NextResponse } from "next/server";
-import type { ChatwootEvent, Conversation } from "@/types/chatwoot";
-import prisma from "@/lib/prisma";
-import { setActiveConversation, clearActiveConversation } from "@/lib/agentRotation";
-import {
-  getConversation,
-  getConversationLabels,
-  setAgentAvailability,
-  updateConversation,
-  setConversationLabels,
-} from "@/lib/chatwoot";
-import { sendBotMessage } from "@/lib/chatwootBot";
-import { CONVO_LABELS } from "@/lib/constants";
-import { dequeueRequest, updateRequest } from "@/lib/handoffQueue";
+import type { ChatwootEvent, Conversation, Message } from "@/types/chatwoot";
+import { releaseAgent } from "@/lib/conversationResolution";
 
 export async function POST(request: Request) {
   try {
     const incoming = (await request.json()) as any;
     const payload: ChatwootEvent = incoming.data ?? incoming;
 
-    if (incoming.event !== "conversation_status_changed") {
+    const event = incoming.event;
+    const changedAttributes = (payload as any)?.changed_attributes;
+    const message: Message | undefined = (payload as any)?.message;
+    console.info("chatwoot status webhook", {
+      event,
+      changed_attributes: changedAttributes,
+    });
+
+    let shouldRelease = false;
+
+    if (event === "conversation_updated") {
+      const status = changedAttributes?.status?.current_value;
+      if (status === "resolved" || status === "pending") {
+        shouldRelease = true;
+      } else {
+        return NextResponse.json({ status: "ignored" });
+      }
+    } else if (event === "message_created") {
+      const content = message?.content;
+      if (
+        (message as any)?.message_type === 2 &&
+        typeof content === "string" &&
+        (content.startsWith("Conversation was marked resolved") ||
+          content.startsWith("Conversation was marked pending"))
+      ) {
+        const convoId =
+          (message as any)?.conversation_id ??
+          (payload as any)?.conversation_id;
+        console.info("chatwoot status webhook resolution message", {
+          messageId: message?.id,
+          conversationId: convoId,
+          content,
+        });
+        shouldRelease = true;
+      } else {
+        return NextResponse.json({ status: "ignored" });
+      }
+    } else {
       return NextResponse.json({ status: "ignored" });
     }
 
-    const conversation: Conversation | undefined = payload.conversation;
+    const conversation: Conversation | undefined =
+      payload.conversation || message?.conversation;
     const accountId =
-      payload.account?.id ?? (payload as any)?.account_id;
+      payload.account?.id ??
+      (payload as any)?.account_id ??
+      message?.account?.id ??
+      (message as any)?.account_id;
     const conversationId =
-      conversation?.id ?? (payload as any)?.conversation_id;
-    let status = (conversation as any)?.status ?? (payload as any)?.status;
+      conversation?.id ??
+      (payload as any)?.conversation_id ??
+      (message as any)?.conversation_id;
 
     if (accountId === undefined || conversationId === undefined) {
-      return NextResponse.json(
-        { error: "Invalid payload" },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
     }
 
-    if (!status) {
-      try {
-        const convo = await getConversation(accountId, conversationId);
-        status = convo?.status;
-      } catch (err) {
-        console.error("fetch conversation error", err);
-      }
-    }
-
-    if (status === "open") {
+    if (!shouldRelease) {
       return NextResponse.json({ status: "ignored" });
     }
 
     try {
-      const current = await getConversationLabels(accountId, conversationId);
-      const reserved = Object.values(CONVO_LABELS) as string[];
-      const labels = Array.isArray((current as any)?.payload)
-        ? (current as any).payload.filter(
-            (l: string) => !reserved.includes(l)
-          )
-        : [];
-      await setConversationLabels(accountId, conversationId, labels);
-    } catch (err) {
-      console.error("remove assigned label error", err);
-    }
-
-    try {
-      let freedAgentId =
-        (conversation as any)?.assignee_id ?? (payload as any)?.assignee_id;
-      if (freedAgentId === undefined) {
-        try {
-          const convo = await getConversation(accountId, conversationId);
-          freedAgentId = (convo as any)?.assignee_id;
-        } catch (err) {
-          console.error("fetch assignee error", err);
-        }
-      }
-      if (freedAgentId === undefined) {
-        const assignment = await prisma.agentAssignment.findFirst({
-          where: { activeConversationId: conversationId },
-        });
-        freedAgentId = assignment?.agentId;
-      }
-
-      if (freedAgentId) {
-        await clearActiveConversation(freedAgentId);
-        try {
-          const response = await setAgentAvailability(
-            accountId,
-            freedAgentId,
-            "online"
-          );
-          console.info("set agent online response", response);
-        } catch (err) {
-          console.error("set agent online error", err);
-          await setActiveConversation(freedAgentId, conversationId);
-          return NextResponse.json({ error: "Agent availability update failed" }, { status: 500 });
-        }
-
-        const request = await dequeueRequest();
-        if (request) {
-          try {
-            await setConversationLabels(accountId, request.conversationId, [
-              CONVO_LABELS.assigned,
-            ]);
-          } catch (err) {
-            console.error("set assigned label error", err);
-          }
-          await updateConversation(accountId, request.conversationId, {
-            status: "open",
-            assignee_id: freedAgentId,
-          });
-          await setActiveConversation(freedAgentId, request.conversationId);
-          try {
-            const response = await setAgentAvailability(
-              accountId,
-              freedAgentId,
-              "busy"
-            );
-            console.info("set agent busy response", response);
-          } catch (err) {
-            console.error("set agent busy error", err);
-            await clearActiveConversation(freedAgentId);
-            return NextResponse.json({ error: "Agent availability update failed" }, { status: 500 });
-          }
-          await updateRequest(request.conversationId, {
-            status: "assigned",
-            agentId: freedAgentId,
-          });
-          await sendBotMessage(
-            accountId,
-            request.conversationId,
-            "A human agent will join shortly."
-          );
-        }
-      }
-    } catch (err) {
-      console.error("conversation status change handling error", err);
+      await releaseAgent(accountId, conversationId, conversation);
+    } catch {
+      return NextResponse.json(
+        { error: "Agent availability update failed" },
+        { status: 500 }
+      );
     }
 
     return NextResponse.json({ status: "handled" });
@@ -142,4 +83,3 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Server error" }, { status: 500 });
   }
 }
-

--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -16,6 +16,7 @@ import { tools } from "@/lib/tools/tools";
 import { toResponseMessage } from "@/lib/utils/toResponseMessage";
 import { enqueueRequest, updateRequest } from "@/lib/handoffQueue";
 import { handoffStrategy } from "@/config/handoffStrategy";
+import { releaseAgent } from "@/lib/conversationResolution";
 
 export async function POST(request: Request) {
   try {
@@ -27,11 +28,6 @@ export async function POST(request: Request) {
     }
 
     const message: Message | undefined = payload.message || (payload as Message);
-    const messageType = message?.message_type || message?.type;
-    if (messageType !== "incoming") {
-      return NextResponse.json({ status: "ignored" });
-    }
-
     const conversation: Conversation | undefined =
       message?.conversation || payload.conversation;
     const accountId =
@@ -48,6 +44,33 @@ export async function POST(request: Request) {
       (message as any)?.inbox_id ??
       (payload as any)?.inbox_id;
     const content = message?.content;
+    const messageId = message?.id;
+    const messageType = message?.message_type || message?.type;
+
+    if (
+      (message as any)?.message_type === 2 &&
+      typeof content === "string" &&
+      (content.startsWith("Conversation was marked resolved") ||
+        content.startsWith("Conversation was marked pending"))
+    ) {
+      console.info("resolution message", { messageId, conversationId, content });
+      if (accountId === undefined || conversationId === undefined) {
+        return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+      }
+      try {
+        await releaseAgent(accountId, conversationId, conversation);
+      } catch {
+        return NextResponse.json(
+          { error: "Agent availability update failed" },
+          { status: 500 }
+        );
+      }
+      return NextResponse.json({ status: "handled" });
+    }
+
+    if (messageType !== "incoming") {
+      return NextResponse.json({ status: "ignored" });
+    }
 
     console.info("handoff", { accountId, conversationId, inboxId, content });
 

--- a/lib/conversationResolution.ts
+++ b/lib/conversationResolution.ts
@@ -1,0 +1,109 @@
+import prisma from "@/lib/prisma";
+import { clearActiveConversation, setActiveConversation } from "@/lib/agentRotation";
+import {
+  getConversation,
+  getConversationLabels,
+  setAgentAvailability,
+  updateConversation,
+  setConversationLabels,
+} from "@/lib/chatwoot";
+import { sendBotMessage } from "@/lib/chatwootBot";
+import { CONVO_LABELS } from "@/lib/constants";
+import { dequeueRequest, updateRequest } from "@/lib/handoffQueue";
+import type { Conversation } from "@/types/chatwoot";
+
+/**
+ * Clear the active conversation for the freed agent and assign the next request in queue.
+ * Throws an error if updating agent availability fails so callers can respond with 500.
+ */
+export async function releaseAgent(
+  accountId: number,
+  conversationId: number,
+  conversation?: Conversation
+) {
+  try {
+    const current = await getConversationLabels(accountId, conversationId);
+    const reserved = Object.values(CONVO_LABELS) as string[];
+    const labels = Array.isArray((current as any)?.payload)
+      ? (current as any).payload.filter((l: string) => !reserved.includes(l))
+      : [];
+    await setConversationLabels(accountId, conversationId, labels);
+  } catch (err) {
+    console.error("remove assigned label error", err);
+  }
+
+  try {
+    let freedAgentId = (conversation as any)?.assignee_id;
+    if (freedAgentId === undefined) {
+      try {
+        const convo = await getConversation(accountId, conversationId);
+        freedAgentId = (convo as any)?.assignee_id;
+      } catch (err) {
+        console.error("fetch assignee error", err);
+      }
+    }
+    if (freedAgentId === undefined) {
+      const assignment = await prisma.agentAssignment.findFirst({
+        where: { activeConversationId: conversationId },
+      });
+      freedAgentId = assignment?.agentId;
+    }
+
+    if (freedAgentId) {
+      await clearActiveConversation(freedAgentId);
+      try {
+        const response = await setAgentAvailability(
+          accountId,
+          freedAgentId,
+          "online"
+        );
+        console.info("set agent online response", response);
+      } catch (err) {
+        console.error("set agent online error", err);
+        await setActiveConversation(freedAgentId, conversationId);
+        throw new Error("Agent availability update failed");
+      }
+
+      const request = await dequeueRequest();
+      if (request) {
+        try {
+          await setConversationLabels(accountId, request.conversationId, [
+            CONVO_LABELS.assigned,
+          ]);
+        } catch (err) {
+          console.error("set assigned label error", err);
+        }
+        await updateConversation(accountId, request.conversationId, {
+          status: "open",
+          assignee_id: freedAgentId,
+        });
+        await setActiveConversation(freedAgentId, request.conversationId);
+        try {
+          const response = await setAgentAvailability(
+            accountId,
+            freedAgentId,
+            "busy"
+          );
+          console.info("set agent busy response", response);
+        } catch (err) {
+          console.error("set agent busy error", err);
+          await clearActiveConversation(freedAgentId);
+          throw new Error("Agent availability update failed");
+        }
+        await updateRequest(request.conversationId, {
+          status: "assigned",
+          agentId: freedAgentId,
+        });
+        await sendBotMessage(
+          accountId,
+          request.conversationId,
+          "A human agent will join shortly."
+        );
+      }
+    }
+  } catch (err) {
+    console.error("conversation status change handling error", err);
+    throw err;
+  }
+}
+


### PR DESCRIPTION
## Summary
- free agents when `conversation_updated` or system `message_created` events mark a conversation resolved or pending
- extract agent release workflow into a shared helper

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b61f7815ac83339f2c675483cda1c4