### PR TITLE
Validate Chatwoot status webhook payloads

### DIFF
--- a/app/api/chatwoot-status-webhook/route.ts
+++ b/app/api/chatwoot-status-webhook/route.ts
@@ -29,8 +29,9 @@ export async function POST(request: Request) {
       message?.conversation?.id ??
       message?.conversation_id;
 
-    if (accountId === undefined || conversationId === undefined) {
-      return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+    if (!conversationId || !accountId) {
+      console.warn("chatwoot webhook: missing IDs", payload);
+      return NextResponse.json({ status: "ignored" }, { status: 400 });
     }
 
     if (event === "conversation_status_changed") {

--- a/tests/chatwootWebhook.test.js
+++ b/tests/chatwootWebhook.test.js
@@ -98,3 +98,38 @@ test('chatwoot status webhook handles label removal', async () => {
   assert.strictEqual(releaseAgentMock.mock.calls.length, 1);
   releaseAgentMock.mock.resetCalls();
 });
+
+test('chatwoot status webhook returns 400 for missing IDs', async () => {
+  const payload = { data: { event: 'conversation_status_changed' } };
+  const req = new Request('http://localhost', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+  const res = await statusPost(req);
+  const data = await res.json();
+  assert.strictEqual(res.status, 400);
+  assert.strictEqual(data.status, 'ignored');
+  assert.strictEqual(releaseAgentMock.mock.calls.length, 0);
+  releaseAgentMock.mock.resetCalls();
+});
+
+test('chatwoot webhook returns 400 for missing IDs', async () => {
+  const payload = {
+    event: 'message_created',
+    data: {
+      event: 'message_created',
+      message: {
+        message_type: 2,
+        content: 'Conversation was marked as pending',
+      },
+    },
+  };
+  const req = new Request('http://localhost', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+  const res = await webhookPost(req);
+  assert.strictEqual(res.status, 400);
+  assert.strictEqual(releaseAgentMock.mock.calls.length, 0);
+  releaseAgentMock.mock.resetCalls();
+});


### PR DESCRIPTION
## Summary
- Warn and ignore Chatwoot status webhooks lacking account or conversation IDs
- Add tests ensuring malformed status and general webhooks return 400

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b76ba8ee988333ae557514f82df841