### PR TITLE
feat: open markdown links in new tab

### DIFF
--- a/components/ListArticles.tsx
+++ b/components/ListArticles.tsx
@@ -2,6 +2,30 @@
 import { Link } from "lucide-react";
 import { useEffect, useState } from "react";
 import ReactMarkdown from "react-markdown";
+import ImageModal from "./ImageModal";
+import ChatImage from "./ChatImage";
+import { ImageProps } from "next/image";
+import type { Components } from "react-markdown";
+
+const markdownComponents: Components = {
+  img: (props) => (
+    <ImageModal src={(props.src as string) ?? ''}>
+      <ChatImage
+        {...(props as unknown as ImageProps)}
+        alt={props.alt || 'image'}
+        className="object-cover rounded-md cursor-pointer"
+      />
+    </ImageModal>
+  ),
+  a: ({ node, ...props }) => {
+    void node;
+    return (
+      <a {...props} target="_blank" rel="noopener noreferrer">
+        {props.children}
+      </a>
+    );
+  },
+};
 
 export default function ListArticles({
   title,
@@ -84,7 +108,10 @@ export default function ListArticles({
               }}
             />
           </h2>
-          <ReactMarkdown className="text-zinc-600 prose prose-zinc text-justify">
+          <ReactMarkdown
+            components={markdownComponents}
+            className="text-zinc-600 prose prose-zinc text-justify"
+          >
             {content}
           </ReactMarkdown>
         </div>

--- a/components/Message.tsx
+++ b/components/Message.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import ReactMarkdown from "react-markdown";
 import ImageModal from "./ImageModal";
 import { ImageProps } from "next/image";
-import type { Components } from 'react-markdown';
+import type { Components } from "react-markdown";
 import ChatImage from "./ChatImage";
 
 const markdownComponents: Components = {
@@ -16,6 +16,14 @@ const markdownComponents: Components = {
       />
     </ImageModal>
   ),
+  a: ({ node, ...props }) => {
+    void node;
+    return (
+      <a {...props} target="_blank" rel="noopener noreferrer">
+        {props.children}
+      </a>
+    );
+  },
 };
 
 interface MessageProps {


### PR DESCRIPTION
## Summary
- render markdown links with `target="_blank"` and `rel="noopener noreferrer"`
- add markdown component mapping to `ListArticles` and pass to `ReactMarkdown`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2b15f915c833391ba7affcb4a8b7a