### PR TITLE
docs: clarify Chatwoot webhook payload typing

### DIFF
--- a/app/api/chatwoot-status-webhook/route.ts
+++ b/app/api/chatwoot-status-webhook/route.ts
@@ -11,11 +11,13 @@ import { CONVO_LABELS } from "@/lib/constants";
 export async function POST(request: Request) {
   try {
     const incoming = await request.json();
+    // Merge Chatwoot's structured payload with any extra fields we might receive
     const payload = (incoming.data ?? incoming) as ChatwootEvent & Record<
       string,
       any
     >;
 
+    // Chatwoot may send either `event` or `type`; fall back accordingly
     const event = payload.event ?? payload.type;
     const message: Message | undefined = payload.message;
 


### PR DESCRIPTION
## Summary
- explain payload typing for Chatwoot status webhook

## Testing
- `npm test`
- `npx tsc -p tsconfig.json --noEmit` *(fails: Property 'type' does not exist on type 'never')*

------
https://chatgpt.com/codex/tasks/task_e_68bab7dfc4e083339e0baeea0a35eec2