### PR TITLE
feat: add guardrails for chatwoot webhook

### DIFF
--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -21,6 +21,10 @@ import { releaseAgent } from "@/lib/conversationResolution";
 import { CHATWOOT_SYSTEM_PROMPT } from "@/config/constants";
 import { getConversationKey } from "@/lib/getConversationKey";
 import { getConversationHistory } from "@/lib/getConversationHistory";
+import {
+  runRelevanceGuardrail,
+  runJailbreakGuardrail,
+} from "@/lib/guardrails";
 
 export async function POST(request: Request) {
   try {
@@ -453,6 +457,35 @@ export async function POST(request: Request) {
     try {
       let replyText = "";
       const history = await getConversationHistory(conversationKey);
+
+      try {
+        const conversationInput = history
+          .filter((m) => m.role !== "developer")
+          .map((m) => m.content.map((c) => c.text).join(" "))
+          .join(" ");
+        const userInput =
+          typeof content === "string"
+            ? content
+            : typeof content === "object"
+              ? JSON.stringify(content)
+              : String(content ?? "");
+        const relevance = await runRelevanceGuardrail({
+          input: conversationInput,
+        });
+        const jailbreak = await runJailbreakGuardrail({ input: userInput });
+        if (relevance.tripwireTriggered || jailbreak.tripwireTriggered) {
+          await sendBotMessage(
+            accountId,
+            conversationId,
+            "I can't assist with that request.",
+            { private: mode !== "auto" }
+          );
+          return NextResponse.json({ status: "guardrail" });
+        }
+      } catch (err) {
+        console.error("guardrail check error", err);
+      }
+
       const events = getProvider(undefined)(
         [toResponseMessage("system", CHATWOOT_SYSTEM_PROMPT), ...history],
         tools,

--- a/tests/chatwootWebhook.test.js
+++ b/tests/chatwootWebhook.test.js
@@ -47,6 +47,18 @@ const setConversationLabelsMock = mock.method(chatwoot, 'setConversationLabels',
 const { CONVO_LABELS } = require('../lib/constants.ts');
 const { CHATWOOT_SYSTEM_PROMPT } = require('../config/constants.ts');
 
+const guardrails = require('../lib/guardrails.ts');
+const runRelevanceGuardrailMock = mock.method(
+  guardrails,
+  'runRelevanceGuardrail',
+  async () => ({ tripwireTriggered: false })
+);
+const runJailbreakGuardrailMock = mock.method(
+  guardrails,
+  'runJailbreakGuardrail',
+  async () => ({ tripwireTriggered: false })
+);
+
 const prisma = require('../lib/prisma.ts').default;
 prisma.handoffRequest.findUnique = mock.fn(async () => null);
 prisma.conversationMessage = {
@@ -95,6 +107,8 @@ function resetMocks() {
   redisPipelineMock.rpush.mock.resetCalls();
   redisPipelineMock.expire.mock.resetCalls();
   redisPipelineMock.exec.mock.resetCalls();
+  runRelevanceGuardrailMock.mock.resetCalls();
+  runJailbreakGuardrailMock.mock.resetCalls();
 }
 
 test('chatwoot status webhook releases agent on conversation_status_changed', async () => {
@@ -325,6 +339,62 @@ test('chatwoot webhook processes incoming message', async () => {
   assert.strictEqual(call[0], 7);
   assert.strictEqual(call[1], 7);
   assert.strictEqual(call[2], 'hi');
+  resetMocks();
+});
+
+test('chatwoot webhook sends fallback when relevance guardrail triggers', async () => {
+  runRelevanceGuardrailMock.mock.mockImplementationOnce(async () => ({
+    tripwireTriggered: true,
+  }));
+  const payload = {
+    event: 'message_created',
+    data: {
+      event: 'message_created',
+      message: {
+        message_type: 0,
+        content: 'off topic',
+        account: { id: 9 },
+        conversation: { id: 9, inbox_id: 1, status: 'resolved', account_id: 9 },
+      },
+    },
+  };
+  const req = new Request('http://localhost', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+  const res = await webhookPost(req);
+  const body = await res.json();
+  assert.strictEqual(body.status, 'guardrail');
+  assert.strictEqual(sendBotMessageMock.mock.calls[0].arguments[2], "I can't assist with that request.");
+  assert.strictEqual(getProviderMock.mock.calls.length, 0);
+  resetMocks();
+});
+
+test('chatwoot webhook sends fallback when jailbreak guardrail triggers', async () => {
+  runJailbreakGuardrailMock.mock.mockImplementationOnce(async () => ({
+    tripwireTriggered: true,
+  }));
+  const payload = {
+    event: 'message_created',
+    data: {
+      event: 'message_created',
+      message: {
+        message_type: 0,
+        content: 'jailbreak attempt',
+        account: { id: 10 },
+        conversation: { id: 10, inbox_id: 1, status: 'resolved', account_id: 10 },
+      },
+    },
+  };
+  const req = new Request('http://localhost', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+  const res = await webhookPost(req);
+  const body = await res.json();
+  assert.strictEqual(body.status, 'guardrail');
+  assert.strictEqual(sendBotMessageMock.mock.calls[0].arguments[2], "I can't assist with that request.");
+  assert.strictEqual(getProviderMock.mock.calls.length, 0);
   resetMocks();
 });
 


### PR DESCRIPTION
## Summary
- add relevance and jailbreak guardrail checks in Chatwoot webhook
- return safe fallback when guardrails trigger
- test webhook guardrail paths

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be1443fddc8333912882a98ec54522