### PR TITLE
fix: cast chatwoot webhook payloads

### DIFF
--- a/app/api/chatwoot-status-webhook/route.ts
+++ b/app/api/chatwoot-status-webhook/route.ts
@@ -48,7 +48,7 @@ export async function POST(request: Request) {
     }
 
     if (event === "conversation_status_changed") {
-      const typedPayload: ConversationStatusChangedPayload = payload;
+      const typedPayload = payload as ConversationStatusChangedPayload;
       const { status, previous_status: previous } = typedPayload;
       console.info("chatwoot status webhook status change", {
         event,
@@ -72,7 +72,7 @@ export async function POST(request: Request) {
         return NextResponse.json({ status: "handled" });
       }
     } else if (event === "conversation_updated") {
-      const typedPayload: ConversationUpdatedPayload = payload;
+      const typedPayload = payload as ConversationUpdatedPayload;
       console.info("chatwoot status webhook conversation update", {
         event,
         conversationId,


### PR DESCRIPTION
## Summary
- assert payload types for conversation status change and update events

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68bacb9362d4833397f739801d40c520