### PR TITLE
fix: narrow conversation update payload

### DIFF
--- a/app/api/chatwoot-status-webhook/route.ts
+++ b/app/api/chatwoot-status-webhook/route.ts
@@ -3,6 +3,7 @@ import type {
   ChatwootEvent,
   Message,
   ConversationStatusChangedPayload,
+  ConversationUpdatedPayload,
 } from "@/types/chatwoot";
 import { releaseAgent } from "@/lib/conversationResolution";
 import { CONVO_LABELS } from "@/lib/constants";
@@ -51,10 +52,9 @@ export async function POST(request: Request) {
         conversationId,
         changed_attributes: (payload as any).changed_attributes,
       });
-      const changes = Object.assign(
-        {},
-        ...(payload.changed_attributes || [])
-      );
+      const { changed_attributes = [] } =
+        payload as ConversationUpdatedPayload;
+      const changes = Object.assign({}, ...changed_attributes);
       console.info("chatwoot status webhook changes", {
         event,
         conversationId,

--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -4,6 +4,7 @@ import type {
   MessageCreatedPayload,
   Conversation,
   ConversationStatusChangedPayload,
+  ConversationUpdatedPayload,
 } from "@/types/chatwoot";
 import prisma from "@/lib/prisma";
 import { getNextAgent, setActiveConversation } from "@/lib/agentRotation";
@@ -120,10 +121,9 @@ export async function POST(request: Request) {
             conversationId,
             changed_attributes: (payload as any).changed_attributes,
           });
-          const changes = Object.assign(
-            {},
-            ...(payload.changed_attributes || [])
-          );
+          const { changed_attributes = [] } =
+            payload as ConversationUpdatedPayload;
+          const changes = Object.assign({}, ...changed_attributes);
           const statusChange = changes.status as
             | { current_value?: string; previous_value?: string }
             | undefined;


### PR DESCRIPTION
## Summary
- narrow Chatwoot conversation_updated payload to access changed_attributes safely

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b879d65b1c833381d275329deabfa1