### PR TITLE
Document release retry settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,10 @@ CHATWOOT_URL=https://e245e7cb03bc.ngrok-free.app
 CHATWOOT_APP_TOKEN=<chatwoot-app-token>
 CHATWOOT_BOT_TOKEN=<bot access token>
 AGENT_TOKENS='{"1":"agent-1-secret","2":"agent-2-secret"}' # JSON map of agent IDs to tokens
+
+# Maximum number of retry attempts when releasing an agent fails
+RELEASE_MAX_ATTEMPTS=5
+# Base delay in milliseconds for exponential backoff between release retries
+RELEASE_RETRY_BASE_MS=1000
+# Timeout in milliseconds for Chatwoot API requests before retrying
+CHATWOOT_TIMEOUT_MS=15000

--- a/README.md
+++ b/README.md
@@ -123,7 +123,15 @@ If Redis runs on a dynamically mapped port (e.g. `docker port` or `docker compos
     - `http://ai-agent:3001/api/chatwoot-webhook` subscribed only to `message_created`.
     - `http://ai-agent:3001/api/chatwoot-status-webhook` subscribed to `conversation_status_changed`, `conversation_updated`, and `message_created` (system events).
 
+    Release retries for these endpoints are controlled by `RELEASE_MAX_ATTEMPTS`, `RELEASE_RETRY_BASE_MS`, and `CHATWOOT_TIMEOUT_MS`.
+
    The `AGENT_TOKENS` environment variable supplies per-agent access tokens in JSON form, e.g. `{ "1": "secret" }`. Store these secrets outside of source control (such as a `.env` file or your hosting platform's secret manager). To rotate a token, update the JSON with the new value and redeploy or restart the service so it reads the updated mapping.
+
+   #### Release retry settings
+
+   - `RELEASE_MAX_ATTEMPTS` (default `5`) – number of retry attempts when releasing an agent fails.
+   - `RELEASE_RETRY_BASE_MS` (default `1000`) – base delay for exponential backoff.
+   - `CHATWOOT_TIMEOUT_MS` (default `15000`) – API request timeout before retries.
 
    A standalone Docker setup is available to test the service in isolation:
 
@@ -155,6 +163,8 @@ If Redis runs on a dynamically mapped port (e.g. `docker port` or `docker compos
 ## Agent release workflow
 
 Releases are triggered only when a conversation moves from `open` to either `pending` or `resolved` **and** still carries the `agent-assigned` label. The `chatwoot-status-webhook` checks for this combination before calling `releaseAgent`. Inside `releaseAgent`, the label is removed, which generates additional webhook events to handle follow-up processing.
+
+Retry behavior for this release process is governed by the `RELEASE_MAX_ATTEMPTS`, `RELEASE_RETRY_BASE_MS`, and `CHATWOOT_TIMEOUT_MS` environment variables.
 
 ## How to use
 


### PR DESCRIPTION
## Summary
- add RELEASE_MAX_ATTEMPTS, RELEASE_RETRY_BASE_MS, and CHATWOOT_TIMEOUT_MS to `.env.example`
- explain release retry variables in README and cross-reference release routes

## Testing
- `npm test` *(fails: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68c1763942b0833388dc32f2af18a320