### PR TITLE
Handle missing Chatwoot IDs

### DIFF
--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -26,18 +26,24 @@ export async function POST(request: Request) {
     }
     const payload = "data" in incoming ? incoming.data : incoming;
     const message = (payload as any).message ?? payload;
+    const conversationId =
+      (message as any).conversation_id ??
+      (message as any).conversation?.id ??
+      (payload as any).id;
+    const accountId =
+      (message as any).account_id ??
+      (message as any).account?.id ??
+      (payload as any).account?.id;
+    if (conversationId === undefined || accountId === undefined) {
+      console.warn("chatwoot webhook missing ids", { accountId, conversationId });
+      return NextResponse.json({ status: "ignored" });
+    }
     const conversation: Conversation | undefined =
       (message as any)?.conversation ??
       (payload as any).conversation ??
       (incoming.event.startsWith("conversation_") ? (payload as any) : undefined);
-    if (!conversation) {
-      console.info("chatwoot webhook", { event: incoming.event });
-      return NextResponse.json({ status: "ignored" });
-    }
-    const accountId =
-      conversation.account?.id ?? conversation.account_id;
-    const conversationId = conversation.id;
-    const inboxId = conversation.inbox_id;
+    const inboxId =
+      (message as any).inbox_id ?? conversation?.inbox_id;
     const content = message.content;
     const messageId = message.id;
     if (

--- a/tests/chatwootWebhook.test.js
+++ b/tests/chatwootWebhook.test.js
@@ -220,7 +220,7 @@ test('chatwoot status webhook releases agent on resolution system message', asyn
   resetMocks();
 });
 
-test('chatwoot webhook returns 400 for missing IDs', async () => {
+test('chatwoot webhook ignores request for missing IDs', async () => {
   const payload = {
     event: 'message_created',
     data: {
@@ -238,7 +238,9 @@ test('chatwoot webhook returns 400 for missing IDs', async () => {
     body: JSON.stringify(payload),
   });
   const res = await webhookPost(req);
-  assert.strictEqual(res.status, 400);
+  const body = await res.json();
+  assert.strictEqual(res.status, 200);
+  assert.strictEqual(body.status, 'ignored');
   assert.strictEqual(sendBotMessageMock.mock.calls.length, 0);
   assert.strictEqual(getProviderMock.mock.calls.length, 0);
   resetMocks();


### PR DESCRIPTION
## Summary
- derive conversation and account IDs from multiple sources in Chatwoot webhook
- ignore and log webhook requests when required IDs are missing
- adjust tests for missing ID behaviour

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9393113c88333a9d67381d7b3f67e