### PR TITLE
fix chatwoot webhook event detection

### DIFF
--- a/app/api/chatwoot-status-webhook/route.ts
+++ b/app/api/chatwoot-status-webhook/route.ts
@@ -11,9 +11,10 @@ import { CONVO_LABELS } from "@/lib/constants";
 export async function POST(request: Request) {
   try {
     const incoming = await request.json();
-    const payload: ChatwootEvent = incoming.data ?? incoming;
+    const payload: ChatwootEvent | { type?: string; [key: string]: any } =
+      incoming.data ?? incoming;
 
-    const event = payload.event ?? payload.type;
+    const event = "event" in payload ? payload.event : payload.type;
     const changedAttributes =
       "changed_attributes" in payload ? payload.changed_attributes : undefined;
     const message: Message | undefined =


### PR DESCRIPTION
## Summary
- handle Chatwoot webhook payloads without `event` using explicit property check

## Testing
- `npx tsc -p tsconfig.json && echo 'tsc completed successfully'`


------
https://chatgpt.com/codex/tasks/task_e_68b72eb50d5883338108f7f6c0dba0c2