### PR TITLE
refactor: extract IDs helper for chatwoot payloads

### DIFF
--- a/app/api/chatwoot-status-webhook/route.ts
+++ b/app/api/chatwoot-status-webhook/route.ts
@@ -7,6 +7,7 @@ import type {
 } from "@/types/chatwoot";
 import { releaseAgent } from "@/lib/conversationResolution";
 import { CONVO_LABELS } from "@/lib/constants";
+import { extractIds } from "@/lib/extractIds";
 
 export async function POST(request: Request) {
   try {
@@ -18,16 +19,7 @@ export async function POST(request: Request) {
     const message: Message | undefined =
       "message" in payload ? payload.message : undefined;
 
-    const accountId =
-      payload.account?.id ??
-      payload.account_id ??
-      message?.account?.id ??
-      message?.account_id;
-    const conversationId =
-      payload.conversation?.id ??
-      payload.conversation_id ??
-      message?.conversation?.id ??
-      message?.conversation_id;
+    const { accountId, conversationId } = extractIds(payload);
 
     if (!conversationId || !accountId) {
       console.warn("chatwoot webhook: missing IDs", payload);

--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -21,37 +21,35 @@ import { toResponseMessage } from "@/lib/utils/toResponseMessage";
 import { enqueueRequest, updateRequest } from "@/lib/handoffQueue";
 import { handoffStrategy } from "@/config/handoffStrategy";
 import { releaseAgent } from "@/lib/conversationResolution";
+import { extractIds } from "@/lib/extractIds";
 
 export async function POST(request: Request) {
   try {
     const payload = (await request.json()) as ChatwootWebhookPayload;
     const event = payload.event;
     const data = "data" in payload ? payload.data : payload;
+    const { message } = data as MessageCreatedPayload;
+    let { accountId, conversationId } = extractIds(data);
     const conversation: Conversation | undefined =
-      data.conversation ?? (event.startsWith("conversation_") ? (data as any) : undefined);
-    if (!conversation) {
-      console.info("chatwoot webhook", { event });
-    }
-    if (event !== "message_created" || !conversation) {
+      data.conversation ??
+      (event.startsWith("conversation_") ? (data as any) : undefined) ??
+      message?.conversation;
+    if (event !== "message_created") {
       return NextResponse.json({ status: "ignored" });
     }
-    const accountId =
-      conversation.account?.id ?? conversation.account_id;
-    const conversationId = conversation.id;
-    const inboxId = conversation.inbox_id;
-    const { message } = data as MessageCreatedPayload;
-    const content = message.content;
-    const messageId = message.id;
-    const messageType = message.message_type ?? message.type;
+    const content = message?.content;
+    const messageId = message?.id;
+    const messageType = message?.message_type ?? message?.type;
 
     if (
-      message.message_type === 2 &&
+      message?.message_type === 2 &&
       typeof content === "string" &&
       (content.startsWith("Conversation was marked resolved") ||
         content.startsWith("Conversation was marked as pending"))
     ) {
       console.info("resolution message", { messageId, conversationId, content });
       if (accountId === undefined || conversationId === undefined) {
+        console.warn("chatwoot webhook: missing IDs", data);
         return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
       }
       try {
@@ -64,6 +62,14 @@ export async function POST(request: Request) {
       }
       return NextResponse.json({ status: "handled" });
     }
+
+    if (!conversation) {
+      console.info("chatwoot webhook", { event });
+      return NextResponse.json({ status: "ignored" });
+    }
+    accountId ??= conversation.account?.id ?? conversation.account_id;
+    conversationId ??= conversation.id;
+    const inboxId = conversation.inbox_id;
 
     if (messageType !== "incoming") {
       return NextResponse.json({ status: "ignored" });

--- a/lib/extractIds.ts
+++ b/lib/extractIds.ts
@@ -1,0 +1,20 @@
+export function extractIds(payload: any): { accountId?: number; conversationId?: number } {
+  const conversationId =
+    payload?.conversation?.id ??
+    payload?.conversation_id ??
+    payload?.id ??
+    payload?.message?.conversation?.id ??
+    payload?.message?.conversation_id;
+
+  const accountId =
+    payload?.conversation?.account_id ??
+    payload?.conversation?.account?.id ??
+    payload?.account?.id ??
+    payload?.account_id ??
+    payload?.message?.conversation?.account_id ??
+    payload?.message?.conversation?.account?.id ??
+    payload?.message?.account?.id ??
+    payload?.message?.account_id;
+
+  return { accountId, conversationId };
+}


### PR DESCRIPTION
## Summary
- add extractIds helper to pull account and conversation IDs from varied Chatwoot payload shapes
- reuse helper in chatwoot webhook handlers and log missing ID cases

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68b812367188833387bbf7c1a59beda5