### PR TITLE
Fix assistant message content type

### DIFF
--- a/lib/utils/toResponseMessage.ts
+++ b/lib/utils/toResponseMessage.ts
@@ -1,11 +1,13 @@
 export type ResponseMessage = {
   role: string;
-  content: { type: "input_text"; text: string }[];
+  content: { type: "input_text" | "output_text"; text: string }[];
 };
 
 export function toResponseMessage(role: string, text: string): ResponseMessage {
   return {
     role,
-    content: [{ type: "input_text", text }],
+    content: [
+      { type: role === "assistant" ? "output_text" : "input_text", text },
+    ],
   };
 }


### PR DESCRIPTION
## Summary
- Return `output_text` for assistant messages and `input_text` for others in `toResponseMessage`
- Update `ResponseMessage` type to include both content types

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bedbddedf883339a06fb02aa7ca9d8