### PR TITLE
Handle label fields in Chatwoot status webhook

### DIFF
--- a/app/api/chatwoot-status-webhook/route.ts
+++ b/app/api/chatwoot-status-webhook/route.ts
@@ -101,12 +101,24 @@ export async function POST(request: Request) {
         | undefined;
       const labelListChange =
         changes.label_list ?? changes.cached_label_list;
-      const labelsCurrent = Array.isArray(labelListChange?.current_value)
+      let labelsCurrent = Array.isArray(labelListChange?.current_value)
         ? labelListChange?.current_value
         : undefined;
       const labelsPrevious = Array.isArray(labelListChange?.previous_value)
         ? labelListChange?.previous_value
         : undefined;
+      if (!labelListChange) {
+        const labelSource =
+          payload.label_list ?? payload.cached_label_list ?? payload.labels;
+        if (Array.isArray(labelSource)) {
+          labelsCurrent = labelSource;
+        } else if (typeof labelSource === "string") {
+          labelsCurrent = labelSource
+            .split(",")
+            .map((l) => l.trim())
+            .filter(Boolean);
+        }
+      }
       const assigneeId =
         payload.assignee_id ??
         (changes.assignee_id?.current_value as number | undefined) ??

--- a/tests/chatwootWebhook.test.js
+++ b/tests/chatwootWebhook.test.js
@@ -188,6 +188,32 @@ test('chatwoot status webhook releases agent on status update', async () => {
   resetMocks();
 });
 
+test('chatwoot status webhook releases agent when label present without change', async () => {
+  const payload = {
+    event: 'conversation_updated',
+    data: {
+      event: 'conversation_updated',
+      changed_attributes: [
+        {
+          status: { previous_value: 'open', current_value: 'resolved' },
+        },
+      ],
+      account: { id: 5 },
+      conversation: { id: 5 },
+      labels: `${CONVO_LABELS.assigned},other`,
+    },
+  };
+  const req = new Request('http://localhost', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+  const res = await statusWebhookPost(req);
+  const data = await res.json();
+  assert.strictEqual(data.status, 'handled');
+  assert.strictEqual(releaseAgentMock.mock.calls.length, 1);
+  resetMocks();
+});
+
 test('chatwoot status webhook skips release when no assignee', async () => {
   const payload = {
     event: 'conversation_updated',


### PR DESCRIPTION
## Summary
- Parse label information from payload when no label change is reported
- Recalculate assignment detection with parsed labels
- Add test covering payload label parsing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c020d0d2448333b01149d57afbb5a9