### PR TITLE
Gracefully handle queue failures with fallback messaging

### DIFF
--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -29,7 +29,7 @@ import {
   recordReleaseFailure,
   clearReleaseAttempts,
 } from "@/lib/releaseAttempts";
-import { notifyMessageIssue } from "@/lib/friendlyErrors";
+import { notifyMessageIssue, notifyHandoffIssue } from "@/lib/friendlyErrors";
 
 export async function POST(request: Request) {
   try {
@@ -291,11 +291,21 @@ export async function POST(request: Request) {
               conversationId,
               agentId: agent.id,
             });
-            await updateRequest(conversationKey, {
-              status: "assigned",
-              agentId: agent.id,
-            });
-            console.info("handoff", "request updated");
+            try {
+              await updateRequest(conversationKey, {
+                status: "assigned",
+                agentId: agent.id,
+              });
+              console.info("handoff", "request updated");
+            } catch (err) {
+              console.error("updateRequest error", err);
+              try {
+                await notifyHandoffIssue(accountId, conversationId);
+              } catch (err2) {
+                console.error("fallback notifyHandoffIssue error", err2);
+              }
+              return NextResponse.json({ status: "fallback" });
+            }
             console.info("handoff", {
               step: "send-message",
               accountId,
@@ -356,11 +366,21 @@ export async function POST(request: Request) {
           }
       } else {
         console.info("handoff", { step: "update-request", conversationId });
-        await updateRequest(conversationKey, {
-          status: "expired",
-          agentId: null,
-        });
-        console.info("handoff", "request updated");
+        try {
+          await updateRequest(conversationKey, {
+            status: "expired",
+            agentId: null,
+          });
+          console.info("handoff", "request updated");
+        } catch (err) {
+          console.error("updateRequest error", err);
+          try {
+            await notifyHandoffIssue(accountId, conversationId);
+          } catch (err2) {
+            console.error("fallback notifyHandoffIssue error", err2);
+          }
+          return NextResponse.json({ status: "fallback" });
+        }
         let labels = [CONVO_LABELS.expired];
         try {
           console.info("handoff", { step: "get-labels", accountId, conversationId });
@@ -433,14 +453,24 @@ export async function POST(request: Request) {
             conversationId,
             agentId: agent.id,
           });
-          await enqueueRequest(
-            accountId,
-            conversationId,
-            "assigned",
-            agent.id,
-            inboxId
-          );
-          console.info("handoff", "request enqueued", agent.id);
+          try {
+            await enqueueRequest(
+              accountId,
+              conversationId,
+              "assigned",
+              agent.id,
+              inboxId
+            );
+            console.info("handoff", "request enqueued", agent.id);
+          } catch (err) {
+            console.error("enqueueRequest error", err);
+            try {
+              await notifyHandoffIssue(accountId, conversationId);
+            } catch (err2) {
+              console.error("fallback notifyHandoffIssue error", err2);
+            }
+            return NextResponse.json({ status: "fallback" });
+          }
             const role =
               agent.role === "administrator" ? "administrator" : "agent";
             const success = await handOff(
@@ -450,10 +480,20 @@ export async function POST(request: Request) {
               role
             );
             if (!success) {
-              await updateRequest(conversationKey, {
-                status: "pending",
-                agentId: null,
-              });
+              try {
+                await updateRequest(conversationKey, {
+                  status: "pending",
+                  agentId: null,
+                });
+              } catch (err) {
+                console.error("updateRequest error", err);
+                try {
+                  await notifyHandoffIssue(accountId, conversationId);
+                } catch (err2) {
+                  console.error("fallback notifyHandoffIssue error", err2);
+                }
+                return NextResponse.json({ status: "fallback" });
+              }
               return NextResponse.json({ status: "handoff_failed" });
             }
             await setActiveConversation(agent.id, conversationId);
@@ -483,8 +523,24 @@ export async function POST(request: Request) {
             }
         } else {
           console.info("handoff", { step: "enqueue", conversationId });
-          await enqueueRequest(accountId, conversationId, undefined, undefined, inboxId);
-          console.info("handoff", "request enqueued");
+          try {
+            await enqueueRequest(
+              accountId,
+              conversationId,
+              undefined,
+              undefined,
+              inboxId
+            );
+            console.info("handoff", "request enqueued");
+          } catch (err) {
+            console.error("enqueueRequest error", err);
+            try {
+              await notifyHandoffIssue(accountId, conversationId);
+            } catch (err2) {
+              console.error("fallback notifyHandoffIssue error", err2);
+            }
+            return NextResponse.json({ status: "fallback" });
+          }
             const labels = [CONVO_LABELS.waiting];
             console.info("handoff", {
               step: "set-labels",

--- a/lib/conversationResolution.ts
+++ b/lib/conversationResolution.ts
@@ -13,6 +13,7 @@ import {
 } from "@/lib/chatwootBot";
 import { CONVO_LABELS } from "@/lib/constants";
 import { dequeueRequest, updateRequest } from "@/lib/handoffQueue";
+import { notifyHandoffIssue } from "@/lib/friendlyErrors";
 import type { Conversation } from "@/types/chatwoot";
 
 /**
@@ -123,10 +124,21 @@ export async function releaseAgent(
           await clearActiveConversation(freedAgentId);
           throw new Error("Agent availability update failed");
         }
-        await updateRequest(request.conversationKey, {
-          status: "assigned",
-          agentId: freedAgentId,
-        });
+        try {
+          await updateRequest(request.conversationKey, {
+            status: "assigned",
+            agentId: freedAgentId,
+          });
+        } catch (err) {
+          console.error("updateRequest error", err);
+          try {
+            await notifyHandoffIssue(accountId, request.conversationId);
+          } catch (err2) {
+            console.error("fallback notifyHandoffIssue error", err2);
+          }
+          outcome = "error";
+          return;
+        }
         await sendBotMessage(
           accountId,
           request.conversationId,

--- a/tests/chatwootWebhook.test.js
+++ b/tests/chatwootWebhook.test.js
@@ -46,6 +46,7 @@ const handOffMock = mock.method(handoff, 'default', async () => true);
 
 const handoffQueue = require('../lib/handoffQueue.ts');
 const enqueueRequestMock = mock.method(handoffQueue, 'enqueueRequest', async () => {});
+const updateRequestMock = mock.method(handoffQueue, 'updateRequest', async () => {});
 
 const chatwoot = require('../lib/chatwoot.ts');
 const getConversationMock = mock.method(chatwoot, 'getConversation', async () => ({ id: 1, status: 'resolved', inbox_id: 1 }));
@@ -108,6 +109,7 @@ function resetMocks() {
   setActiveConversationMock.mock.resetCalls();
   handOffMock.mock.resetCalls();
   enqueueRequestMock.mock.resetCalls();
+  updateRequestMock.mock.resetCalls();
   getConversationMock.mock.resetCalls();
   setConversationLabelsMock.mock.resetCalls();
   getConversationLabelsMock.mock.resetCalls();
@@ -547,6 +549,68 @@ test('chatwoot webhook queues request when no agent available', async () => {
   assert.deepStrictEqual(setConversationLabelsMock.mock.calls[0].arguments[2], [CONVO_LABELS.waiting]);
   assert.strictEqual(sendBotMessageMock.mock.calls[0].arguments[2], 'All human agents are currently busy. Please wait for the next available agent.');
   assert.strictEqual(getProviderMock.mock.calls.length, 0);
+  resetMocks();
+});
+
+test('chatwoot webhook sends fallback when enqueueRequest fails', async () => {
+  getNextAgentMock.mock.mockImplementationOnce(async () => ({ id: 10, role: 'agent' }));
+  getConversationMock.mock.mockImplementationOnce(async () => ({ id: 1, status: 'resolved', inbox_id: 1 }));
+  enqueueRequestMock.mock.mockImplementationOnce(async () => { throw new Error('fail'); });
+  const payload = {
+    event: 'message_created',
+    data: {
+      event: 'message_created',
+      message: {
+        id: 1,
+        message_type: 0,
+        content: 'I need a human',
+        account: { id: 1 },
+        conversation: { id: 1, inbox_id: 1, status: 'resolved', account_id: 1 },
+      },
+    },
+  };
+  const req = new Request('http://localhost', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+  const res = await webhookPost(req);
+  const body = await res.json();
+  assert.strictEqual(body.status, 'fallback');
+  assert.strictEqual(handOffMock.mock.calls.length, 0);
+  assert.strictEqual(sendBotMessageMock.mock.calls.length, 1);
+  assert.strictEqual(sendBotMessageMock.mock.calls[0].arguments[2], HANDOFF_FALLBACK_TEXT);
+  resetMocks();
+});
+
+test('chatwoot webhook sends fallback when updateRequest fails', async () => {
+  getNextAgentMock.mock.mockImplementationOnce(async () => ({ id: 10, role: 'agent' }));
+  getConversationMock.mock.mockImplementationOnce(async () => ({ id: 1, status: 'resolved', inbox_id: 1 }));
+  handOffMock.mock.mockImplementationOnce(async () => false);
+  updateRequestMock.mock.mockImplementationOnce(async () => { throw new Error('fail'); });
+  const payload = {
+    event: 'message_created',
+    data: {
+      event: 'message_created',
+      message: {
+        id: 1,
+        message_type: 0,
+        content: 'I need a human',
+        account: { id: 1 },
+        conversation: { id: 1, inbox_id: 1, status: 'resolved', account_id: 1 },
+      },
+    },
+  };
+  const req = new Request('http://localhost', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+  const res = await webhookPost(req);
+  const body = await res.json();
+  assert.strictEqual(body.status, 'fallback');
+  assert.strictEqual(updateRequestMock.mock.calls.length, 1);
+  assert.strictEqual(sendBotMessageMock.mock.calls.length, 1);
+  assert.strictEqual(sendBotMessageMock.mock.calls[0].arguments[2], HANDOFF_FALLBACK_TEXT);
+  assert.strictEqual(setConversationLabelsMock.mock.calls.length, 0);
   resetMocks();
 });
 

--- a/tests/releaseAgent.test.js
+++ b/tests/releaseAgent.test.js
@@ -8,6 +8,7 @@ const chatwoot = require('../lib/chatwoot.ts');
 const chatwootBot = require('../lib/chatwootBot.ts');
 const agentRotation = require('../lib/agentRotation.ts');
 const handoffQueue = require('../lib/handoffQueue.ts');
+const friendlyErrors = require('../lib/friendlyErrors.ts');
 const prisma = require('../lib/prisma.ts').default;
 const redis = require('../lib/redis.ts').default;
 const { POST: statusWebhookPost } = require('../app/api/chatwoot-status-webhook/route.ts');
@@ -56,6 +57,16 @@ test('releaseAgent opens and assigns conversation before notifying', async () =>
   assert.strictEqual(assignMock.mock.calls.length, 1);
   assert.deepStrictEqual(assignMock.mock.calls[0].arguments, [accountId, queuedConversationId, freedAgentId]);
   assert.strictEqual(sendMock.mock.calls.length, 1);
+});
+
+test('releaseAgent sends fallback when updateRequest fails', async () => {
+  sendMock.mock.resetCalls();
+  handoffQueue.updateRequest.mock.mockImplementationOnce(async () => { throw new Error('fail'); });
+  const notifyMock = mock.method(friendlyErrors, 'notifyHandoffIssue', async () => {});
+  await conversationResolution.releaseAgent(accountId, releasedConversationId, { assignee_id: freedAgentId });
+  assert.strictEqual(notifyMock.mock.calls.length, 1);
+  assert.strictEqual(sendMock.mock.calls.length, 0);
+  notifyMock.mock.restore();
 });
 
 test('releaseAgent throws when freed agent cannot be resolved', async () => {


### PR DESCRIPTION
## Summary
- wrap enqueueRequest and updateRequest in try/catch and send user-friendly fallback messages on failure
- prevent further processing when queue actions fail
- add regression tests for queue failure scenarios

## Testing
- `npm test` *(fails: require() of ES module p-limit from localVectorStore.ts not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68c2594712d88333a30d5f8bc8d600dd