### PR TITLE
Avoid releasing unassigned Chatwoot conversations

### DIFF
--- a/app/api/chatwoot-status-webhook/route.ts
+++ b/app/api/chatwoot-status-webhook/route.ts
@@ -56,7 +56,14 @@ export async function POST(request: Request) {
         status,
         previous_status: previous,
       });
-      if (previous === "open" && status !== "open") {
+      const isAssigned = Boolean(
+        typedPayload.conversation?.assignee_id ||
+          typedPayload.conversation?.labels?.includes(CONVO_LABELS.assigned) ||
+          typedPayload.conversation?.label_list?.includes(
+            CONVO_LABELS.assigned
+          )
+      );
+      if (previous === "open" && status !== "open" && isAssigned) {
         try {
           await releaseAgent(
             accountId,
@@ -98,9 +105,18 @@ export async function POST(request: Request) {
       const labelsPrevious = Array.isArray(labelListChange?.previous_value)
         ? labelListChange?.previous_value
         : undefined;
+      const isAssigned = Boolean(
+        typedPayload.conversation?.assignee_id ||
+          labelsCurrent?.includes(CONVO_LABELS.assigned) ||
+          typedPayload.conversation?.labels?.includes(CONVO_LABELS.assigned) ||
+          typedPayload.conversation?.label_list?.includes(
+            CONVO_LABELS.assigned
+          )
+      );
       if (
-        statusCurrent === "resolved" ||
-        statusCurrent === "pending" ||
+        ((statusCurrent === "resolved" || statusCurrent === "pending") &&
+          changes.status?.previous_value === "open" &&
+          isAssigned) ||
         (Array.isArray(labelsCurrent) &&
           labelsPrevious?.includes(CONVO_LABELS.assigned) &&
           !labelsCurrent.includes(CONVO_LABELS.assigned))

--- a/tests/chatwootWebhook.test.js
+++ b/tests/chatwootWebhook.test.js
@@ -61,7 +61,7 @@ test('chatwoot status webhook releases agent on conversation_status_changed', as
       status: 'snoozed',
       previous_status: 'open',
       account: { id: 1 },
-      conversation: { id: 1 },
+      conversation: { id: 1, assignee_id: 10 },
     },
   };
   const req = new Request('http://localhost', {
@@ -116,7 +116,7 @@ test('chatwoot status webhook releases agent on status update', async () => {
         },
       ],
       account: { id: 3 },
-      conversation: { id: 3 },
+      conversation: { id: 3, assignee_id: 30 },
     },
   };
   const req = new Request('http://localhost', {
@@ -127,6 +127,53 @@ test('chatwoot status webhook releases agent on status update', async () => {
   const data = await res.json();
   assert.strictEqual(data.status, 'handled');
   assert.strictEqual(releaseAgentMock.mock.calls.length, 1);
+  resetMocks();
+});
+
+test('chatwoot status webhook ignores pending status change when unassigned', async () => {
+  const payload = {
+    event: 'conversation_status_changed',
+    data: {
+      event: 'conversation_status_changed',
+      status: 'pending',
+      previous_status: 'open',
+      account: { id: 4 },
+      conversation: { id: 4 },
+    },
+  };
+  const req = new Request('http://localhost', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+  const res = await statusWebhookPost(req);
+  const data = await res.json();
+  assert.strictEqual(data.status, 'ignored');
+  assert.strictEqual(releaseAgentMock.mock.calls.length, 0);
+  resetMocks();
+});
+
+test('chatwoot status webhook ignores pending update when unassigned', async () => {
+  const payload = {
+    event: 'conversation_updated',
+    data: {
+      event: 'conversation_updated',
+      changed_attributes: [
+        {
+          status: { previous_value: 'open', current_value: 'pending' },
+        },
+      ],
+      account: { id: 5 },
+      conversation: { id: 5 },
+    },
+  };
+  const req = new Request('http://localhost', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+  const res = await statusWebhookPost(req);
+  const data = await res.json();
+  assert.strictEqual(data.status, 'ignored');
+  assert.strictEqual(releaseAgentMock.mock.calls.length, 0);
   resetMocks();
 });
 


### PR DESCRIPTION
## Summary
- Release agents only when conversations were open and assigned
- Guard status updates to pending/resolved without assignment
- Cover unassigned pending transitions with regression tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb381e1b4c8333a34a5f6cffd31419