### PR TITLE
Send fallback messages when status webhook errors

### DIFF
--- a/app/api/chatwoot-status-webhook/route.ts
+++ b/app/api/chatwoot-status-webhook/route.ts
@@ -12,8 +12,24 @@ import {
   recordReleaseFailure,
   clearReleaseAttempts,
 } from "@/lib/releaseAttempts";
+import { sendBotMessage } from "@/lib/chatwootBot";
 
 export async function POST(request: Request) {
+  let accountId: number | undefined;
+  let conversationId: number | undefined;
+  const fallbackMessage =
+    "We're updating your conversation. Please wait and try again in a moment.";
+  let fallbackSent = false;
+  const sendFallback = async () => {
+    if (fallbackSent || accountId === undefined || conversationId === undefined)
+      return;
+    fallbackSent = true;
+    try {
+      await sendBotMessage(accountId, conversationId, fallbackMessage);
+    } catch (err) {
+      console.error("fallback sendBotMessage error", err);
+    }
+  };
   try {
     const incoming = await request.json();
     // Merge Chatwoot's structured payload with any extra fields we might receive
@@ -23,7 +39,7 @@ export async function POST(request: Request) {
     // Chatwoot may send either `event` or `type`; fall back accordingly
     const event = payload.event ?? payload.type;
 
-    const accountId: number | undefined =
+    accountId =
       payload.account_id ??
       payload.account?.id ??
       payload.conversation?.account_id ??
@@ -34,7 +50,7 @@ export async function POST(request: Request) {
       payload.message?.conversation?.account_id ??
       payload.message?.conversation?.account?.id;
 
-    const conversationId: number | undefined =
+    conversationId =
       payload.id ??
       payload.conversation?.id ??
       payload.messages?.[0]?.conversation_id ??
@@ -76,6 +92,7 @@ export async function POST(request: Request) {
             conversationId,
             err
           );
+          await sendFallback();
           if (shouldRetry) {
             return NextResponse.json({ error: message }, { status: 500 });
           }
@@ -99,6 +116,7 @@ export async function POST(request: Request) {
             await setAgentAvailability(accountId, agentId, "busy");
           } catch (err) {
             console.error("set agent busy error", err);
+            await sendFallback();
           }
         }
         return NextResponse.json({ status: "handled" });
@@ -191,6 +209,7 @@ export async function POST(request: Request) {
             conversationId,
             err
           );
+          await sendFallback();
           if (shouldRetry) {
             return NextResponse.json({ error: message }, { status: 500 });
           }
@@ -216,6 +235,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ status: "ignored" });
   } catch (error) {
     console.error("Chatwoot status webhook error", error);
+    await sendFallback();
     return NextResponse.json({ status: "error" });
   }
 }

--- a/tests/chatwootWebhook.test.js
+++ b/tests/chatwootWebhook.test.js
@@ -166,6 +166,11 @@ test('chatwoot status webhook returns error when releaseAgent fails', async () =
   const data = await res.json();
   assert.strictEqual(res.status, 500);
   assert.ok(data.error.includes('Unable to resolve freed agent'));
+  assert.strictEqual(sendBotMessageMock.mock.calls.length, 1);
+  assert.strictEqual(
+    sendBotMessageMock.mock.calls[0].arguments[2],
+    "We're updating your conversation. Please wait and try again in a moment."
+  );
   resetMocks();
 });
 
@@ -199,6 +204,15 @@ test('chatwoot status webhook stops returning 500 after retry limit', async () =
   const data = await res.json();
   assert.strictEqual(res.status, 200);
   assert.strictEqual(data.status, 'unreleased');
+  assert.strictEqual(sendBotMessageMock.mock.calls.length, 2);
+  assert.strictEqual(
+    sendBotMessageMock.mock.calls[0].arguments[2],
+    "We're updating your conversation. Please wait and try again in a moment."
+  );
+  assert.strictEqual(
+    sendBotMessageMock.mock.calls[1].arguments[2],
+    "We're updating your conversation. Please wait and try again in a moment."
+  );
   resetMocks();
 });
 


### PR DESCRIPTION
## Summary
- send reassuring fallback message when chatwoot status webhook operations fail
- test status webhook fallback bot messaging and retry behavior

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1f70fe05c8333b9c02eae537e8a10