### PR TITLE
Split Chatwoot message and status webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,10 @@ If Redis runs on a dynamically mapped port (e.g. `docker port` or `docker compos
 
    `SESSION_RETENTION_DAYS` controls how long ended sessions are kept before cleanup (defaults to 30 days).
    Session messages cached in Redis are retained indefinitely until the session is cleaned up.
-   The Chatwoot variables configure the webhook endpoints to send automated replies and handle status changes in your Chatwoot instance.
-   When Chatwoot and the AI service run inside the same Docker Compose network, use `http://ai-agent:3001/api/chatwoot-webhook` for message events and add another webhook subscribed to `conversation_updated` pointing to `http://ai-agent:3001/api/chatwoot-status-webhook`.
+    The Chatwoot variables configure the webhook endpoints to send automated replies and handle status changes in your Chatwoot instance.
+    Create two webhooks in Chatwoot:
+    - `http://ai-agent:3001/api/chatwoot-webhook` subscribed only to `message_created`.
+    - `http://ai-agent:3001/api/chatwoot-status-webhook` subscribed to `conversation_status_changed`, `conversation_updated`, and `message_created` (system events).
 
    The `AGENT_TOKENS` environment variable supplies per-agent access tokens in JSON form, e.g. `{ "1": "secret" }`. Store these secrets outside of source control (such as a `.env` file or your hosting platform's secret manager). To rotate a token, update the JSON with the new value and redeploy or restart the service so it reads the updated mapping.
 

--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -3,8 +3,6 @@ import type {
   ChatwootWebhookPayload,
   MessageCreatedPayload,
   Conversation,
-  ConversationStatusChangedPayload,
-  ConversationUpdatedPayload,
 } from "@/types/chatwoot";
 import prisma from "@/lib/prisma";
 import { getNextAgent, setActiveConversation } from "@/lib/agentRotation";
@@ -22,7 +20,6 @@ import { tools } from "@/lib/tools/tools";
 import { toResponseMessage } from "@/lib/utils/toResponseMessage";
 import { enqueueRequest, updateRequest } from "@/lib/handoffQueue";
 import { handoffStrategy } from "@/config/handoffStrategy";
-import { releaseAgent } from "@/lib/conversationResolution";
 import { extractIds } from "@/lib/extractIds";
 
 export async function POST(request: Request) {
@@ -33,143 +30,17 @@ export async function POST(request: Request) {
     const { message } = payload as MessageCreatedPayload;
     let { accountId, conversationId } = extractIds(payload);
     const conversation: Conversation | undefined =
-      payload.conversation ??
-      (event?.startsWith("conversation_") ? (payload as any) : undefined) ??
-      message?.conversation;
+      payload.conversation ?? message?.conversation;
 
-    switch (event) {
-      case "message_created": {
-        if (message?.message_type === 2) {
-          const content = message.content;
-          if (
-            typeof content === "string" &&
-            content.startsWith("Conversation was marked")
-          ) {
-            accountId ??= message.account?.id;
-            conversationId ??= message.conversation?.id;
-            console.info("chatwoot webhook resolution message", {
-              event,
-              conversationId,
-              messageId: message.id,
-              content,
-            });
-            if (accountId === undefined || conversationId === undefined) {
-              console.warn("chatwoot webhook: missing IDs", payload);
-              return NextResponse.json(
-                { error: "Invalid payload" },
-                { status: 400 }
-              );
-            }
-            try {
-              await releaseAgent(
-                accountId,
-                conversationId,
-                conversation ?? message.conversation
-              );
-            } catch {
-              return NextResponse.json(
-                { error: "Agent availability update failed" },
-                { status: 500 }
-              );
-            }
-            return NextResponse.json({ status: "handled" });
-          }
-          return NextResponse.json({ status: "ignored" });
-        }
-        if (message?.message_type !== 0) {
-          return NextResponse.json({ status: "ignored" });
-        }
-        break;
-      }
-      case "conversation_status_changed":
-      case "conversation_updated": {
-        if (!conversation) {
-          console.info("chatwoot webhook", { event });
-          return NextResponse.json({ status: "ignored" });
-        }
-        accountId ??= conversation.account?.id ?? conversation.account_id;
-        conversationId ??= conversation.id;
-        if (accountId === undefined || conversationId === undefined) {
-          console.warn("chatwoot webhook: missing IDs", payload);
-          return NextResponse.json({ error: "Invalid payload" }, {
-            status: 400,
-          });
-        }
-        if (event === "conversation_status_changed") {
-          const { status, previous_status: previous } =
-            payload as ConversationStatusChangedPayload;
-          console.info("chatwoot webhook status change", {
-            event,
-            conversationId,
-            status,
-            previous_status: previous,
-          });
-          if (previous === "open" && status !== "open") {
-            try {
-              await releaseAgent(accountId, conversationId, conversation);
-            } catch {
-              return NextResponse.json(
-                { error: "Agent availability update failed" },
-                { status: 500 }
-              );
-            }
-            return NextResponse.json({ status: "handled" });
-          }
-        } else {
-          console.info("chatwoot webhook conversation update", {
-            event,
-            conversationId,
-            changed_attributes: (payload as any).changed_attributes,
-          });
-          const { changed_attributes = [] } =
-            payload as ConversationUpdatedPayload;
-          const changes = Object.assign({}, ...changed_attributes);
-          const statusChange = changes.status as
-            | { current_value?: string; previous_value?: string }
-            | undefined;
-          const labelListChange =
-            (changes.label_list ?? changes.cached_label_list) as
-              | { current_value?: string[]; previous_value?: string[] }
-              | undefined;
-          const statusCurrent = statusChange?.current_value;
-          const statusPrevious = statusChange?.previous_value;
-          const labelsCurrent = Array.isArray(labelListChange?.current_value)
-            ? labelListChange?.current_value
-            : undefined;
-          const labelsPrevious = Array.isArray(labelListChange?.previous_value)
-            ? labelListChange?.previous_value
-            : undefined;
-          if (
-            (statusChange &&
-              (statusCurrent === "resolved" || statusCurrent === "pending") &&
-              statusCurrent !== statusPrevious) ||
-            (Array.isArray(labelsCurrent) &&
-              labelsPrevious?.includes(CONVO_LABELS.assigned) &&
-              !labelsCurrent.includes(CONVO_LABELS.assigned))
-          ) {
-            try {
-              await releaseAgent(accountId, conversationId, conversation);
-            } catch {
-              return NextResponse.json(
-                { error: "Agent availability update failed" },
-                { status: 500 }
-              );
-            }
-            return NextResponse.json({ status: "handled" });
-          }
-        }
-        return NextResponse.json({ status: "ignored" });
-      }
-      default:
-        return NextResponse.json({ status: "ignored" });
+    if (event !== "message_created") {
+      return NextResponse.json({ status: "ignored" });
+    }
+
+    if (message?.message_type !== 0 && message?.message_type !== "incoming") {
+      return NextResponse.json({ status: "ignored" });
     }
 
     const content = message?.content;
-    const messageType = message?.message_type ?? message?.type;
-
-    if (messageType !== 0 && messageType !== "incoming") {
-      return NextResponse.json({ status: "ignored" });
-    }
 
     if (!conversation) {
       console.info("chatwoot webhook", { event });

--- a/tests/chatwootWebhook.test.js
+++ b/tests/chatwootWebhook.test.js
@@ -38,6 +38,7 @@ const prisma = require('../lib/prisma.ts').default;
 prisma.handoffRequest.findUnique = mock.fn(async () => null);
 
 const { POST: webhookPost } = require('../app/api/chatwoot-webhook/route.ts');
+const { POST: statusWebhookPost } = require('../app/api/chatwoot-status-webhook/route.ts');
 
 function resetMocks() {
   releaseAgentMock.mock.resetCalls();
@@ -52,7 +53,7 @@ function resetMocks() {
   prisma.handoffRequest.findUnique.mock.resetCalls();
 }
 
-test('chatwoot webhook releases agent on conversation_status_changed', async () => {
+test('chatwoot status webhook releases agent on conversation_status_changed', async () => {
   const payload = {
     event: 'conversation_status_changed',
     data: {
@@ -67,7 +68,7 @@ test('chatwoot webhook releases agent on conversation_status_changed', async () 
     method: 'POST',
     body: JSON.stringify(payload),
   });
-  const res = await webhookPost(req);
+  const res = await statusWebhookPost(req);
   const data = await res.json();
   assert.strictEqual(data.status, 'handled');
   assert.strictEqual(releaseAgentMock.mock.calls.length, 1);
@@ -76,7 +77,7 @@ test('chatwoot webhook releases agent on conversation_status_changed', async () 
   resetMocks();
 });
 
-test('chatwoot webhook releases agent on label removal', async () => {
+test('chatwoot status webhook releases agent on label removal', async () => {
   const payload = {
     event: 'conversation_updated',
     data: {
@@ -97,14 +98,14 @@ test('chatwoot webhook releases agent on label removal', async () => {
     method: 'POST',
     body: JSON.stringify(payload),
   });
-  const res = await webhookPost(req);
+  const res = await statusWebhookPost(req);
   const data = await res.json();
   assert.strictEqual(data.status, 'handled');
   assert.strictEqual(releaseAgentMock.mock.calls.length, 1);
   resetMocks();
 });
 
-test('chatwoot webhook releases agent on status update', async () => {
+test('chatwoot status webhook releases agent on status update', async () => {
   const payload = {
     event: 'conversation_updated',
     data: {
@@ -122,7 +123,7 @@ test('chatwoot webhook releases agent on status update', async () => {
     method: 'POST',
     body: JSON.stringify(payload),
   });
-  const res = await webhookPost(req);
+  const res = await statusWebhookPost(req);
   const data = await res.json();
   assert.strictEqual(data.status, 'handled');
   assert.strictEqual(releaseAgentMock.mock.calls.length, 1);
@@ -195,7 +196,7 @@ test('chatwoot webhook queues request when no agent available', async () => {
   resetMocks();
 });
 
-test('chatwoot webhook releases agent on resolution system message', async () => {
+test('chatwoot status webhook releases agent on resolution system message', async () => {
   const payload = {
     event: 'message_created',
     data: {
@@ -212,7 +213,7 @@ test('chatwoot webhook releases agent on resolution system message', async () =>
     method: 'POST',
     body: JSON.stringify(payload),
   });
-  const res = await webhookPost(req);
+  const res = await statusWebhookPost(req);
   const data = await res.json();
   assert.strictEqual(data.status, 'handled');
   assert.strictEqual(releaseAgentMock.mock.calls.length, 1);


### PR DESCRIPTION
## Summary
- Restrict `app/api/chatwoot-webhook` to handle only `message_created` events
- Document setup of separate `chatwoot-webhook` and `chatwoot-status-webhook` in README
- Update tests to verify status webhook processes conversation updates and resolution messages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b88014c0048333a154d7e9ce745b0a