### PR TITLE
Add detailed logging for Chatwoot webhook and agent release

### DIFF
--- a/app/api/chatwoot-status-webhook/route.ts
+++ b/app/api/chatwoot-status-webhook/route.ts
@@ -15,14 +15,8 @@ export async function POST(request: Request) {
       incoming.data ?? incoming;
 
     const event = "event" in payload ? payload.event : payload.type;
-    const changedAttributes =
-      "changed_attributes" in payload ? payload.changed_attributes : undefined;
     const message: Message | undefined =
       "message" in payload ? payload.message : undefined;
-    console.info("chatwoot status webhook", {
-      event,
-      changed_attributes: changedAttributes,
-    });
 
     const accountId =
       payload.account?.id ??
@@ -40,6 +34,11 @@ export async function POST(request: Request) {
     }
 
     if (event === "conversation_status_changed") {
+      console.info("chatwoot status webhook", {
+        event,
+        conversationId,
+        changed_attributes: (payload as any).changed_attributes,
+      });
       const { status, previous_status: previous } =
         payload as ConversationStatusChangedPayload;
       if (
@@ -57,9 +56,19 @@ export async function POST(request: Request) {
         return NextResponse.json({ status: "handled" });
       }
     } else if (event === "conversation_updated") {
+      console.info("chatwoot status webhook", {
+        event,
+        conversationId,
+        changed_attributes: (payload as any).changed_attributes,
+      });
       const { changed_attributes } =
         payload as ConversationUpdatedPayload;
       const changes = Object.assign({}, ...(changed_attributes ?? []));
+      console.info("chatwoot status webhook changes", {
+        event,
+        conversationId,
+        changes,
+      });
       const status = changes?.status?.current_value;
       const labels = changes?.labels;
       if (
@@ -78,6 +87,11 @@ export async function POST(request: Request) {
         return NextResponse.json({ status: "handled" });
       }
     } else if (event === "message_created" && message) {
+      console.info("chatwoot status webhook", {
+        event,
+        conversationId,
+        changed_attributes: (payload as any).changed_attributes,
+      });
       const content = message.content;
       if (
         message.message_type === 2 &&

--- a/lib/conversationResolution.ts
+++ b/lib/conversationResolution.ts
@@ -21,6 +21,8 @@ export async function releaseAgent(
   conversationId: number,
   conversation?: Conversation
 ) {
+  let freedAgentId: number | undefined;
+  let outcome = "no-agent";
   try {
     const current = await getConversationLabels(accountId, conversationId);
     const reserved = Object.values(CONVO_LABELS) as string[];
@@ -33,7 +35,7 @@ export async function releaseAgent(
   }
 
   try {
-    let freedAgentId = (conversation as any)?.assignee_id;
+    freedAgentId = (conversation as any)?.assignee_id;
     if (freedAgentId === undefined) {
       try {
         const convo = await getConversation(accountId, conversationId);
@@ -99,11 +101,21 @@ export async function releaseAgent(
           request.conversationId,
           "A human agent will join shortly."
         );
+        outcome = "assigned";
+      } else {
+        outcome = "released";
       }
     }
   } catch (err) {
     console.error("conversation status change handling error", err);
+    outcome = "error";
     throw err;
+  } finally {
+    console.info("releaseAgent", {
+      agentId: freedAgentId,
+      conversationId,
+      outcome,
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- log event, conversation, and changed attributes before each Chatwoot status branch
- record normalized change set
- log agent ID, conversation ID, and outcome in `releaseAgent`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b757115fa8833399a5c95688558a5d