### PR TITLE
Disconnect Prisma after chatwoot webhook tests

### DIFF
--- a/tests/chatwootWebhook.test.js
+++ b/tests/chatwootWebhook.test.js
@@ -66,6 +66,10 @@ redis.pipeline = mock.fn(() => redisPipelineMock);
 
 const { POST: webhookPost } = require('../app/api/chatwoot-webhook/route.ts');
 const { POST: statusWebhookPost } = require('../app/api/chatwoot-status-webhook/route.ts');
+ 
+test.after(async () => {
+  await prisma.$disconnect();
+});
 
 function resetMocks() {
   releaseAgentMock.mock.resetCalls();


### PR DESCRIPTION
## Summary
- ensure Prisma client disconnects when chatwoot webhook tests complete

## Testing
- `npm test tests/chatwootWebhook.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd54f40a248333b1664749ddf84f72