### PR TITLE
feat: replace orange accents with blue

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,7 +11,7 @@ export default function Main() {
   return (
     <>
       <SessionTimer />
-      <div className="flex flex-col h-screen bg-[#ED6A5E] p-2">
+      <div className="flex flex-col h-screen bg-[#2B83F6] p-2">
       {/* Small screens */}
       <div className="flex gap-2 justify-center pt-2 pb-4 md:hidden">
         <div

--- a/components/ListArticles.tsx
+++ b/components/ListArticles.tsx
@@ -78,7 +78,7 @@ export default function ListArticles({
             {title}
             <Link
               size={16}
-              className="text-[#ED6A5E] cursor-pointer hover:size-[18px] transition-all duration-100"
+              className="text-[#2B83F6] cursor-pointer hover:size-[18px] transition-all duration-100"
               onClick={() => {
                 getLink(id);
               }}

--- a/components/RelevantArticles.tsx
+++ b/components/RelevantArticles.tsx
@@ -18,7 +18,7 @@ function Article({
       <div className="flex items-baseline gap-2">
         <div className=" text-black font-bold">{title}</div>
         <Link href={link} target="_blank">
-          <div className="flex items-center  text-[#ED6A5E] gap-1">
+          <div className="flex items-center  text-[#2B83F6] gap-1">
             <div className="text-xs font-medium">
               {type === "knowledge_base" ? "INTERNAL" : "PUBLIC FAQ"}
             </div>

--- a/components/ToolCall.tsx
+++ b/components/ToolCall.tsx
@@ -23,7 +23,7 @@ function FunctionCall({ toolCall }: ToolCallProps) {
   return (
     <div className="w-full mb-4">
       <div
-        className="flex gap-1 items-center justify-end w-full px-4 text-[#ED6A5E]  cursor-pointer"
+        className="flex gap-1 items-center justify-end w-full px-4 text-[#2B83F6]  cursor-pointer"
         onClick={toggleShowDetails}
       >
         <div className="flex gap-2 items-center">
@@ -90,7 +90,7 @@ function FunctionCall({ toolCall }: ToolCallProps) {
 
 function FileSearchCall({ toolCall }: ToolCallProps) {
   return (
-    <div className="flex gap-2 items-center text-[#ED6A5E] justify-end w-full mb-4 mr-2">
+    <div className="flex gap-2 items-center text-[#2B83F6] justify-end w-full mb-4 mr-2">
       <BookOpenText size={16} />
       <div className="text-sm font-medium mb-0.5">
         {toolCall.status === "completed"

--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -36,7 +36,7 @@ const Switch = React.forwardRef<
 // Add custom styles for the 'custom' mode
 const customStyles = `
   .bg-custom-background { background-color: #f0f0f0; }
-  .bg-custom-thumb { background-color: #ff6347; }
+  .bg-custom-thumb { background-color: #2B83F6; }
 `;
 
 // Inject custom styles into the document


### PR DESCRIPTION
## Summary
- update main page background to blue
- switch remaining accent text and switch thumb to blue
- confirm no lingering references to old orange colors

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c26c7f6cec8333b858edfd37930f41