### PR TITLE
Avoid releasing agent when conversation unassigned

### DIFF
--- a/app/api/chatwoot-status-webhook/route.ts
+++ b/app/api/chatwoot-status-webhook/route.ts
@@ -107,6 +107,10 @@ export async function POST(request: Request) {
       const labelsPrevious = Array.isArray(labelListChange?.previous_value)
         ? labelListChange?.previous_value
         : undefined;
+      const assigneeId = (typedPayload.conversation as any)?.assignee_id;
+      const hasAssignedLabel =
+        Array.isArray(labelsCurrent) &&
+        labelsCurrent.includes(CONVO_LABELS.assigned);
       if (
         statusCurrent === "resolved" ||
         statusCurrent === "pending" ||
@@ -114,14 +118,21 @@ export async function POST(request: Request) {
           labelsPrevious?.includes(CONVO_LABELS.assigned) &&
           !labelsCurrent.includes(CONVO_LABELS.assigned))
       ) {
-        try {
-          await releaseAgent(
-            accountId,
-            conversationId,
-            typedPayload.conversation
+        if (assigneeId === undefined && !hasAssignedLabel) {
+          console.info(
+            "chatwoot status webhook skipping release: no assignee",
+            { event, conversationId }
           );
-        } catch (err) {
-          console.error("Agent availability update failed", err);
+        } else {
+          try {
+            await releaseAgent(
+              accountId,
+              conversationId,
+              typedPayload.conversation
+            );
+          } catch (err) {
+            console.error("Agent availability update failed", err);
+          }
         }
         return NextResponse.json({ status: "handled" });
       }

--- a/tests/chatwootWebhook.test.js
+++ b/tests/chatwootWebhook.test.js
@@ -149,7 +149,7 @@ test('chatwoot status webhook releases agent on label removal', async () => {
         },
       ],
       account: { id: 2 },
-      conversation: { id: 2 },
+      conversation: { id: 2, assignee_id: 42 },
     },
   };
   const req = new Request('http://localhost', {
@@ -174,7 +174,7 @@ test('chatwoot status webhook releases agent on status update', async () => {
         },
       ],
       account: { id: 3 },
-      conversation: { id: 3 },
+      conversation: { id: 3, assignee_id: 43 },
     },
   };
   const req = new Request('http://localhost', {
@@ -185,6 +185,34 @@ test('chatwoot status webhook releases agent on status update', async () => {
   const data = await res.json();
   assert.strictEqual(data.status, 'handled');
   assert.strictEqual(releaseAgentMock.mock.calls.length, 1);
+  resetMocks();
+});
+
+test('chatwoot status webhook skips release when no assignee', async () => {
+  const payload = {
+    event: 'conversation_updated',
+    data: {
+      event: 'conversation_updated',
+      changed_attributes: [
+        {
+          label_list: {
+            previous_value: [CONVO_LABELS.assigned],
+            current_value: [],
+          },
+        },
+      ],
+      account: { id: 4 },
+      conversation: { id: 4 },
+    },
+  };
+  const req = new Request('http://localhost', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+  const res = await statusWebhookPost(req);
+  const data = await res.json();
+  assert.strictEqual(data.status, 'handled');
+  assert.strictEqual(releaseAgentMock.mock.calls.length, 0);
   resetMocks();
 });
 


### PR DESCRIPTION
## Summary
- prevent releaseAgent calls when a conversation update event lacks an assignee and the assigned label
- expand conversation webhook tests and add coverage for skipping release when unassigned

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c00530d0c48333b3c79b4adc74c45c