### PR TITLE
feat: include assignee id in Chatwoot meta

### DIFF
--- a/types/chatwoot.ts
+++ b/types/chatwoot.ts
@@ -4,6 +4,11 @@ interface Account {
   [key: string]: any;
 }
 
+interface Assignee {
+  id?: number;
+  account_id?: number;
+}
+
 export interface Conversation {
   id: number;
   status?: string;
@@ -34,7 +39,7 @@ export interface BasePayload {
   conversation_id?: number;
   inbox_id?: number;
   id?: number;
-  meta?: { assignee?: { account_id?: number } } & Record<string, any>;
+  meta?: { assignee?: Assignee } & Record<string, any>;
   messages?: Message[];
   message?: Message;
 }


### PR DESCRIPTION
## Summary
- support optional `id` field in Chatwoot webhook assignee metadata

## Testing
- `npx tsc --noEmit`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c02fa81628833382ef352a72ee2ed8