### PR TITLE
Clarify Chatwoot release decisions in webhook logs

### DIFF
--- a/app/api/chatwoot-status-webhook/route.ts
+++ b/app/api/chatwoot-status-webhook/route.ts
@@ -127,6 +127,14 @@ export async function POST(request: Request) {
       const hasAssignedLabel =
         Array.isArray(labelsCurrent) &&
         labelsCurrent.includes(CONVO_LABELS.assigned);
+      console.info("chatwoot status webhook resolved fields", {
+        event,
+        conversationId,
+        assigneeId,
+        labels_current: labelsCurrent,
+        labels_previous: labelsPrevious,
+        status_current: statusCurrent,
+      });
       if (
         statusCurrent === "resolved" ||
         statusCurrent === "pending" ||
@@ -137,9 +145,24 @@ export async function POST(request: Request) {
         if (assigneeId === undefined && !hasAssignedLabel) {
           console.info(
             "chatwoot status webhook skipping release: no assignee",
-            { event, conversationId }
+            {
+              event,
+              conversationId,
+              assigneeId,
+              labels_current: labelsCurrent,
+              labels_previous: labelsPrevious,
+              status_current: statusCurrent,
+            }
           );
         } else {
+          console.info("chatwoot status webhook releasing agent", {
+            event,
+            conversationId,
+            assigneeId,
+            labels_current: labelsCurrent,
+            labels_previous: labelsPrevious,
+            status_current: statusCurrent,
+          });
           try {
             await releaseAgent(
               accountId,


### PR DESCRIPTION
## Summary
- Log resolved assignee ID and label state on `conversation_updated`
- Report key fields when deciding to skip or release an agent

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c042a19fd48333a5091ca1700c0873