### PR TITLE
Ensure conversation reopened and assigned before notification

### DIFF
--- a/lib/conversationResolution.ts
+++ b/lib/conversationResolution.ts
@@ -4,10 +4,13 @@ import {
   getConversation,
   getConversationLabels,
   setAgentAvailability,
-  updateConversation,
   setConversationLabels,
 } from "@/lib/chatwoot";
-import { sendBotMessage } from "@/lib/chatwootBot";
+import {
+  sendBotMessage,
+  toggleConversationStatus,
+  assignConversation,
+} from "@/lib/chatwootBot";
 import { CONVO_LABELS } from "@/lib/constants";
 import { dequeueRequest, updateRequest } from "@/lib/handoffQueue";
 import type { Conversation } from "@/types/chatwoot";
@@ -75,10 +78,16 @@ export async function releaseAgent(
         } catch (err) {
           console.error("set assigned label error", err);
         }
-        await updateConversation(accountId, request.conversationId, {
-          status: "open",
-          assignee_id: freedAgentId,
-        });
+        await toggleConversationStatus(
+          accountId,
+          request.conversationId,
+          "open"
+        );
+        await assignConversation(
+          accountId,
+          request.conversationId,
+          freedAgentId
+        );
         await setActiveConversation(freedAgentId, request.conversationId);
         try {
           const response = await setAgentAvailability(

--- a/tests/releaseAgent.test.js
+++ b/tests/releaseAgent.test.js
@@ -1,0 +1,45 @@
+const assert = require('assert');
+const { test, mock } = require('node:test');
+require('ts-node/register/transpile-only');
+require('tsconfig-paths/register');
+
+const conversationResolution = require('../lib/conversationResolution.ts');
+const chatwoot = require('../lib/chatwoot.ts');
+const chatwootBot = require('../lib/chatwootBot.ts');
+const agentRotation = require('../lib/agentRotation.ts');
+const handoffQueue = require('../lib/handoffQueue.ts');
+
+// Mock external dependencies
+mock.method(chatwoot, 'getConversationLabels', async () => ({ payload: [] }));
+mock.method(chatwoot, 'setConversationLabels', async () => {});
+mock.method(chatwoot, 'setAgentAvailability', async () => {});
+mock.method(agentRotation, 'clearActiveConversation', async () => {});
+mock.method(agentRotation, 'setActiveConversation', async () => {});
+mock.method(handoffQueue, 'updateRequest', async () => {});
+
+const accountId = 1;
+const releasedConversationId = 1;
+const queuedConversationId = 2;
+const freedAgentId = 5;
+
+let status = 'resolved';
+
+const dequeueRequestMock = mock.method(handoffQueue, 'dequeueRequest', async () => ({ conversationId: queuedConversationId }));
+const toggleMock = mock.method(chatwootBot, 'toggleConversationStatus', async () => {
+  status = 'open';
+});
+const assignMock = mock.method(chatwootBot, 'assignConversation', async () => {});
+const sendMock = mock.method(chatwootBot, 'sendBotMessage', async () => {
+  assert.strictEqual(status, 'open');
+});
+
+test('releaseAgent opens and assigns conversation before notifying', async () => {
+  await conversationResolution.releaseAgent(accountId, releasedConversationId, { assignee_id: freedAgentId });
+
+  assert.strictEqual(dequeueRequestMock.mock.calls.length, 1);
+  assert.strictEqual(toggleMock.mock.calls.length, 1);
+  assert.deepStrictEqual(toggleMock.mock.calls[0].arguments, [accountId, queuedConversationId, 'open']);
+  assert.strictEqual(assignMock.mock.calls.length, 1);
+  assert.deepStrictEqual(assignMock.mock.calls[0].arguments, [accountId, queuedConversationId, freedAgentId]);
+  assert.strictEqual(sendMock.mock.calls.length, 1);
+});


### PR DESCRIPTION
## Summary
- Reopen and assign queued conversations in `releaseAgent` using `toggleConversationStatus` and `assignConversation`
- Verify conversation is opened before notifying user via new unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb04430a4483338fa8114b70419e3f