### PR TITLE
Enrich referenced Chatwoot replies for logging and providers

### DIFF
--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -247,6 +247,81 @@ export async function POST(request: Request) {
       (message as any)?.sender?.name ??
       "";
 
+    const userInput =
+      typeof content === "string"
+        ? content
+        : typeof content === "object"
+          ? JSON.stringify(content)
+          : String(content ?? "");
+    const normalizedMessageId = parseMessageId(messageId);
+    const referencedMessageId = extractReferencedMessageId(message);
+    let referencedTurn: HistoryTurn | undefined;
+
+    if (
+      accountId !== undefined &&
+      conversationId !== undefined &&
+      typeof referencedMessageId === "number" &&
+      referencedMessageId !== normalizedMessageId
+    ) {
+      referencedTurn = await getReferencedHistoryTurn(
+        conversationKey,
+        referencedMessageId
+      );
+      if (!referencedTurn) {
+        try {
+          const remoteMessagesResponse = await getConversationMessages(
+            accountId,
+            conversationId
+          );
+          const candidateLists = [
+            (remoteMessagesResponse as any)?.payload,
+            (remoteMessagesResponse as any)?.data,
+            remoteMessagesResponse,
+          ];
+          let remoteMessages: any[] = [];
+          for (const candidate of candidateLists) {
+            if (Array.isArray(candidate)) {
+              remoteMessages = candidate;
+              break;
+            }
+          }
+          const referencedMessage = remoteMessages.find((m: any) => {
+            const id = parseMessageId(m?.id);
+            const sourceId = parseMessageId((m as any)?.source_id);
+            const idString =
+              typeof (m as any)?.id === "string" ? (m as any).id.trim() : undefined;
+            const sourceIdString =
+              typeof (m as any)?.source_id === "string"
+                ? (m as any).source_id.trim()
+                : undefined;
+            const referencedMessageIdString = String(referencedMessageId);
+            return (
+              (typeof id === "number" && id === referencedMessageId) ||
+              (typeof sourceId === "number" && sourceId === referencedMessageId) ||
+              (idString !== undefined && idString === referencedMessageIdString) ||
+              (sourceIdString !== undefined &&
+                sourceIdString === referencedMessageIdString)
+            );
+          });
+          referencedTurn = normalizeHistoryTurnFromMessage(referencedMessage);
+        } catch (err) {
+          console.error("referenced message remote fetch error", err);
+        }
+      }
+      if (!referencedTurn) {
+        console.warn("referenced message not found", {
+          accountId,
+          conversationId,
+          referencedMessageId,
+        });
+      }
+    }
+
+    const enrichedContent = referencedTurn
+      ? `Customer referenced: "${referencedTurn.content}"\n\n${userInput}`
+      : undefined;
+    const storedContent = enrichedContent ?? userInput;
+
     if (
       messageId !== undefined &&
       conversationId !== undefined &&
@@ -276,10 +351,7 @@ export async function POST(request: Request) {
             inboxId,
             conversationKey,
             sender,
-            content:
-              typeof content === "string"
-                ? content
-                : JSON.stringify(content),
+            content: storedContent,
             createdAt,
           },
         });
@@ -318,10 +390,7 @@ export async function POST(request: Request) {
                     inboxId,
                     conversationKey,
                     sender,
-                    content:
-                      typeof content === "string"
-                        ? content
-                        : JSON.stringify(content),
+                    content: storedContent,
                     createdAt,
                   })
                 );
@@ -776,82 +845,46 @@ export async function POST(request: Request) {
       return NextResponse.json({ status: "fallback" });
     }
 
+    if (enrichedContent && Array.isArray(history)) {
+      let updatedHistory = [...history];
+      const hasEnrichedTurn = updatedHistory.some(
+        (turn: any) =>
+          turn?.role === "user" &&
+          Array.isArray(turn?.content) &&
+          turn.content.some((c: any) => c?.text === enrichedContent)
+      );
+      if (!hasEnrichedTurn) {
+        let replaced = false;
+        for (let i = updatedHistory.length - 1; i >= 0; i -= 1) {
+          const turn = updatedHistory[i];
+          if (
+            turn?.role === "user" &&
+            Array.isArray(turn?.content) &&
+            turn.content.some((c: any) => c?.text === userInput)
+          ) {
+            updatedHistory[i] = toResponseMessage("user", enrichedContent);
+            replaced = true;
+            break;
+          }
+        }
+        if (!replaced) {
+          updatedHistory = [
+            ...updatedHistory,
+            toResponseMessage("user", enrichedContent),
+          ];
+        }
+      }
+      history = updatedHistory;
+    }
+
     try {
-      const userInput =
-        typeof content === "string"
-          ? content
-          : typeof content === "object"
-            ? JSON.stringify(content)
-            : String(content ?? "");
+      const guardrailUserInput = enrichedContent ?? userInput;
       const baseHistoryTurns: HistoryTurn[] = history
         .filter((m: { role: string }) => m.role !== "developer")
         .map((m: { role: string; content: any[] }) => ({
           role: m.role,
           content: m.content.map((c: { text: any }) => c.text).join(" "),
         }));
-      const normalizedMessageId = parseMessageId(messageId);
-      const referencedMessageId = extractReferencedMessageId(message);
-      let referencedTurn: HistoryTurn | undefined;
-      if (
-        typeof referencedMessageId === "number" &&
-        referencedMessageId !== normalizedMessageId
-      ) {
-        referencedTurn = await getReferencedHistoryTurn(
-          conversationKey,
-          referencedMessageId
-        );
-        if (!referencedTurn) {
-          try {
-            const remoteMessagesResponse = await getConversationMessages(
-              accountId,
-              conversationId
-            );
-            const candidateLists = [
-              (remoteMessagesResponse as any)?.payload,
-              (remoteMessagesResponse as any)?.data,
-              remoteMessagesResponse,
-            ];
-            let remoteMessages: any[] = [];
-            for (const candidate of candidateLists) {
-              if (Array.isArray(candidate)) {
-                remoteMessages = candidate;
-                break;
-              }
-            }
-            const referencedMessage = remoteMessages.find((m: any) => {
-              const id = parseMessageId(m?.id);
-              const sourceId = parseMessageId((m as any)?.source_id);
-              const idString =
-                typeof (m as any)?.id === "string"
-                  ? (m as any).id.trim()
-                  : undefined;
-              const sourceIdString =
-                typeof (m as any)?.source_id === "string"
-                  ? (m as any).source_id.trim()
-                  : undefined;
-              const referencedMessageIdString = String(referencedMessageId);
-              return (
-                (typeof id === "number" && id === referencedMessageId) ||
-                (typeof sourceId === "number" && sourceId === referencedMessageId) ||
-                (idString !== undefined &&
-                  idString === referencedMessageIdString) ||
-                (sourceIdString !== undefined &&
-                  sourceIdString === referencedMessageIdString)
-              );
-            });
-            referencedTurn = normalizeHistoryTurnFromMessage(referencedMessage);
-          } catch (err) {
-            console.error("referenced message remote fetch error", err);
-          }
-        }
-        if (!referencedTurn) {
-          console.warn("referenced message not found", {
-            accountId,
-            conversationId,
-            referencedMessageId,
-          });
-        }
-      }
       const historyTurns = referencedTurn
         ? [referencedTurn, ...baseHistoryTurns]
         : baseHistoryTurns;
@@ -871,12 +904,12 @@ export async function POST(request: Request) {
       }
       const relevanceInput = JSON.stringify([
         ...recentTurns,
-        { role: "user", content: userInput },
+        { role: "user", content: guardrailUserInput },
       ]);
       const relevance = await runRelevanceGuardrail({
         input: relevanceInput,
       });
-      const jailbreak = await runJailbreakGuardrail({ input: userInput });
+      const jailbreak = await runJailbreakGuardrail({ input: guardrailUserInput });
       if (relevance.tripwireTriggered || jailbreak.tripwireTriggered) {
         await sendBotMessage(
           accountId,

--- a/tests/chatwootWebhook.test.js
+++ b/tests/chatwootWebhook.test.js
@@ -798,6 +798,7 @@ test('chatwoot webhook includes referenced message in guardrail input', async ()
     guardrailInput = input;
     return { tripwireTriggered: false };
   });
+  redis.exists.mock.mockImplementationOnce(async () => 1);
   const referencedMessageId = 1234;
   redis.lrange.mock.mockImplementationOnce(async () => [
     JSON.stringify({
@@ -841,7 +842,23 @@ test('chatwoot webhook includes referenced message in guardrail input', async ()
   assert.strictEqual(turns[0].role, 'user');
   assert.strictEqual(turns[0].content, 'Original order number was 5678.');
   assert.strictEqual(turns[turns.length - 1].role, 'user');
-  assert.strictEqual(turns[turns.length - 1].content, 'Sure, here are the details you asked for.');
+  const expectedEnrichedText =
+    'Customer referenced: "Original order number was 5678."\n\nSure, here are the details you asked for.';
+  assert.strictEqual(turns[turns.length - 1].content, expectedEnrichedText);
+  assert.strictEqual(
+    prisma.conversationMessage.upsert.mock.calls[0].arguments[0].create.content,
+    expectedEnrichedText
+  );
+  const providerMessages = providerFnMock.mock.calls[0].arguments[0];
+  assert.strictEqual(
+    providerMessages[providerMessages.length - 1].content[0].text,
+    expectedEnrichedText
+  );
+  assert.strictEqual(redisPipelineMock.rpush.mock.calls.length, 1);
+  const storedRedisEntry = JSON.parse(
+    redisPipelineMock.rpush.mock.calls[0].arguments[1]
+  );
+  assert.strictEqual(storedRedisEntry.content, expectedEnrichedText);
   resetMocks();
 });
 


### PR DESCRIPTION
## Summary
- Detect when a Chatwoot message references a prior turn and build an enriched customer message.
- Store the enriched text in Prisma/Redis and reuse it for guardrail checks and provider history/user input.
- Update the Chatwoot webhook tests to assert the enriched text is logged and sent to the provider.

## Testing
- npm test -- tests/chatwootWebhook.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ca7ec476a88333b2465af3bf037f27