### PR TITLE
Fix Chatwoot webhook message type handling

### DIFF
--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -38,13 +38,15 @@ export async function POST(request: Request) {
     if (event !== "message_created" || !conversation) {
       return NextResponse.json({ status: "ignored" });
     }
+    if (!message) {
+      return NextResponse.json({ status: "ignored" });
+    }
     const accountId =
       conversation.account?.id ?? conversation.account_id;
     const conversationId = conversation.id;
     const inboxId = conversation.inbox_id;
     const content = message.content;
     const messageId = message.id;
-    const messageType = message.message_type ?? message.type;
 
     if (
       message.message_type === 2 &&
@@ -67,7 +69,10 @@ export async function POST(request: Request) {
       return NextResponse.json({ status: "handled" });
     }
 
-    if (messageType !== "incoming") {
+    if (
+      message?.message_type !== 0 &&
+      message?.message_type !== "incoming"
+    ) {
       return NextResponse.json({ status: "ignored" });
     }
 


### PR DESCRIPTION
## Summary
- Safely ignore non-incoming Chatwoot messages by checking for both `0` and `incoming` types
- Guard against undefined `message` payloads in webhook handler

## Testing
- `npm test` *(fails: fail 4)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b000d78c83338de9cda531f1ced4