### PR TITLE
Add strong Chatwoot webhook typings

### DIFF
--- a/app/api/chatwoot-status-webhook/route.ts
+++ b/app/api/chatwoot-status-webhook/route.ts
@@ -1,16 +1,24 @@
 import { NextResponse } from "next/server";
-import type { ChatwootEvent, Conversation, Message } from "@/types/chatwoot";
+import type {
+  ChatwootEvent,
+  Conversation,
+  Message,
+  ConversationUpdatedPayload,
+  ConversationStatusChangedPayload,
+} from "@/types/chatwoot";
 import { releaseAgent } from "@/lib/conversationResolution";
 import { CONVO_LABELS } from "@/lib/constants";
 
 export async function POST(request: Request) {
   try {
-    const incoming = (await request.json()) as any;
+    const incoming = await request.json();
     const payload: ChatwootEvent = incoming.data ?? incoming;
 
-    const event = (payload as any)?.event || (payload as any)?.type;
-    const changedAttributes = (payload as any)?.changed_attributes;
-    const message: Message | undefined = (payload as any)?.message;
+    const event = payload.event ?? payload.type;
+    const changedAttributes =
+      "changed_attributes" in payload ? payload.changed_attributes : undefined;
+    const message: Message | undefined =
+      "message" in payload ? payload.message : undefined;
     console.info("chatwoot status webhook", {
       event,
       changed_attributes: changedAttributes,
@@ -19,8 +27,8 @@ export async function POST(request: Request) {
     let shouldRelease = false;
 
     if (event === "conversation_status_changed") {
-      const status = (payload as any)?.status;
-      const previous = (payload as any)?.previous_status;
+      const { status, previous_status: previous } =
+        payload as ConversationStatusChangedPayload;
       if (
         (status === "resolved" || status === "pending") &&
         status !== previous
@@ -28,10 +36,9 @@ export async function POST(request: Request) {
         shouldRelease = true;
       }
     } else if (event === "conversation_updated") {
-      const changes = Object.assign(
-        {},
-        ...((changedAttributes as any[]) ?? [])
-      );
+      const { changed_attributes } =
+        payload as ConversationUpdatedPayload;
+      const changes = Object.assign({}, ...(changed_attributes ?? []));
       const status = changes?.status?.current_value;
       const labels = changes?.labels;
       if (status === "resolved" || status === "pending") {
@@ -42,10 +49,10 @@ export async function POST(request: Request) {
       ) {
         shouldRelease = true;
       }
-    } else if (event === "message_created") {
-      const content = message?.content;
+    } else if (event === "message_created" && message) {
+      const content = message.content;
       if (
-        (message as any)?.message_type === 2 &&
+        message.message_type === 2 &&
         typeof content === "string" &&
         content.startsWith("Conversation was marked")
       ) {
@@ -57,13 +64,13 @@ export async function POST(request: Request) {
       payload.conversation || message?.conversation;
     const accountId =
       payload.account?.id ??
-      (payload as any)?.account_id ??
+      payload.account_id ??
       message?.account?.id ??
-      (message as any)?.account_id;
+      message?.account_id;
     const conversationId =
       conversation?.id ??
-      (payload as any)?.conversation_id ??
-      (message as any)?.conversation_id;
+      payload.conversation_id ??
+      message?.conversation_id;
 
     if (accountId === undefined || conversationId === undefined) {
       return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
@@ -73,11 +80,11 @@ export async function POST(request: Request) {
       return NextResponse.json({ status: "ignored" });
     }
 
-    if (event === "message_created") {
+    if (event === "message_created" && message) {
       console.info("chatwoot status webhook resolution message", {
-        messageId: message?.id,
+        messageId: message.id,
         conversationId,
-        content: message?.content,
+        content: message.content,
       });
     }
 

--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -1,5 +1,9 @@
 import { NextResponse } from "next/server";
-import type { ChatwootEvent, Message, Conversation } from "@/types/chatwoot";
+import type {
+  ChatwootEvent,
+  MessageCreatedPayload,
+  Conversation,
+} from "@/types/chatwoot";
 import prisma from "@/lib/prisma";
 import { getNextAgent, setActiveConversation } from "@/lib/agentRotation";
 import { sendBotMessage } from "@/lib/chatwootBot";
@@ -20,35 +24,36 @@ import { releaseAgent } from "@/lib/conversationResolution";
 
 export async function POST(request: Request) {
   try {
-    const incoming = (await request.json()) as any;
+    const incoming = await request.json();
     const payload: ChatwootEvent = incoming.data ?? incoming;
 
-    if (incoming.event !== "message_created") {
+    if (payload.event !== "message_created") {
       return NextResponse.json({ status: "ignored" });
     }
 
-    const message: Message | undefined = payload.message || (payload as Message);
+    const {
+      message,
+      conversation: payloadConversation,
+      account,
+      account_id,
+      conversation_id,
+      inbox_id,
+    } = payload as MessageCreatedPayload;
+
     const conversation: Conversation | undefined =
-      message?.conversation || payload.conversation;
+      message.conversation || payloadConversation;
     const accountId =
-      payload.account?.id ??
-      message?.account?.id ??
-      (message as any)?.account_id ??
-      (payload as any)?.account_id;
+      account?.id ?? message.account?.id ?? message.account_id ?? account_id;
     const conversationId =
-      conversation?.id ??
-      (message as any)?.conversation_id ??
-      (payload as any)?.conversation_id;
+      conversation?.id ?? message.conversation_id ?? conversation_id;
     const inboxId =
-      (conversation as any)?.inbox_id ??
-      (message as any)?.inbox_id ??
-      (payload as any)?.inbox_id;
-    const content = message?.content;
-    const messageId = message?.id;
-    const messageType = message?.message_type || message?.type;
+      conversation?.inbox_id ?? message.inbox_id ?? inbox_id;
+    const content = message.content;
+    const messageId = message.id;
+    const messageType = message.message_type ?? message.type;
 
     if (
-      (message as any)?.message_type === 2 &&
+      message.message_type === 2 &&
       typeof content === "string" &&
       (content.startsWith("Conversation was marked resolved") ||
         content.startsWith("Conversation was marked as pending"))

--- a/types/chatwoot.ts
+++ b/types/chatwoot.ts
@@ -6,6 +6,8 @@ interface Account {
 
 export interface Conversation {
   id: number;
+  status?: string;
+  inbox_id?: number;
   account?: Account;
   [key: string]: any;
 }
@@ -13,17 +15,44 @@ export interface Conversation {
 export interface Message {
   id?: number;
   content: string;
-  message_type?: string;
+  message_type?: number | string;
   type?: string;
   conversation?: Conversation;
+  conversation_id?: number;
   account?: Account;
+  account_id?: number;
+  inbox_id?: number;
   [key: string]: any;
 }
 
-export interface ChatwootEvent {
-  message?: Message;
-  conversation?: Conversation;
+interface BasePayload {
+  event: "message_created" | "conversation_updated" | "conversation_status_changed";
+  type?: string;
   account?: Account;
-  [key: string]: any;
+  account_id?: number;
+  conversation?: Conversation;
+  conversation_id?: number;
+  inbox_id?: number;
 }
+
+export interface MessageCreatedPayload extends BasePayload {
+  event: "message_created";
+  message: Message;
+}
+
+export interface ConversationUpdatedPayload extends BasePayload {
+  event: "conversation_updated";
+  changed_attributes?: Record<string, any>[];
+}
+
+export interface ConversationStatusChangedPayload extends BasePayload {
+  event: "conversation_status_changed";
+  status?: string;
+  previous_status?: string;
+}
+
+export type ChatwootEvent =
+  | MessageCreatedPayload
+  | ConversationUpdatedPayload
+  | ConversationStatusChangedPayload;
 


### PR DESCRIPTION
## Summary
- define structured Chatwoot event payloads and union type
- apply new typings in chatwoot webhook handlers with safe destructuring

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6d7c5c244833399078b1cf8ea0c40