### PR TITLE
feat: centralize temporary error messaging

### DIFF
--- a/app/api/chatwoot-status-webhook/route.ts
+++ b/app/api/chatwoot-status-webhook/route.ts
@@ -12,22 +12,20 @@ import {
   recordReleaseFailure,
   clearReleaseAttempts,
 } from "@/lib/releaseAttempts";
-import { sendBotMessage } from "@/lib/chatwootBot";
+import { notifyTemporaryIssue } from "@/lib/friendlyErrors";
 
 export async function POST(request: Request) {
   let accountId: number | undefined;
   let conversationId: number | undefined;
-  const fallbackMessage =
-    "We're updating your conversation. Please wait and try again in a moment.";
   let fallbackSent = false;
   const sendFallback = async () => {
     if (fallbackSent || accountId === undefined || conversationId === undefined)
       return;
     fallbackSent = true;
     try {
-      await sendBotMessage(accountId, conversationId, fallbackMessage);
+      await notifyTemporaryIssue(accountId, conversationId);
     } catch (err) {
-      console.error("fallback sendBotMessage error", err);
+      console.error("fallback notifyTemporaryIssue error", err);
     }
   };
   try {

--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -29,6 +29,7 @@ import {
   recordReleaseFailure,
   clearReleaseAttempts,
 } from "@/lib/releaseAttempts";
+import { notifyTemporaryIssue } from "@/lib/friendlyErrors";
 
 export async function POST(request: Request) {
   try {
@@ -243,11 +244,7 @@ export async function POST(request: Request) {
           status = retry?.status;
         } catch (retryErr) {
           console.error("retry fetch conversation error", retryErr);
-          await sendBotMessage(
-            accountId,
-            conversationId,
-            "We're having trouble retrieving conversation details. Please try again later."
-          );
+          await notifyTemporaryIssue(accountId, conversationId);
           return NextResponse.json(
             { status: "conversation_fetch_failed" },
             { status: 200 }
@@ -413,11 +410,7 @@ export async function POST(request: Request) {
           console.info("handoff", "conversation fetched", currentConversation);
         } catch (err) {
           console.error("handoff", "conversation fetch error", err);
-          await sendBotMessage(
-            accountId,
-            conversationId,
-            "We're having trouble retrieving conversation details. Please try again later."
-          );
+          await notifyTemporaryIssue(accountId, conversationId);
           return NextResponse.json(
             { status: "conversation_fetch_failed" },
             { status: 200 }
@@ -524,18 +517,16 @@ export async function POST(request: Request) {
 
     const mode = INBOX_MODE[inboxId] ?? "auto";
 
-    const fallbackMessage =
-      "We ran into a hiccup processing your message. Please wait and try again.";
     let fallbackSent = false;
     const sendFallback = async () => {
       if (fallbackSent) return;
       fallbackSent = true;
       try {
-        await sendBotMessage(accountId, conversationId, fallbackMessage, {
+        await notifyTemporaryIssue(accountId, conversationId, {
           private: mode !== "auto",
         });
       } catch (err) {
-        console.error("fallback sendBotMessage error", err);
+        console.error("fallback notifyTemporaryIssue error", err);
       }
     };
 

--- a/lib/friendlyErrors.ts
+++ b/lib/friendlyErrors.ts
@@ -1,0 +1,12 @@
+import { sendBotMessage } from "@/lib/chatwootBot";
+
+export const TEMPORARY_ISSUE_MESSAGE =
+  "We hit a temporary snag. Please try again in a bit!";
+
+export async function notifyTemporaryIssue(
+  accountId: number,
+  conversationId: number,
+  options?: { private?: boolean }
+) {
+  return sendBotMessage(accountId, conversationId, TEMPORARY_ISSUE_MESSAGE, options);
+}

--- a/tests/chatwootWebhook.test.js
+++ b/tests/chatwootWebhook.test.js
@@ -12,6 +12,8 @@ const releaseAgentMock = mock.method(conversationResolution, 'releaseAgent', asy
 const chatwootBot = require('../lib/chatwootBot.ts');
 const sendBotMessageMock = mock.method(chatwootBot, 'sendBotMessage', async () => {});
 
+const { TEMPORARY_ISSUE_MESSAGE } = require('../lib/friendlyErrors.ts');
+
 const providers = require('../lib/providers/index.ts');
 const providerFnMock = mock.fn((messages, toolsArg, options) =>
   (async function* () {
@@ -169,7 +171,7 @@ test('chatwoot status webhook returns error when releaseAgent fails', async () =
   assert.strictEqual(sendBotMessageMock.mock.calls.length, 1);
   assert.strictEqual(
     sendBotMessageMock.mock.calls[0].arguments[2],
-    "We're updating your conversation. Please wait and try again in a moment."
+    TEMPORARY_ISSUE_MESSAGE
   );
   resetMocks();
 });
@@ -207,11 +209,11 @@ test('chatwoot status webhook stops returning 500 after retry limit', async () =
   assert.strictEqual(sendBotMessageMock.mock.calls.length, 2);
   assert.strictEqual(
     sendBotMessageMock.mock.calls[0].arguments[2],
-    "We're updating your conversation. Please wait and try again in a moment."
+    TEMPORARY_ISSUE_MESSAGE
   );
   assert.strictEqual(
     sendBotMessageMock.mock.calls[1].arguments[2],
-    "We're updating your conversation. Please wait and try again in a moment."
+    TEMPORARY_ISSUE_MESSAGE
   );
   resetMocks();
 });
@@ -772,7 +774,7 @@ test('chatwoot webhook sends fallback when sendBotMessage fails', async () => {
   assert.strictEqual(sendBotMessageMock.mock.calls.length, 2);
   assert.strictEqual(
     sendBotMessageMock.mock.calls[1].arguments[2],
-    'We ran into a hiccup processing your message. Please wait and try again.'
+    TEMPORARY_ISSUE_MESSAGE
   );
   resetMocks();
 });


### PR DESCRIPTION
## Summary
- add friendly error helper to send a consistent retry message
- use friendly helper in chatwoot webhooks for temporary issues
- update tests for new friendly error message

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1fd2e0e5c833394b1244318dff68c