### PR TITLE
Handle additional assignee fallbacks in chatwoot webhook

### DIFF
--- a/app/api/chatwoot-status-webhook/route.ts
+++ b/app/api/chatwoot-status-webhook/route.ts
@@ -107,7 +107,11 @@ export async function POST(request: Request) {
       const labelsPrevious = Array.isArray(labelListChange?.previous_value)
         ? labelListChange?.previous_value
         : undefined;
-      const assigneeId = (typedPayload.conversation as any)?.assignee_id;
+      const assigneeId =
+        payload.assignee_id ??
+        (changes.assignee_id?.current_value as number | undefined) ??
+        payload.meta?.assignee?.id ??
+        (typedPayload.conversation as any)?.assignee_id;
       const hasAssignedLabel =
         Array.isArray(labelsCurrent) &&
         labelsCurrent.includes(CONVO_LABELS.assigned);


### PR DESCRIPTION
## Summary
- expand assignee fallback logic when handling conversation updates from Chatwoot

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c01ee65ca48333ad3a1a42adb231b7