### PR TITLE
Handle conversation updates in webhook

### DIFF
--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -3,6 +3,8 @@ import type {
   ChatwootWebhookPayload,
   MessageCreatedPayload,
   Conversation,
+  ConversationStatusChangedPayload,
+  ConversationUpdatedPayload,
 } from "@/types/chatwoot";
 import prisma from "@/lib/prisma";
 import { getNextAgent, setActiveConversation } from "@/lib/agentRotation";
@@ -32,11 +34,76 @@ export async function POST(request: Request) {
     let { accountId, conversationId } = extractIds(data);
     const conversation: Conversation | undefined =
       data.conversation ??
-      (event.startsWith("conversation_") ? (data as any) : undefined) ??
+      (event?.startsWith("conversation_") ? (data as any) : undefined) ??
       message?.conversation;
-    if (event !== "message_created") {
-      return NextResponse.json({ status: "ignored" });
+
+    switch (event) {
+      case "message_created":
+        break;
+      case "conversation_status_changed":
+      case "conversation_updated": {
+        if (!conversation) {
+          console.info("chatwoot webhook", { event });
+          return NextResponse.json({ status: "ignored" });
+        }
+        accountId ??= conversation.account?.id ?? conversation.account_id;
+        conversationId ??= conversation.id;
+        if (accountId === undefined || conversationId === undefined) {
+          console.warn("chatwoot webhook: missing IDs", data);
+          return NextResponse.json({ error: "Invalid payload" }, {
+            status: 400,
+          });
+        }
+        console.info("chatwoot webhook", {
+          event,
+          conversationId,
+          changed_attributes: (data as any).changed_attributes,
+        });
+
+        if (event === "conversation_status_changed") {
+          const { status, previous_status: previous } =
+            data as ConversationStatusChangedPayload;
+          if (
+            (status === "resolved" || status === "pending") &&
+            status !== previous
+          ) {
+            try {
+              await releaseAgent(accountId, conversationId, conversation);
+            } catch {
+              return NextResponse.json(
+                { error: "Agent availability update failed" },
+                { status: 500 }
+              );
+            }
+            return NextResponse.json({ status: "handled" });
+          }
+        } else {
+          const { changed_attributes } = data as ConversationUpdatedPayload;
+          const changes = Object.assign({}, ...(changed_attributes ?? []));
+          const status = changes?.status?.current_value;
+          const labels = changes?.labels;
+          if (
+            status === "resolved" ||
+            status === "pending" ||
+            (Array.isArray(labels) && !labels.includes(CONVO_LABELS.assigned))
+          ) {
+            try {
+              await releaseAgent(accountId, conversationId, conversation);
+            } catch {
+              return NextResponse.json(
+                { error: "Agent availability update failed" },
+                { status: 500 }
+              );
+            }
+            return NextResponse.json({ status: "handled" });
+          }
+        }
+        return NextResponse.json({ status: "ignored" });
+      }
+      default:
+        return NextResponse.json({ status: "ignored" });
     }
+
     const content = message?.content;
     const messageId = message?.id;
     const messageType = message?.message_type ?? message?.type;
@@ -48,7 +115,11 @@ export async function POST(request: Request) {
         content.startsWith("Conversation was marked as pending"))
     ) {
       console.info("resolution message", { messageId, conversationId, content });
-      if (accountId === undefined || conversationId === undefined) {
+      if (
+        accountId === undefined ||
+        conversationId === undefined ||
+        !conversation
+      ) {
         console.warn("chatwoot webhook: missing IDs", data);
         return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
       }

--- a/tests/chatwootWebhook.test.js
+++ b/tests/chatwootWebhook.test.js
@@ -58,6 +58,49 @@ test('chatwoot webhook handles pending system message', async () => {
   releaseAgentMock.mock.resetCalls();
 });
 
+test('chatwoot webhook handles conversation_status_changed', async () => {
+  const payload = {
+    event: 'conversation_status_changed',
+    data: {
+      event: 'conversation_status_changed',
+      status: 'resolved',
+      previous_status: 'open',
+      account: { id: 5 },
+      conversation: { id: 5 },
+    },
+  };
+  const req = new Request('http://localhost', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+  const res = await webhookPost(req);
+  const data = await res.json();
+  assert.strictEqual(data.status, 'handled');
+  assert.strictEqual(releaseAgentMock.mock.calls.length, 1);
+  releaseAgentMock.mock.resetCalls();
+});
+
+test('chatwoot webhook handles label removal', async () => {
+  const payload = {
+    event: 'conversation_updated',
+    data: {
+      event: 'conversation_updated',
+      changed_attributes: [{ labels: [] }],
+      account: { id: 6 },
+      conversation: { id: 6 },
+    },
+  };
+  const req = new Request('http://localhost', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+  const res = await webhookPost(req);
+  const data = await res.json();
+  assert.strictEqual(data.status, 'handled');
+  assert.strictEqual(releaseAgentMock.mock.calls.length, 1);
+  releaseAgentMock.mock.resetCalls();
+});
+
 test('chatwoot status webhook handles conversation_status_changed', async () => {
   const payload = {
     data: {


### PR DESCRIPTION
## Summary
- add switch over Chatwoot webhook event types
- handle conversation status and label updates by releasing assigned agents
- validate conversations before use
- add tests for new conversation update cases
- validate presence of account and conversation IDs before releasing agents

## Testing
- `npm test`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68b815533ee4833393079f0df6a6308d