### PR TITLE
feat: add timeout and retry to chatwoot fetch

### DIFF
--- a/lib/chatwoot.ts
+++ b/lib/chatwoot.ts
@@ -1,21 +1,70 @@
 const CHATWOOT_URL = (process.env.CHATWOOT_URL || "").replace(/\/$/, "");
 const CHATWOOT_TOKEN = process.env.CHATWOOT_APP_TOKEN || "";
+const CHATWOOT_TIMEOUT_MS = Number(process.env.CHATWOOT_TIMEOUT_MS || 15000);
 
-async function chatwootFetch(path: string, init: RequestInit = {}) {
+async function chatwootFetch(
+  path: string,
+  init: RequestInit & { timeoutMs?: number; maxAttempts?: number } = {}
+) {
   const url = `${CHATWOOT_URL}${path}`;
   const headers = {
     "api_access_token": CHATWOOT_TOKEN,
     ...(init.headers || {}),
   } as Record<string, string>;
-  const { method = "GET", body } = init;
-  console.info("[chatwoot]", method, url, body);
-  const res = await fetch(url, { ...init, headers });
-  const text = await res.text();
-  if (!res.ok) {
-    console.error("[chatwoot]", res.status, text);
-    throw new Error(`Chatwoot request failed: ${res.status}`);
+  const {
+    method = "GET",
+    body,
+    timeoutMs = CHATWOOT_TIMEOUT_MS,
+    maxAttempts = 3,
+    ...rest
+  } = init as RequestInit & { timeoutMs?: number; maxAttempts?: number };
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      console.info("[chatwoot]", method, url, body);
+      const res = await fetch(url, {
+        ...rest,
+        method,
+        body,
+        headers,
+        signal: controller.signal,
+      });
+      const text = await res.text();
+
+      if (!res.ok) {
+        console.error("[chatwoot]", res.status, text);
+        if (res.status >= 500 && attempt < maxAttempts) {
+          const backoff = 500 * 2 ** (attempt - 1);
+          console.warn(`[chatwoot] retrying in ${backoff}ms`);
+          await new Promise((r) => setTimeout(r, backoff));
+          continue;
+        }
+        throw new Error(`Chatwoot request failed: ${res.status} ${text}`);
+      }
+
+      return JSON.parse(text || "{}");
+    } catch (err) {
+      if (attempt >= maxAttempts) {
+        const msg = err instanceof Error ? err.message : String(err);
+        const finalErr = new Error(
+          `Chatwoot request failed after ${attempt} attempts: ${method} ${url} - ${msg}`
+        );
+        (finalErr as any).cause = err;
+        throw finalErr;
+      }
+      const backoff = 500 * 2 ** (attempt - 1);
+      console.warn(`[chatwoot] attempt ${attempt} failed, retrying in ${backoff}ms`, err);
+      await new Promise((r) => setTimeout(r, backoff));
+    } finally {
+      clearTimeout(timer);
+    }
   }
-  return JSON.parse(text || "{}");
+
+  // Should be unreachable
+  throw new Error(`Chatwoot request failed: ${method} ${url}`);
 }
 
 export async function getConversation(


### PR DESCRIPTION
## Summary
- add configurable timeout and retry logic to Chatwoot API wrapper
- surface final error with context for easier debugging

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c0951097d88333bb22efe31298a107