### PR TITLE
test: ensure fallback when bot message fails

### DIFF
--- a/tests/chatwootWebhook.test.js
+++ b/tests/chatwootWebhook.test.js
@@ -731,7 +731,7 @@ test('chatwoot webhook sends fallback when jailbreak guardrail triggers', async 
   resetMocks();
 });
 
-test('chatwoot webhook returns 500 when sendBotMessage fails', async () => {
+test('chatwoot webhook sends fallback when sendBotMessage fails', async () => {
   sendBotMessageMock.mock.mockImplementationOnce(async () => {
     throw new Error('fail');
   });
@@ -752,7 +752,13 @@ test('chatwoot webhook returns 500 when sendBotMessage fails', async () => {
     body: JSON.stringify(payload),
   });
   const res = await webhookPost(req);
-  assert.strictEqual(res.status, 500);
-  assert.strictEqual(sendBotMessageMock.mock.calls.length, 1);
+  const body = await res.json();
+  assert.strictEqual(res.status, 200);
+  assert.strictEqual(body.status, 'fallback');
+  assert.strictEqual(sendBotMessageMock.mock.calls.length, 2);
+  assert.strictEqual(
+    sendBotMessageMock.mock.calls[1].arguments[2],
+    'We ran into a hiccup processing your message. Please wait and try again.'
+  );
   resetMocks();
 });


### PR DESCRIPTION
## Summary
- rename sendBotMessage failure test to check fallback behavior
- ensure webhook responds with fallback message and retries sending fallback

## Testing
- `npm test -- --test-name-pattern="chatwoot webhook sends fallback when sendBotMessage fails" tests/chatwootWebhook.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c1f57b08108333901ae6d07595c521