### PR TITLE
Disconnect Redis in releaseAgent test

### DIFF
--- a/tests/releaseAgent.test.js
+++ b/tests/releaseAgent.test.js
@@ -9,6 +9,7 @@ const chatwootBot = require('../lib/chatwootBot.ts');
 const agentRotation = require('../lib/agentRotation.ts');
 const handoffQueue = require('../lib/handoffQueue.ts');
 const prisma = require('../lib/prisma.ts').default;
+const redis = require('../lib/redis.ts').default;
 
 // Mock external dependencies
 mock.method(chatwoot, 'getConversationLabels', async () => ({ payload: [] }));
@@ -27,6 +28,9 @@ prisma.agentAssignment.findFirst = mock.fn(async () => ({ agentId: freedAgentId 
 
 test.after(async () => {
   await prisma.$disconnect();
+  if (typeof redis.disconnect === 'function') {
+    redis.disconnect();
+  }
 });
 
 let status = 'resolved';


### PR DESCRIPTION
## Summary
- Import Redis client in `releaseAgent` test
- Disconnect Redis after tests to avoid hanging connections

## Testing
- `npm test tests/releaseAgent.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68be0e3437a88333bf4231562fbfb3b8