### PR TITLE
Cache Chatwoot conversation messages in Redis

### DIFF
--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -3,6 +3,7 @@ import type { ChatwootWebhookPayload, Conversation } from "@/types/chatwoot";
 import prisma from "@/lib/prisma";
 import { getNextAgent, setActiveConversation } from "@/lib/agentRotation";
 import { sendBotMessage } from "@/lib/chatwootBot";
+import redis from "@/lib/redis";
 import handOff from "@/lib/handoff";
 import {
   getConversation,
@@ -81,6 +82,52 @@ export async function POST(request: Request) {
             createdAt,
           },
         });
+        try {
+          if (
+            typeof (redis as any)?.exists === "function" &&
+            typeof (redis as any)?.rpush === "function" &&
+            typeof (redis as any)?.pipeline === "function"
+          ) {
+            const key = `chatwoot:${accountId}:${conversationId}`;
+            const exists = await redis.exists(key);
+            if (!exists) {
+              const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
+              const recent = await prisma.conversationMessage.findMany({
+                where: {
+                  conversationId,
+                  createdAt: { gte: since },
+                },
+                orderBy: { createdAt: "asc" },
+              });
+              if (recent.length) {
+                const pipeline = redis.pipeline();
+                for (const m of recent) {
+                  pipeline.rpush(key, JSON.stringify(m));
+                }
+                pipeline.expire(key, 86400);
+                await pipeline.exec();
+              }
+            } else {
+              const pipeline = redis.pipeline();
+              pipeline.rpush(
+                key,
+                JSON.stringify({
+                  id: messageId,
+                  conversationId,
+                  inboxId,
+                  sender,
+                  content:
+                    typeof content === "string" ? content : JSON.stringify(content),
+                  createdAt,
+                })
+              );
+              pipeline.expire(key, 86400);
+              await pipeline.exec();
+            }
+          }
+        } catch (err) {
+          console.error("conversation redis log error", err);
+        }
       } catch (err) {
         console.error("conversation message log error", err);
       }

--- a/lib/chatwootBot.ts
+++ b/lib/chatwootBot.ts
@@ -1,4 +1,5 @@
 import prisma from "@/lib/prisma";
+import redis from "@/lib/redis";
 
 const CHATWOOT_URL = (process.env.CHATWOOT_URL || "").replace(/\/$/, "");
 const CHATWOOT_BOT_TOKEN = process.env.CHATWOOT_BOT_TOKEN || "";
@@ -65,6 +66,30 @@ export async function sendBotMessage(
           createdAt,
         },
       });
+      try {
+        if (
+          typeof (redis as any)?.rpush === "function" &&
+          typeof (redis as any)?.pipeline === "function"
+        ) {
+          const key = `chatwoot:${accountId}:${conversationId}`;
+          const pipeline = redis.pipeline();
+          pipeline.rpush(
+            key,
+            JSON.stringify({
+              id: res.id,
+              conversationId: res.conversation_id ?? conversationId,
+              inboxId,
+              sender: "bot",
+              content,
+              createdAt,
+            })
+          );
+          pipeline.expire(key, 86400);
+          await pipeline.exec();
+        }
+      } catch (err) {
+        console.error("bot message redis log error", err);
+      }
     }
   } catch (err) {
     console.error("log bot message error", err);


### PR DESCRIPTION
## Summary
- cache every Chatwoot message in Redis using per-conversation keys
- repopulate Redis with last day of ConversationMessage records if key missing
- log bot replies to the same Redis history

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc449b97c08333b813b9311275e1ba