### PR TITLE
Handle Chatwoot conversation resolution events

### DIFF
--- a/app/api/chatwoot-status-webhook/route.ts
+++ b/app/api/chatwoot-status-webhook/route.ts
@@ -26,17 +26,15 @@ export async function POST(request: Request) {
     }
 
     if (event === "conversation_status_changed") {
-      console.info("chatwoot status webhook", {
-        event,
-        conversationId,
-        changed_attributes: (payload as any).changed_attributes,
-      });
       const { status, previous_status: previous } =
         payload as ConversationStatusChangedPayload;
-      if (
-        (status === "resolved" || status === "pending") &&
-        status !== previous
-      ) {
+      console.info("chatwoot status webhook status change", {
+        event,
+        conversationId,
+        status,
+        previous_status: previous,
+      });
+      if (previous === "open" && status !== "open") {
         try {
           await releaseAgent(accountId, conversationId, payload.conversation);
         } catch {
@@ -48,7 +46,7 @@ export async function POST(request: Request) {
         return NextResponse.json({ status: "handled" });
       }
     } else if (event === "conversation_updated") {
-      console.info("chatwoot status webhook", {
+      console.info("chatwoot status webhook conversation update", {
         event,
         conversationId,
         changed_attributes: (payload as any).changed_attributes,
@@ -96,10 +94,11 @@ export async function POST(request: Request) {
         return NextResponse.json({ status: "handled" });
       }
     } else if (event === "message_created" && message) {
-      console.info("chatwoot status webhook", {
+      console.info("chatwoot status webhook message", {
         event,
         conversationId,
-        changed_attributes: (payload as any).changed_attributes,
+        messageId: message.id,
+        message_type: message.message_type,
       });
       const content = message.content;
       if (
@@ -110,7 +109,7 @@ export async function POST(request: Request) {
         console.info("chatwoot status webhook resolution message", {
           messageId: message.id,
           conversationId,
-          content: message.content,
+          content,
         });
         try {
           await releaseAgent(accountId, conversationId, payload.conversation);

--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -38,6 +38,43 @@ export async function POST(request: Request) {
 
     switch (event) {
       case "message_created": {
+        if (message?.message_type === 2) {
+          const content = message.content;
+          if (
+            typeof content === "string" &&
+            content.startsWith("Conversation was marked")
+          ) {
+            accountId ??= message.account?.id;
+            conversationId ??= message.conversation?.id;
+            console.info("chatwoot webhook resolution message", {
+              event,
+              conversationId,
+              messageId: message.id,
+              content,
+            });
+            if (accountId === undefined || conversationId === undefined) {
+              console.warn("chatwoot webhook: missing IDs", payload);
+              return NextResponse.json(
+                { error: "Invalid payload" },
+                { status: 400 }
+              );
+            }
+            try {
+              await releaseAgent(
+                accountId,
+                conversationId,
+                conversation ?? message.conversation
+              );
+            } catch {
+              return NextResponse.json(
+                { error: "Agent availability update failed" },
+                { status: 500 }
+              );
+            }
+            return NextResponse.json({ status: "handled" });
+          }
+          return NextResponse.json({ status: "ignored" });
+        }
         if (message?.message_type !== 0) {
           return NextResponse.json({ status: "ignored" });
         }
@@ -57,19 +94,16 @@ export async function POST(request: Request) {
             status: 400,
           });
         }
-        console.info("chatwoot webhook", {
-          event,
-          conversationId,
-          changed_attributes: (payload as any).changed_attributes,
-        });
-
         if (event === "conversation_status_changed") {
           const { status, previous_status: previous } =
             payload as ConversationStatusChangedPayload;
-          if (
-            (status === "resolved" || status === "pending") &&
-            status !== previous
-          ) {
+          console.info("chatwoot webhook status change", {
+            event,
+            conversationId,
+            status,
+            previous_status: previous,
+          });
+          if (previous === "open" && status !== "open") {
             try {
               await releaseAgent(accountId, conversationId, conversation);
             } catch {
@@ -81,6 +115,11 @@ export async function POST(request: Request) {
             return NextResponse.json({ status: "handled" });
           }
         } else {
+          console.info("chatwoot webhook conversation update", {
+            event,
+            conversationId,
+            changed_attributes: (payload as any).changed_attributes,
+          });
           const changes = Object.assign(
             {},
             ...(payload.changed_attributes || [])

--- a/tests/chatwootWebhook.test.js
+++ b/tests/chatwootWebhook.test.js
@@ -57,7 +57,7 @@ test('chatwoot webhook releases agent on conversation_status_changed', async () 
     event: 'conversation_status_changed',
     data: {
       event: 'conversation_status_changed',
-      status: 'resolved',
+      status: 'snoozed',
       previous_status: 'open',
       account: { id: 1 },
       conversation: { id: 1 },
@@ -71,6 +71,8 @@ test('chatwoot webhook releases agent on conversation_status_changed', async () 
   const data = await res.json();
   assert.strictEqual(data.status, 'handled');
   assert.strictEqual(releaseAgentMock.mock.calls.length, 1);
+  assert.strictEqual(sendBotMessageMock.mock.calls.length, 0);
+  assert.strictEqual(getProviderMock.mock.calls.length, 0);
   resetMocks();
 });
 
@@ -193,7 +195,7 @@ test('chatwoot webhook queues request when no agent available', async () => {
   resetMocks();
 });
 
-test('chatwoot webhook ignores system message', async () => {
+test('chatwoot webhook releases agent on resolution system message', async () => {
   const payload = {
     event: 'message_created',
     data: {
@@ -212,9 +214,8 @@ test('chatwoot webhook ignores system message', async () => {
   });
   const res = await webhookPost(req);
   const data = await res.json();
-  assert.strictEqual(data.status, 'ignored');
-  assert.strictEqual(sendBotMessageMock.mock.calls.length, 0);
-  assert.strictEqual(getProviderMock.mock.calls.length, 0);
+  assert.strictEqual(data.status, 'handled');
+  assert.strictEqual(releaseAgentMock.mock.calls.length, 1);
   resetMocks();
 });
 


### PR DESCRIPTION
## Summary
- Release agents when conversation status changes from open to another state using root `status` and `previous_status`
- Release agents on system messages that mark conversations
- Add structured logging and tests for conversation resolution

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8757460b88333b6bc4fb657e353af