### PR TITLE
Disconnect Redis in chatwoot webhook tests

### DIFF
--- a/tests/chatwootWebhook.test.js
+++ b/tests/chatwootWebhook.test.js
@@ -69,6 +69,9 @@ const { POST: statusWebhookPost } = require('../app/api/chatwoot-status-webhook/
  
 test.after(async () => {
   await prisma.$disconnect();
+  if (typeof redis.disconnect === 'function') {
+    await redis.disconnect();
+  }
 });
 
 function resetMocks() {


### PR DESCRIPTION
## Summary
- disconnect Redis in `test.after` hook for `chatwootWebhook` tests to ensure clean shutdown

## Testing
- `npm test tests/chatwootWebhook.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd63e07c6083339533061134c7cebf