### PR TITLE
Summarize recent conversation turns for guardrails

### DIFF
--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -596,18 +596,25 @@ export async function POST(request: Request) {
     }
 
     try {
-      const conversationInput = history
-        .filter((m: { role: string; }) => m.role !== "developer")
-        .map((m: { content: any[]; }) => m.content.map((c: { text: any; }) => c.text).join(" "))
-        .join(" ");
       const userInput =
         typeof content === "string"
           ? content
           : typeof content === "object"
             ? JSON.stringify(content)
             : String(content ?? "");
+      const historyTurns = history
+        .filter((m: { role: string }) => m.role !== "developer")
+        .map((m: { role: string; content: any[] }) => ({
+          role: m.role,
+          content: m.content.map((c: { text: any }) => c.text).join(" "),
+        }));
+      const recentTurns = historyTurns.slice(-6);
+      const relevanceInput = JSON.stringify([
+        ...recentTurns,
+        { role: "user", content: userInput },
+      ]);
       const relevance = await runRelevanceGuardrail({
-        input: conversationInput,
+        input: relevanceInput,
       });
       const jailbreak = await runJailbreakGuardrail({ input: userInput });
       if (relevance.tripwireTriggered || jailbreak.tripwireTriggered) {

--- a/app/api/turn_response/route.ts
+++ b/app/api/turn_response/route.ts
@@ -39,29 +39,31 @@ export async function POST(request: Request) {
         : null;
 
     let userInput = "";
-    let conversationInput = "";
+    let guardrailInput = "";
     let relevance = { tripwireTriggered: false };
     let jailbreak = { tripwireTriggered: false };
 
     if (Array.isArray(normalizedMessages)) {
-      conversationInput = normalizedMessages
+      const relevant = normalizedMessages
         .filter((m) => m.role !== "developer")
-        .map((m) =>
-          Array.isArray(m.content)
+        .map((m) => ({
+          role: m.role,
+          content: Array.isArray(m.content)
             ? m.content.map((c: any) => c.text ?? "").join(" ")
-            : String(m.content || "")
-        )
-        .join(" ");
+            : String(m.content || ""),
+        }));
+      let recent = relevant.slice(-6);
+      if (lastMessage && lastMessage.role === "user") {
+        const content = lastMessage.content;
+        userInput = Array.isArray(content)
+          ? content.map((c: any) => c.text ?? "").join(" ")
+          : String(content || "");
+        recent = [...recent, { role: "user", content: userInput }];
+      }
+      guardrailInput = JSON.stringify(recent);
     }
 
-    if (lastMessage && lastMessage.role === "user") {
-      const content = lastMessage.content;
-      userInput = Array.isArray(content)
-        ? content.map((c: any) => c.text ?? "").join(" ")
-        : String(content || "");
-    }
-
-    relevance = await runRelevanceGuardrail({ input: conversationInput });
+    relevance = await runRelevanceGuardrail({ input: guardrailInput });
     console.log("Relevance guardrail result:", relevance);
 
     jailbreak = await runJailbreakGuardrail({ input: userInput });


### PR DESCRIPTION
## Summary
- condense recent user and assistant turns to a short JSON summary for guardrail checks
- append the latest user message to the summary before running `runRelevanceGuardrail`

## Testing
- `npm run lint`
- `npm test` *(fails: 3 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c422f359088333ad36afc1ae1bc33e