### PR TITLE
Add content attributes to Chatwoot message type

### DIFF
--- a/types/chatwoot.ts
+++ b/types/chatwoot.ts
@@ -26,6 +26,11 @@ export interface Message {
   conversation_id?: number;
   account?: Account;
   account_id?: number;
+  content_attributes?: {
+    in_reply_to?: number | string;
+    in_reply_to_external_id?: number | string;
+    [key: string]: any;
+  };
   inbox_id?: number;
   [key: string]: any;
 }


### PR DESCRIPTION
## Summary
- allow Chatwoot messages to expose optional content_attributes metadata with reply identifiers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c99f1c1b488333836323d9e70832bc