### PR TITLE
Handle missing accountId in status webhook

### DIFF
--- a/app/api/chatwoot-status-webhook/route.ts
+++ b/app/api/chatwoot-status-webhook/route.ts
@@ -21,8 +21,13 @@ export async function POST(request: Request) {
 
     const { accountId, conversationId } = extractIds(payload);
 
-    if (!conversationId || !accountId) {
-      console.warn("chatwoot webhook: missing IDs", payload);
+    if (accountId === undefined) {
+      console.warn("chatwoot status webhook missing account ID", payload);
+      return NextResponse.json({ status: "ignored" });
+    }
+
+    if (conversationId === undefined) {
+      console.warn("chatwoot status webhook missing conversation ID", payload);
       return NextResponse.json({ status: "ignored" }, { status: 400 });
     }
 


### PR DESCRIPTION
## Summary
- warn when `accountId` is missing in Chatwoot status webhook and ignore the event with HTTP 200

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b95cba60b4833381c4c4f6157f18da