### PR TITLE
Handle unresolved agent releases with explicit error

### DIFF
--- a/app/api/chatwoot-status-webhook/route.ts
+++ b/app/api/chatwoot-status-webhook/route.ts
@@ -65,6 +65,9 @@ export async function POST(request: Request) {
           );
         } catch (err) {
           console.error("Agent availability update failed", err);
+          const message =
+            err instanceof Error ? err.message : "Agent release failed";
+          return NextResponse.json({ error: message }, { status: 500 });
         }
         return NextResponse.json({ status: "handled" });
       }
@@ -171,6 +174,9 @@ export async function POST(request: Request) {
             );
           } catch (err) {
             console.error("Agent availability update failed", err);
+            const message =
+              err instanceof Error ? err.message : "Agent release failed";
+            return NextResponse.json({ error: message }, { status: 500 });
           }
         }
         return NextResponse.json({ status: "handled" });

--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -162,11 +162,10 @@ export async function POST(request: Request) {
       }
       try {
         await releaseAgent(accountId, conversationId, conversation);
-      } catch {
-        return NextResponse.json(
-          { error: "Agent availability update failed" },
-          { status: 500 }
-        );
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : "Agent release failed";
+        return NextResponse.json({ error: message }, { status: 500 });
       }
       return NextResponse.json({ status: "handled" });
     }

--- a/lib/conversationResolution.ts
+++ b/lib/conversationResolution.ts
@@ -26,6 +26,7 @@ export async function releaseAgent(
 ) {
   let freedAgentId: number | undefined;
   let outcome = "no-agent";
+  let resolveError: unknown;
   try {
     const current = await getConversationLabels(accountId, conversationId);
     const reserved = Object.values(CONVO_LABELS) as string[];
@@ -45,13 +46,34 @@ export async function releaseAgent(
         freedAgentId = (convo as any)?.assignee_id;
       } catch (err) {
         console.error("fetch assignee error", err);
+        resolveError = err;
       }
     }
     if (freedAgentId === undefined) {
-      const assignment = await prisma.agentAssignment.findFirst({
-        where: { activeConversationId: conversationId },
-      });
-      freedAgentId = assignment?.agentId;
+      try {
+        const assignment = await prisma.agentAssignment.findFirst({
+          where: { activeConversationId: conversationId },
+        });
+        freedAgentId = assignment?.agentId;
+      } catch (err) {
+        console.error("lookup assignment error", err);
+        resolveError = err;
+      }
+    }
+    if (freedAgentId === undefined) {
+      const error = new Error(
+        `Unable to resolve freed agent for conversation ${conversationId}`
+      );
+      (error as any).conversationId = conversationId;
+      if (resolveError) {
+        (error as any).cause = resolveError;
+        error.message += `: ${
+          resolveError instanceof Error
+            ? resolveError.message
+            : String(resolveError)
+        }`;
+      }
+      throw error;
     }
 
     if (freedAgentId) {

--- a/tests/chatwootWebhook.test.js
+++ b/tests/chatwootWebhook.test.js
@@ -135,6 +135,31 @@ test('chatwoot status webhook releases agent on conversation_status_changed', as
   resetMocks();
 });
 
+test('chatwoot status webhook returns error when releaseAgent fails', async () => {
+  const payload = {
+    event: 'conversation_status_changed',
+    data: {
+      event: 'conversation_status_changed',
+      status: 'snoozed',
+      previous_status: 'open',
+      account: { id: 2 },
+      conversation: { id: 2 },
+    },
+  };
+  releaseAgentMock.mock.mockImplementationOnce(async () => {
+    throw new Error('Unable to resolve freed agent for conversation 2');
+  });
+  const req = new Request('http://localhost', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+  const res = await statusWebhookPost(req);
+  const data = await res.json();
+  assert.strictEqual(res.status, 500);
+  assert.ok(data.error.includes('Unable to resolve freed agent'));
+  resetMocks();
+});
+
 test('chatwoot status webhook releases agent on label removal', async () => {
   const payload = {
     event: 'conversation_updated',

--- a/tests/releaseAgent.test.js
+++ b/tests/releaseAgent.test.js
@@ -15,6 +15,7 @@ const redis = require('../lib/redis.ts').default;
 mock.method(chatwoot, 'getConversationLabels', async () => ({ payload: [] }));
 mock.method(chatwoot, 'setConversationLabels', async () => {});
 mock.method(chatwoot, 'setAgentAvailability', async () => {});
+const getConversationMock = mock.method(chatwoot, 'getConversation', async () => ({}));
 mock.method(agentRotation, 'clearActiveConversation', async () => {});
 mock.method(agentRotation, 'setActiveConversation', async () => {});
 mock.method(handoffQueue, 'updateRequest', async () => {});
@@ -53,4 +54,23 @@ test('releaseAgent opens and assigns conversation before notifying', async () =>
   assert.strictEqual(assignMock.mock.calls.length, 1);
   assert.deepStrictEqual(assignMock.mock.calls[0].arguments, [accountId, queuedConversationId, freedAgentId]);
   assert.strictEqual(sendMock.mock.calls.length, 1);
+});
+
+test('releaseAgent throws when freed agent cannot be resolved', async () => {
+  const fetchErr = new Error('fetch failed');
+  getConversationMock.mock.mockImplementationOnce(async () => {
+    throw fetchErr;
+  });
+  prisma.agentAssignment.findFirst.mock.mockImplementationOnce(async () => null);
+  await assert.rejects(
+    async () => {
+      await conversationResolution.releaseAgent(accountId, releasedConversationId);
+    },
+    (err) => {
+      assert.strictEqual(err.conversationId, releasedConversationId);
+      assert.ok(err.message.includes(`conversation ${releasedConversationId}`));
+      assert.ok(err.message.includes(fetchErr.message));
+      return true;
+    }
+  );
 });


### PR DESCRIPTION
## Summary
- Throw explicit error when freed agent ID can't be resolved
- Return 500 from webhooks when release fails so Chatwoot can retry
- Add tests for unresolved release scenarios

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c09b15efc48333b29216f4b71c675d