### PR TITLE
Only guardrail latest user message in Chatwoot webhook

### DIFF
--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -466,19 +466,15 @@ export async function POST(request: Request) {
       const history = await getConversationHistory(conversationKey);
 
       try {
-        const conversationInput = history
-          .filter((m) => m.role !== "developer")
-          .map((m) => m.content.map((c) => c.text).join(" "))
-          .join(" ");
         const userInput =
           typeof content === "string"
             ? content
             : typeof content === "object"
               ? JSON.stringify(content)
               : String(content ?? "");
-        const relevance = await runRelevanceGuardrail({
-          input: conversationInput,
-        });
+
+        // Only pass the latest user message (or a shortened context) to the relevance guardrail
+        const relevance = await runRelevanceGuardrail({ input: userInput });
         const jailbreak = await runJailbreakGuardrail({ input: userInput });
         if (relevance.tripwireTriggered || jailbreak.tripwireTriggered) {
           await sendBotMessage(

--- a/tests/chatwootWebhook.test.js
+++ b/tests/chatwootWebhook.test.js
@@ -398,6 +398,44 @@ test('chatwoot webhook sends fallback when jailbreak guardrail triggers', async 
   resetMocks();
 });
 
+test("chatwoot webhook allows legitimate product questions", async () => {
+  const question = "Do you sell ATS panels?";
+  const payload = {
+    event: "message_created",
+    data: {
+      event: "message_created",
+      message: {
+        message_type: 0,
+        content: question,
+        account: { id: 11 },
+        conversation: { id: 11, inbox_id: 1, status: "resolved", account_id: 11 },
+      },
+    },
+  };
+  const history = [
+    toResponseMessage("user", "random chatter"),
+    toResponseMessage("assistant", "..."),
+    toResponseMessage("user", question),
+  ];
+  getConversationHistoryMock.mock.mockImplementationOnce(async () => history);
+  runRelevanceGuardrailMock.mock.mockImplementationOnce(async ({ input }) => {
+    assert.strictEqual(input, question);
+    return { tripwireTriggered: false };
+  });
+
+  const req = new Request("http://localhost", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+  const res = await webhookPost(req);
+  await res.json();
+
+  assert.strictEqual(runRelevanceGuardrailMock.mock.calls.length, 1);
+  assert.strictEqual(getProviderMock.mock.calls.length, 1);
+  assert.strictEqual(sendBotMessageMock.mock.calls[0].arguments[2], "hi");
+  resetMocks();
+});
+
 test('chatwoot webhook returns 500 when sendBotMessage fails', async () => {
   sendBotMessageMock.mock.mockImplementationOnce(async () => {
     throw new Error('fail');


### PR DESCRIPTION
## Summary
- Use only the most recent user message when invoking the relevance guardrail in the Chatwoot webhook
- Add regression test ensuring product-related questions pass through without being blocked

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bef9b05ec483338c02a1e2a3cb247c