### PR TITLE
feat: track release attempts with backoff

### DIFF
--- a/app/api/chatwoot-status-webhook/route.ts
+++ b/app/api/chatwoot-status-webhook/route.ts
@@ -8,6 +8,10 @@ import { releaseAgent } from "@/lib/conversationResolution";
 import { CONVO_LABELS } from "@/lib/constants";
 import { setAgentAvailability } from "@/lib/chatwoot";
 import { setActiveConversation } from "@/lib/agentRotation";
+import {
+  recordReleaseFailure,
+  clearReleaseAttempts,
+} from "@/lib/releaseAttempts";
 
 export async function POST(request: Request) {
   try {
@@ -63,11 +67,22 @@ export async function POST(request: Request) {
             conversationId,
             typedPayload.conversation
           );
+          clearReleaseAttempts(conversationId);
         } catch (err) {
           console.error("Agent availability update failed", err);
           const message =
             err instanceof Error ? err.message : "Agent release failed";
-          return NextResponse.json({ error: message }, { status: 500 });
+          const { shouldRetry } = await recordReleaseFailure(
+            conversationId,
+            err
+          );
+          if (shouldRetry) {
+            return NextResponse.json({ error: message }, { status: 500 });
+          }
+          return NextResponse.json(
+            { status: "unreleased", error: message },
+            { status: 200 }
+          );
         }
         return NextResponse.json({ status: "handled" });
       }
@@ -172,11 +187,22 @@ export async function POST(request: Request) {
               conversationId,
               typedPayload.conversation
             );
+            clearReleaseAttempts(conversationId);
           } catch (err) {
             console.error("Agent availability update failed", err);
             const message =
               err instanceof Error ? err.message : "Agent release failed";
-            return NextResponse.json({ error: message }, { status: 500 });
+            const { shouldRetry } = await recordReleaseFailure(
+              conversationId,
+              err
+            );
+            if (shouldRetry) {
+              return NextResponse.json({ error: message }, { status: 500 });
+            }
+            return NextResponse.json(
+              { status: "unreleased", error: message },
+              { status: 200 }
+            );
           }
         }
         return NextResponse.json({ status: "handled" });

--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -25,6 +25,10 @@ import {
   runRelevanceGuardrail,
   runJailbreakGuardrail,
 } from "@/lib/guardrails";
+import {
+  recordReleaseFailure,
+  clearReleaseAttempts,
+} from "@/lib/releaseAttempts";
 
 export async function POST(request: Request) {
   try {
@@ -162,10 +166,21 @@ export async function POST(request: Request) {
       }
       try {
         await releaseAgent(accountId, conversationId, conversation);
+        clearReleaseAttempts(conversationId);
       } catch (err) {
         const message =
           err instanceof Error ? err.message : "Agent release failed";
-        return NextResponse.json({ error: message }, { status: 500 });
+        const { shouldRetry } = await recordReleaseFailure(
+          conversationId,
+          err
+        );
+        if (shouldRetry) {
+          return NextResponse.json({ error: message }, { status: 500 });
+        }
+        return NextResponse.json(
+          { status: "unreleased", error: message },
+          { status: 200 }
+        );
       }
       return NextResponse.json({ status: "handled" });
     }

--- a/lib/releaseAttempts.ts
+++ b/lib/releaseAttempts.ts
@@ -1,0 +1,32 @@
+import { setTimeout as delay } from 'timers/promises';
+
+const releaseAttempts = new Map<number, number>();
+
+const MAX_ATTEMPTS = parseInt(process.env.RELEASE_MAX_ATTEMPTS || '5', 10);
+const BASE_DELAY_MS = parseInt(process.env.RELEASE_RETRY_BASE_MS || '1000', 10);
+
+export async function recordReleaseFailure(
+  conversationId: number,
+  err: unknown
+): Promise<{ shouldRetry: boolean }>
+{
+  const attempt = (releaseAttempts.get(conversationId) ?? 0) + 1;
+  releaseAttempts.set(conversationId, attempt);
+  const delayMs = BASE_DELAY_MS * 2 ** (attempt - 1);
+  if (attempt >= MAX_ATTEMPTS) {
+    console.error('release retry limit reached', {
+      conversationId,
+      attempts: attempt,
+      error: err,
+    });
+    releaseAttempts.delete(conversationId);
+    return { shouldRetry: false };
+  }
+  // Exponential backoff before signalling retry
+  await delay(delayMs);
+  return { shouldRetry: true };
+}
+
+export function clearReleaseAttempts(conversationId: number) {
+  releaseAttempts.delete(conversationId);
+}

--- a/tests/chatwootWebhook.test.js
+++ b/tests/chatwootWebhook.test.js
@@ -1,5 +1,7 @@
 const assert = require('assert');
 const { test, mock } = require('node:test');
+process.env.RELEASE_MAX_ATTEMPTS = '2';
+process.env.RELEASE_RETRY_BASE_MS = '1';
 require('ts-node/register/transpile-only');
 require('tsconfig-paths/register');
 
@@ -88,6 +90,7 @@ test.after(async () => {
 
 function resetMocks() {
   releaseAgentMock.mock.resetCalls();
+  releaseAgentMock.mock.mockImplementation(async () => {});
   sendBotMessageMock.mock.resetCalls();
   getProviderMock.mock.resetCalls();
   providerFnMock.mock.resetCalls();
@@ -157,6 +160,39 @@ test('chatwoot status webhook returns error when releaseAgent fails', async () =
   const data = await res.json();
   assert.strictEqual(res.status, 500);
   assert.ok(data.error.includes('Unable to resolve freed agent'));
+  resetMocks();
+});
+
+test('chatwoot status webhook stops returning 500 after retry limit', async () => {
+  const payload = {
+    event: 'conversation_status_changed',
+    data: {
+      event: 'conversation_status_changed',
+      status: 'snoozed',
+      previous_status: 'open',
+      account: { id: 3 },
+      conversation: { id: 3 },
+    },
+  };
+  releaseAgentMock.mock.mockImplementation(async () => {
+    throw new Error('fail');
+  });
+  // first attempt => 500
+  let req = new Request('http://localhost', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+  let res = await statusWebhookPost(req);
+  assert.strictEqual(res.status, 500);
+  // second attempt => limit reached, no 500
+  req = new Request('http://localhost', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+  res = await statusWebhookPost(req);
+  const data = await res.json();
+  assert.strictEqual(res.status, 200);
+  assert.strictEqual(data.status, 'unreleased');
   resetMocks();
 });
 


### PR DESCRIPTION
## Summary
- track release attempts per conversation with exponential backoff
- stop sending 500s after configurable retry limit in webhooks
- add tests for retry backoff

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1139519f483339a306d1398222ca3