### PR TITLE
Check labels before releasing agent

### DIFF
--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -164,6 +164,28 @@ export async function POST(request: Request) {
       if (accountId === undefined || conversationId === undefined) {
         return NextResponse.json({ status: "ignored" });
       }
+      let labels = Array.isArray((conversation as any)?.label_list)
+        ? (conversation as any).label_list
+        : undefined;
+      if (!Array.isArray(labels)) {
+        try {
+          const current = await getConversationLabels(accountId, conversationId);
+          labels = Array.isArray((current as any)?.payload)
+            ? (current as any).payload
+            : undefined;
+        } catch (err) {
+          console.error("resolution labels fetch error", err);
+        }
+      }
+      const hasAssigned =
+        Array.isArray(labels) && labels.includes(CONVO_LABELS.assigned);
+      if (!hasAssigned) {
+        console.info("resolution message skipping release", {
+          conversationId,
+          labels,
+        });
+        return NextResponse.json({ status: "handled" });
+      }
       try {
         await releaseAgent(accountId, conversationId, conversation);
         clearReleaseAttempts(conversationId);

--- a/tests/chatwootWebhook.test.js
+++ b/tests/chatwootWebhook.test.js
@@ -45,6 +45,11 @@ const enqueueRequestMock = mock.method(handoffQueue, 'enqueueRequest', async () 
 const chatwoot = require('../lib/chatwoot.ts');
 const getConversationMock = mock.method(chatwoot, 'getConversation', async () => ({ id: 1, status: 'resolved', inbox_id: 1 }));
 const setConversationLabelsMock = mock.method(chatwoot, 'setConversationLabels', async () => {});
+const getConversationLabelsMock = mock.method(
+  chatwoot,
+  'getConversationLabels',
+  async () => ({ payload: [] })
+);
 
 const { CONVO_LABELS } = require('../lib/constants.ts');
 const { CHATWOOT_SYSTEM_PROMPT } = require('../config/constants.ts');
@@ -100,6 +105,7 @@ function resetMocks() {
   enqueueRequestMock.mock.resetCalls();
   getConversationMock.mock.resetCalls();
   setConversationLabelsMock.mock.resetCalls();
+  getConversationLabelsMock.mock.resetCalls();
   prisma.handoffRequest.findUnique.mock.resetCalls();
   prisma.conversationMessage.upsert.mock.resetCalls();
   prisma.conversationMessage.findMany.mock.resetCalls();
@@ -419,6 +425,62 @@ test('chatwoot status webhook ignores resolution system message', async () => {
   const res = await statusWebhookPost(req);
   const data = await res.json();
   assert.strictEqual(data.status, 'ignored');
+  assert.strictEqual(releaseAgentMock.mock.calls.length, 0);
+  resetMocks();
+});
+
+test('chatwoot webhook releases agent on resolution with assigned label', async () => {
+  getConversationLabelsMock.mock.mockImplementationOnce(async () => ({
+    payload: [CONVO_LABELS.assigned],
+  }));
+  const payload = {
+    event: 'message_created',
+    data: {
+      event: 'message_created',
+      message: {
+        id: 11,
+        message_type: 2,
+        content: 'Conversation was marked resolved',
+        account: { id: 11 },
+        conversation: { id: 11, inbox_id: 1, account_id: 11 },
+      },
+    },
+  };
+  const req = new Request('http://localhost', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+  const res = await webhookPost(req);
+  const data = await res.json();
+  assert.strictEqual(data.status, 'handled');
+  assert.strictEqual(releaseAgentMock.mock.calls.length, 1);
+  resetMocks();
+});
+
+test('chatwoot webhook skips release when assigned label missing', async () => {
+  getConversationLabelsMock.mock.mockImplementationOnce(async () => ({
+    payload: [],
+  }));
+  const payload = {
+    event: 'message_created',
+    data: {
+      event: 'message_created',
+      message: {
+        id: 12,
+        message_type: 2,
+        content: 'Conversation was marked resolved',
+        account: { id: 12 },
+        conversation: { id: 12, inbox_id: 1, account_id: 12 },
+      },
+    },
+  };
+  const req = new Request('http://localhost', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+  const res = await webhookPost(req);
+  const data = await res.json();
+  assert.strictEqual(data.status, 'handled');
   assert.strictEqual(releaseAgentMock.mock.calls.length, 0);
   resetMocks();
 });


### PR DESCRIPTION
## Summary
- Ensure agent release only when `agent-assigned` label present
- Add tests for resolution messages with and without assigned label

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c14254eb408333b3cd0687078b285a