### PR TITLE
test: mock prisma agent assignment in releaseAgent test

### DIFF
--- a/tests/releaseAgent.test.js
+++ b/tests/releaseAgent.test.js
@@ -8,6 +8,7 @@ const chatwoot = require('../lib/chatwoot.ts');
 const chatwootBot = require('../lib/chatwootBot.ts');
 const agentRotation = require('../lib/agentRotation.ts');
 const handoffQueue = require('../lib/handoffQueue.ts');
+const prisma = require('../lib/prisma.ts').default;
 
 // Mock external dependencies
 mock.method(chatwoot, 'getConversationLabels', async () => ({ payload: [] }));
@@ -21,6 +22,12 @@ const accountId = 1;
 const releasedConversationId = 1;
 const queuedConversationId = 2;
 const freedAgentId = 5;
+
+prisma.agentAssignment.findFirst = mock.fn(async () => ({ agentId: freedAgentId }));
+
+test.after(async () => {
+  await prisma.$disconnect();
+});
 
 let status = 'resolved';
 


### PR DESCRIPTION
## Summary
- mock `prisma.agentAssignment.findFirst` to avoid DB access
- disconnect Prisma client after tests

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68bd65bafddc8333a0b3a57e977c3995