### PR TITLE
Rely on webhook for bot message logging

### DIFF
--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -68,74 +68,81 @@ export async function POST(request: Request) {
       content !== undefined
     ) {
       try {
-        const createdAtRaw = (message as any)?.created_at;
-        const createdAt = createdAtRaw
-          ? new Date(
-              typeof createdAtRaw === "number"
-                ? createdAtRaw * 1000
-                : createdAtRaw
-            )
-          : undefined;
-        await prisma.conversationMessage.create({
-          data: {
-            id: messageId,
-            conversationId,
-            inboxId,
-            conversationKey,
-            sender,
-            content:
-              typeof content === "string"
-                ? content
-                : JSON.stringify(content),
-            createdAt,
-          },
+        const existing = await prisma.conversationMessage.findUnique({
+          where: { id: messageId },
         });
-        try {
-          if (
-            typeof (redis as any)?.exists === "function" &&
-            typeof (redis as any)?.rpush === "function" &&
-            typeof (redis as any)?.pipeline === "function"
-          ) {
-            const key = conversationKey;
-            const exists = await redis.exists(key);
-            if (!exists) {
-              const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
-              const recent = await prisma.conversationMessage.findMany({
-                where: {
-                  conversationKey,
-                  createdAt: { gte: since },
-                },
-                orderBy: { createdAt: "asc" },
-              });
-              if (recent.length) {
-                const pipeline = redis.pipeline();
-                for (const m of recent) {
-                  pipeline.rpush(key, JSON.stringify(m));
+        if (!existing) {
+          const createdAtRaw = (message as any)?.created_at;
+          const createdAt = createdAtRaw
+            ? new Date(
+                typeof createdAtRaw === "number"
+                  ? createdAtRaw * 1000
+                  : createdAtRaw
+              )
+            : undefined;
+          await prisma.conversationMessage.create({
+            data: {
+              id: messageId,
+              conversationId,
+              inboxId,
+              conversationKey,
+              sender,
+              content:
+                typeof content === "string"
+                  ? content
+                  : JSON.stringify(content),
+              createdAt,
+            },
+          });
+          try {
+            if (
+              typeof (redis as any)?.exists === "function" &&
+              typeof (redis as any)?.rpush === "function" &&
+              typeof (redis as any)?.pipeline === "function"
+            ) {
+              const key = conversationKey;
+              const keyExists = await redis.exists(key);
+              if (!keyExists) {
+                const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
+                const recent = await prisma.conversationMessage.findMany({
+                  where: {
+                    conversationKey,
+                    createdAt: { gte: since },
+                  },
+                  orderBy: { createdAt: "asc" },
+                });
+                if (recent.length) {
+                  const pipeline = redis.pipeline();
+                  for (const m of recent) {
+                    pipeline.rpush(key, JSON.stringify(m));
+                  }
+                  pipeline.expire(key, 86400);
+                  await pipeline.exec();
                 }
+              } else {
+                const pipeline = redis.pipeline();
+                pipeline.rpush(
+                  key,
+                  JSON.stringify({
+                    id: messageId,
+                    conversationId,
+                    inboxId,
+                    conversationKey,
+                    sender,
+                    content:
+                      typeof content === "string"
+                        ? content
+                        : JSON.stringify(content),
+                    createdAt,
+                  })
+                );
                 pipeline.expire(key, 86400);
                 await pipeline.exec();
               }
-            } else {
-              const pipeline = redis.pipeline();
-              pipeline.rpush(
-                key,
-                JSON.stringify({
-                  id: messageId,
-                  conversationId,
-                  inboxId,
-                  conversationKey,
-                  sender,
-                  content:
-                    typeof content === "string" ? content : JSON.stringify(content),
-                  createdAt,
-                })
-              );
-              pipeline.expire(key, 86400);
-              await pipeline.exec();
             }
+          } catch (err) {
+            console.error("conversation redis log error", err);
           }
-        } catch (err) {
-          console.error("conversation redis log error", err);
         }
       } catch (err) {
         console.error("conversation message log error", err);

--- a/lib/chatwootBot.ts
+++ b/lib/chatwootBot.ts
@@ -1,7 +1,3 @@
-import prisma from "@/lib/prisma";
-import redis from "@/lib/redis";
-import { getConversationKey } from "@/lib/getConversationKey";
-
 const CHATWOOT_URL = (process.env.CHATWOOT_URL || "").replace(/\/$/, "");
 const CHATWOOT_BOT_TOKEN = process.env.CHATWOOT_BOT_TOKEN || "";
 
@@ -39,7 +35,7 @@ export async function sendBotMessage(
   content: string,
   options: Record<string, any> = {}
 ) {
-  const res = await chatwootBotFetch(
+  return chatwootBotFetch(
     `/api/v1/accounts/${accountId}/conversations/${conversationId}/messages`,
     {
       method: "POST",
@@ -47,63 +43,6 @@ export async function sendBotMessage(
       body: JSON.stringify({ content, message_type: "outgoing", ...options }),
     }
   );
-
-  try {
-    const inboxId = (res as any)?.inbox_id ?? (res as any)?.conversation?.inbox_id;
-    if (res?.id !== undefined && inboxId !== undefined) {
-      const conversationKey = getConversationKey(
-        accountId,
-        res.conversation_id ?? conversationId,
-        inboxId
-      );
-      const createdAtRaw = (res as any)?.created_at;
-      const createdAt = createdAtRaw
-        ? new Date(
-            typeof createdAtRaw === "number" ? createdAtRaw * 1000 : createdAtRaw
-          )
-        : undefined;
-      await prisma.conversationMessage.create({
-        data: {
-          id: res.id,
-          conversationId: res.conversation_id ?? conversationId,
-          inboxId,
-          conversationKey,
-          sender: "bot",
-          content,
-          createdAt,
-        },
-      });
-      try {
-        if (
-          typeof (redis as any)?.rpush === "function" &&
-          typeof (redis as any)?.pipeline === "function"
-        ) {
-          const key = conversationKey;
-          const pipeline = redis.pipeline();
-          pipeline.rpush(
-            key,
-            JSON.stringify({
-              id: res.id,
-              conversationId: res.conversation_id ?? conversationId,
-              inboxId,
-              conversationKey,
-              sender: "bot",
-              content,
-              createdAt,
-            })
-          );
-          pipeline.expire(key, 86400);
-          await pipeline.exec();
-        }
-      } catch (err) {
-        console.error("bot message redis log error", err);
-      }
-    }
-  } catch (err) {
-    console.error("log bot message error", err);
-  }
-
-  return res;
 }
 
 export async function assignConversation(


### PR DESCRIPTION
## Summary
- remove direct Prisma logging from `sendBotMessage`
- skip duplicate messages in Chatwoot webhook before logging

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bef4c6c18c8333aa0566c57cd8300e