### PR TITLE
feat: add route-specific fallback notifications

### DIFF
--- a/app/api/chatwoot-status-webhook/route.ts
+++ b/app/api/chatwoot-status-webhook/route.ts
@@ -12,7 +12,7 @@ import {
   recordReleaseFailure,
   clearReleaseAttempts,
 } from "@/lib/releaseAttempts";
-import { notifyTemporaryIssue } from "@/lib/friendlyErrors";
+import { notifyHandoffIssue } from "@/lib/friendlyErrors";
 
 export async function POST(request: Request) {
   let accountId: number | undefined;
@@ -23,9 +23,9 @@ export async function POST(request: Request) {
       return;
     fallbackSent = true;
     try {
-      await notifyTemporaryIssue(accountId, conversationId);
+      await notifyHandoffIssue(accountId, conversationId);
     } catch (err) {
-      console.error("fallback notifyTemporaryIssue error", err);
+      console.error("fallback notifyHandoffIssue error", err);
     }
   };
   try {

--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -29,7 +29,7 @@ import {
   recordReleaseFailure,
   clearReleaseAttempts,
 } from "@/lib/releaseAttempts";
-import { notifyTemporaryIssue } from "@/lib/friendlyErrors";
+import { notifyMessageIssue } from "@/lib/friendlyErrors";
 
 export async function POST(request: Request) {
   try {
@@ -244,7 +244,7 @@ export async function POST(request: Request) {
           status = retry?.status;
         } catch (retryErr) {
           console.error("retry fetch conversation error", retryErr);
-          await notifyTemporaryIssue(accountId, conversationId);
+          await notifyMessageIssue(accountId, conversationId);
           return NextResponse.json(
             { status: "conversation_fetch_failed" },
             { status: 200 }
@@ -410,7 +410,7 @@ export async function POST(request: Request) {
           console.info("handoff", "conversation fetched", currentConversation);
         } catch (err) {
           console.error("handoff", "conversation fetch error", err);
-          await notifyTemporaryIssue(accountId, conversationId);
+          await notifyMessageIssue(accountId, conversationId);
           return NextResponse.json(
             { status: "conversation_fetch_failed" },
             { status: 200 }
@@ -522,11 +522,11 @@ export async function POST(request: Request) {
       if (fallbackSent) return;
       fallbackSent = true;
       try {
-        await notifyTemporaryIssue(accountId, conversationId, {
+        await notifyMessageIssue(accountId, conversationId, {
           private: mode !== "auto",
         });
       } catch (err) {
-        console.error("fallback notifyTemporaryIssue error", err);
+        console.error("fallback notifyMessageIssue error", err);
       }
     };
 

--- a/lib/friendlyErrors.ts
+++ b/lib/friendlyErrors.ts
@@ -1,12 +1,29 @@
 import { sendBotMessage } from "@/lib/chatwootBot";
 
-export const TEMPORARY_ISSUE_MESSAGE =
+// Text shown to users when the assistant cannot send a regular message
+// response. Exported for tests to assert route-specific fallbacks.
+export const MESSAGE_FALLBACK_TEXT =
   "We hit a temporary snag. Please try again in a bit!";
 
-export async function notifyTemporaryIssue(
+// Text shown to users when the assistant cannot complete a handoff.
+// Currently the message is the same as MESSAGE_FALLBACK_TEXT but is
+// exported separately to allow route-specific assertions.
+export const HANDOFF_FALLBACK_TEXT =
+  "We hit a temporary snag. Please try again in a bit!";
+
+export async function notifyMessageIssue(
   accountId: number,
   conversationId: number,
   options?: { private?: boolean }
 ) {
-  return sendBotMessage(accountId, conversationId, TEMPORARY_ISSUE_MESSAGE, options);
+  return sendBotMessage(accountId, conversationId, MESSAGE_FALLBACK_TEXT, options);
 }
+
+export async function notifyHandoffIssue(
+  accountId: number,
+  conversationId: number,
+  options?: { private?: boolean }
+) {
+  return sendBotMessage(accountId, conversationId, HANDOFF_FALLBACK_TEXT, options);
+}
+

--- a/tests/chatwootWebhook.test.js
+++ b/tests/chatwootWebhook.test.js
@@ -12,7 +12,10 @@ const releaseAgentMock = mock.method(conversationResolution, 'releaseAgent', asy
 const chatwootBot = require('../lib/chatwootBot.ts');
 const sendBotMessageMock = mock.method(chatwootBot, 'sendBotMessage', async () => {});
 
-const { TEMPORARY_ISSUE_MESSAGE } = require('../lib/friendlyErrors.ts');
+const {
+  MESSAGE_FALLBACK_TEXT,
+  HANDOFF_FALLBACK_TEXT,
+} = require('../lib/friendlyErrors.ts');
 
 const providers = require('../lib/providers/index.ts');
 const providerFnMock = mock.fn((messages, toolsArg, options) =>
@@ -171,7 +174,7 @@ test('chatwoot status webhook returns error when releaseAgent fails', async () =
   assert.strictEqual(sendBotMessageMock.mock.calls.length, 1);
   assert.strictEqual(
     sendBotMessageMock.mock.calls[0].arguments[2],
-    TEMPORARY_ISSUE_MESSAGE
+    HANDOFF_FALLBACK_TEXT
   );
   resetMocks();
 });
@@ -209,11 +212,11 @@ test('chatwoot status webhook stops returning 500 after retry limit', async () =
   assert.strictEqual(sendBotMessageMock.mock.calls.length, 2);
   assert.strictEqual(
     sendBotMessageMock.mock.calls[0].arguments[2],
-    TEMPORARY_ISSUE_MESSAGE
+    HANDOFF_FALLBACK_TEXT
   );
   assert.strictEqual(
     sendBotMessageMock.mock.calls[1].arguments[2],
-    TEMPORARY_ISSUE_MESSAGE
+    HANDOFF_FALLBACK_TEXT
   );
   resetMocks();
 });
@@ -774,7 +777,7 @@ test('chatwoot webhook sends fallback when sendBotMessage fails', async () => {
   assert.strictEqual(sendBotMessageMock.mock.calls.length, 2);
   assert.strictEqual(
     sendBotMessageMock.mock.calls[1].arguments[2],
-    TEMPORARY_ISSUE_MESSAGE
+    MESSAGE_FALLBACK_TEXT
   );
   resetMocks();
 });


### PR DESCRIPTION
## Summary
- add distinct message and handoff fallback helpers
- use route-specific fallback helpers in Chatwoot webhooks
- adjust webhook tests for new friendly error messages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c250b5ef3c833387284953040b7615