### PR TITLE
Ensure chatwoot status updates release only after assignment

### DIFF
--- a/app/api/chatwoot-status-webhook/route.ts
+++ b/app/api/chatwoot-status-webhook/route.ts
@@ -120,6 +120,9 @@ export async function POST(request: Request) {
       const statusCurrent = changes.status?.current_value as
         | string
         | undefined;
+      const statusPrevious = changes.status?.previous_value as
+        | string
+        | undefined;
       const labelListChange =
         changes.label_list ?? changes.cached_label_list;
       let labelsCurrent = Array.isArray(labelListChange?.current_value)
@@ -155,61 +158,57 @@ export async function POST(request: Request) {
         labels_current: labelsCurrent,
         labels_previous: labelsPrevious,
         status_current: statusCurrent,
+        status_previous: statusPrevious,
       });
-      if (
-        statusCurrent === "resolved" ||
-        statusCurrent === "pending" ||
-        (Array.isArray(labelsCurrent) &&
-          labelsPrevious?.includes(CONVO_LABELS.assigned) &&
-          !labelsCurrent.includes(CONVO_LABELS.assigned))
-      ) {
-        if (assigneeId === undefined && !hasAssignedLabel) {
-          console.info(
-            "chatwoot status webhook skipping release: no assignee",
-            {
-              event,
-              conversationId,
-              assigneeId,
-              labels_current: labelsCurrent,
-              labels_previous: labelsPrevious,
-              status_current: statusCurrent,
-            }
-          );
-        } else {
-          console.info("chatwoot status webhook releasing agent", {
-            event,
+      const shouldRelease =
+        (statusCurrent === "pending" || statusCurrent === "resolved") &&
+        statusPrevious === "open" &&
+        hasAssignedLabel;
+      if (shouldRelease) {
+        console.info("chatwoot status webhook releasing agent", {
+          event,
+          conversationId,
+          assigneeId,
+          labels_current: labelsCurrent,
+          labels_previous: labelsPrevious,
+          status_current: statusCurrent,
+          status_previous: statusPrevious,
+        });
+        try {
+          await releaseAgent(
+            accountId,
             conversationId,
-            assigneeId,
-            labels_current: labelsCurrent,
-            labels_previous: labelsPrevious,
-            status_current: statusCurrent,
-          });
-          try {
-            await releaseAgent(
-              accountId,
-              conversationId,
-              typedPayload.conversation
-            );
-            clearReleaseAttempts(conversationId);
-          } catch (err) {
-            console.error("Agent availability update failed", err);
-            const message =
-              err instanceof Error ? err.message : "Agent release failed";
-            const { shouldRetry } = await recordReleaseFailure(
-              conversationId,
-              err
-            );
-            if (shouldRetry) {
-              return NextResponse.json({ error: message }, { status: 500 });
-            }
-            return NextResponse.json(
-              { status: "unreleased", error: message },
-              { status: 200 }
-            );
+            typedPayload.conversation
+          );
+          clearReleaseAttempts(conversationId);
+        } catch (err) {
+          console.error("Agent availability update failed", err);
+          const message =
+            err instanceof Error ? err.message : "Agent release failed";
+          const { shouldRetry } = await recordReleaseFailure(
+            conversationId,
+            err
+          );
+          if (shouldRetry) {
+            return NextResponse.json({ error: message }, { status: 500 });
           }
+          return NextResponse.json(
+            { status: "unreleased", error: message },
+            { status: 200 }
+          );
         }
-        return NextResponse.json({ status: "handled" });
+      } else {
+        console.info("chatwoot status webhook skipping release", {
+          event,
+          conversationId,
+          assigneeId,
+          labels_current: labelsCurrent,
+          labels_previous: labelsPrevious,
+          status_current: statusCurrent,
+          status_previous: statusPrevious,
+        });
       }
+      return NextResponse.json({ status: "handled" });
     }
 
     return NextResponse.json({ status: "ignored" });

--- a/tests/chatwootWebhook.test.js
+++ b/tests/chatwootWebhook.test.js
@@ -196,7 +196,7 @@ test('chatwoot status webhook stops returning 500 after retry limit', async () =
   resetMocks();
 });
 
-test('chatwoot status webhook releases agent on label removal', async () => {
+test('chatwoot status webhook skips release on label removal', async () => {
   const payload = {
     event: 'conversation_updated',
     data: {
@@ -221,7 +221,7 @@ test('chatwoot status webhook releases agent on label removal', async () => {
   const res = await statusWebhookPost(req);
   const data = await res.json();
   assert.strictEqual(data.status, 'handled');
-  assert.strictEqual(releaseAgentMock.mock.calls.length, 1);
+  assert.strictEqual(releaseAgentMock.mock.calls.length, 0);
   resetMocks();
 });
 
@@ -265,6 +265,7 @@ test('chatwoot status webhook releases agent on status update', async () => {
       account: { id: 3 },
       conversation: { id: 3 },
       assignee_id: 43,
+      labels: [CONVO_LABELS.assigned],
     },
   };
   const req = new Request('http://localhost', {


### PR DESCRIPTION
## Summary
- Capture previous status in Chatwoot webhook payload
- Release agent only when status moves from open to pending/resolved with assigned label
- Adjust tests for new release logic

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1274a45b48333a7d2614997af9ea8