### PR TITLE
Handle nested Chatwoot webhook payload structure

### DIFF
--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import type {
-  ChatwootEvent,
+  ChatwootWebhookPayload,
   MessageCreatedPayload,
   Conversation,
 } from "@/types/chatwoot";
@@ -24,9 +24,9 @@ import { releaseAgent } from "@/lib/conversationResolution";
 
 export async function POST(request: Request) {
   try {
-    const payload: ChatwootEvent = await request.json();
+    const payload = (await request.json()) as ChatwootWebhookPayload;
     const event = payload.event;
-    const data = payload.data ?? payload;
+    const data = "data" in payload ? payload.data : payload;
     const conversation: Conversation | undefined =
       data.conversation ?? (event.startsWith("conversation_") ? (data as any) : undefined);
     if (!conversation) {

--- a/types/chatwoot.ts
+++ b/types/chatwoot.ts
@@ -56,3 +56,7 @@ export type ChatwootEvent =
   | ConversationUpdatedPayload
   | ConversationStatusChangedPayload;
 
+export type ChatwootWebhookPayload =
+  | ChatwootEvent
+  | { event: ChatwootEvent["event"]; data: ChatwootEvent };
+


### PR DESCRIPTION
## Summary
- support webhook payloads optionally wrapped under `data`
- safely unwrap nested Chatwoot webhook events in API route

## Testing
- `npm test` *(fails: chatwoot webhook handles pending system message; chatwoot webhook returns 400 for missing IDs)*

------
https://chatgpt.com/codex/tasks/task_e_68b80f9d6eec8333af0bb7bbf09ed3e0