### PR TITLE
Populate conversation message IDs and enforce uniqueness

### DIFF
--- a/prisma/migrations/20250908173356_conversation_message_messageId/migration.sql
+++ b/prisma/migrations/20250908173356_conversation_message_messageId/migration.sql
@@ -1,8 +1,23 @@
 -- AlterTable
 CREATE SEQUENCE "public".conversationmessage_id_seq;
-ALTER TABLE "public"."ConversationMessage" ADD COLUMN     "messageId" INTEGER NOT NULL,
-ALTER COLUMN "id" SET DEFAULT nextval('"public".conversationmessage_id_seq');
+ALTER TABLE "public"."ConversationMessage"
+    ADD COLUMN "messageId" INTEGER,
+    ALTER COLUMN "id" SET DEFAULT nextval('"public".conversationmessage_id_seq');
 ALTER SEQUENCE "public".conversationmessage_id_seq OWNED BY "public"."ConversationMessage"."id";
+
+-- Populate existing rows with sequential messageIds per conversation
+WITH ordered AS (
+    SELECT "id", ROW_NUMBER() OVER (PARTITION BY "conversationKey" ORDER BY "id") AS rn
+    FROM "public"."ConversationMessage"
+)
+UPDATE "public"."ConversationMessage" cm
+SET "messageId" = ordered.rn
+FROM ordered
+WHERE cm.id = ordered.id;
+
+-- Make messageId required
+ALTER TABLE "public"."ConversationMessage"
+    ALTER COLUMN "messageId" SET NOT NULL;
 
 -- CreateIndex
 CREATE UNIQUE INDEX "ConversationMessage_conversationKey_messageId_key" ON "public"."ConversationMessage"("conversationKey", "messageId");


### PR DESCRIPTION
## Summary
- populate `ConversationMessage.messageId` for existing rows and enforce not-null constraint
- regenerate Prisma client

## Testing
- `npx prisma generate`
- `npx prisma migrate reset --force --skip-seed` *(fails: Can't reach database server at `localhost:5433`)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf325236a88333bb0fef795a3f85e9