### PR TITLE
Add quoted reply support for Chatwoot responses

### DIFF
--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -479,6 +479,18 @@ export async function POST(request: Request) {
       return NextResponse.json({ status: "ignored" });
     }
 
+    const mode = INBOX_MODE[inboxId] ?? "auto";
+
+    const buildReplyOptions = () => {
+      const options: { private?: boolean; inReplyTo?: number } = {
+        private: mode !== "auto",
+      };
+      if (typeof normalizedMessageId === "number") {
+        options.inReplyTo = normalizedMessageId;
+      }
+      return options;
+    };
+
     // Reuse conversation data from the payload when possible.
     // Only fetch from Chatwoot if we are missing critical fields like `status`.
     let status = conversation?.status;
@@ -494,7 +506,11 @@ export async function POST(request: Request) {
           status = retry?.status;
         } catch (retryErr) {
           console.error("retry fetch conversation error", retryErr);
-          await notifyMessageIssue(accountId, conversationId);
+          await notifyMessageIssue(
+            accountId,
+            conversationId,
+            buildReplyOptions()
+          );
           return NextResponse.json(
             { status: "conversation_fetch_failed" },
             { status: 200 }
@@ -550,7 +566,11 @@ export async function POST(request: Request) {
             } catch (err) {
               console.error("updateRequest error", err);
               try {
-                await notifyHandoffIssue(accountId, conversationId);
+                await notifyHandoffIssue(
+                  accountId,
+                  conversationId,
+                  buildReplyOptions()
+                );
               } catch (err2) {
                 console.error("fallback notifyHandoffIssue error", err2);
               }
@@ -564,7 +584,8 @@ export async function POST(request: Request) {
             await sendBotMessage(
               accountId,
               conversationId,
-              "A human agent will join shortly."
+              "A human agent will join shortly.",
+              buildReplyOptions()
             );
             console.info("handoff", "message sent");
               let labels = [CONVO_LABELS.assigned];
@@ -625,7 +646,11 @@ export async function POST(request: Request) {
         } catch (err) {
           console.error("updateRequest error", err);
           try {
-            await notifyHandoffIssue(accountId, conversationId);
+            await notifyHandoffIssue(
+              accountId,
+              conversationId,
+              buildReplyOptions()
+            );
           } catch (err2) {
             console.error("fallback notifyHandoffIssue error", err2);
           }
@@ -680,7 +705,11 @@ export async function POST(request: Request) {
           console.info("handoff", "conversation fetched", currentConversation);
         } catch (err) {
           console.error("handoff", "conversation fetch error", err);
-          await notifyMessageIssue(accountId, conversationId);
+          await notifyMessageIssue(
+            accountId,
+            conversationId,
+            buildReplyOptions()
+          );
           return NextResponse.json(
             { status: "conversation_fetch_failed" },
             { status: 200 }
@@ -715,7 +744,11 @@ export async function POST(request: Request) {
           } catch (err) {
             console.error("enqueueRequest error", err);
             try {
-              await notifyHandoffIssue(accountId, conversationId);
+              await notifyHandoffIssue(
+                accountId,
+                conversationId,
+                buildReplyOptions()
+              );
             } catch (err2) {
               console.error("fallback notifyHandoffIssue error", err2);
             }
@@ -738,7 +771,11 @@ export async function POST(request: Request) {
               } catch (err) {
                 console.error("updateRequest error", err);
                 try {
-                  await notifyHandoffIssue(accountId, conversationId);
+                  await notifyHandoffIssue(
+                    accountId,
+                    conversationId,
+                    buildReplyOptions()
+                  );
                 } catch (err2) {
                   console.error("fallback notifyHandoffIssue error", err2);
                 }
@@ -756,7 +793,8 @@ export async function POST(request: Request) {
           await sendBotMessage(
             accountId,
             conversationId,
-            "A human agent will join shortly."
+            "A human agent will join shortly.",
+            buildReplyOptions()
           );
           console.info("handoff", "message sent");
             const labels = [CONVO_LABELS.assigned];
@@ -785,7 +823,11 @@ export async function POST(request: Request) {
           } catch (err) {
             console.error("enqueueRequest error", err);
             try {
-              await notifyHandoffIssue(accountId, conversationId);
+              await notifyHandoffIssue(
+                accountId,
+                conversationId,
+                buildReplyOptions()
+              );
             } catch (err2) {
               console.error("fallback notifyHandoffIssue error", err2);
             }
@@ -811,7 +853,8 @@ export async function POST(request: Request) {
           await sendBotMessage(
             accountId,
             conversationId,
-            "All human agents are currently busy. Please wait for the next available agent."
+            "All human agents are currently busy. Please wait for the next available agent.",
+            buildReplyOptions()
           );
           console.info("handoff", "message sent");
         }
@@ -821,16 +864,16 @@ export async function POST(request: Request) {
       return NextResponse.json({ status: "handoff" });
     }
 
-    const mode = INBOX_MODE[inboxId] ?? "auto";
-
     let fallbackSent = false;
     const sendFallback = async () => {
       if (fallbackSent) return;
       fallbackSent = true;
       try {
-        await notifyMessageIssue(accountId, conversationId, {
-          private: mode !== "auto",
-        });
+        await notifyMessageIssue(
+          accountId,
+          conversationId,
+          buildReplyOptions()
+        );
       } catch (err) {
         console.error("fallback notifyMessageIssue error", err);
       }
@@ -915,7 +958,7 @@ export async function POST(request: Request) {
           accountId,
           conversationId,
           "I can't assist with that request.",
-          { private: mode !== "auto" }
+          buildReplyOptions()
         );
         return NextResponse.json({ status: "guardrail" });
       }
@@ -956,9 +999,12 @@ export async function POST(request: Request) {
     }
 
     try {
-      await sendBotMessage(accountId, conversationId, replyText, {
-        private: mode !== "auto",
-      });
+      await sendBotMessage(
+        accountId,
+        conversationId,
+        replyText,
+        buildReplyOptions()
+      );
     } catch (err) {
       console.error("sendBotMessage error", err);
       await sendFallback();

--- a/lib/chatwootBot.ts
+++ b/lib/chatwootBot.ts
@@ -29,18 +29,37 @@ async function chatwootBotFetch(path: string, init: RequestInit = {}) {
   return JSON.parse(text || "{}");
 }
 
+export type SendBotMessageOptions = {
+  inReplyTo?: number;
+  private?: boolean;
+};
+
 export async function sendBotMessage(
   accountId: number,
   conversationId: number,
   content: string,
-  options: Record<string, any> = {}
+  options: SendBotMessageOptions = {}
 ) {
+  const { inReplyTo, private: isPrivate } = options;
+  const payload: Record<string, unknown> = {
+    content,
+    message_type: "outgoing",
+  };
+
+  if (typeof isPrivate === "boolean") {
+    payload.private = isPrivate;
+  }
+
+  if (typeof inReplyTo === "number" && Number.isFinite(inReplyTo)) {
+    payload.content_attributes = { in_reply_to: inReplyTo };
+  }
+
   return chatwootBotFetch(
     `/api/v1/accounts/${accountId}/conversations/${conversationId}/messages`,
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ content, message_type: "outgoing", ...options }),
+      body: JSON.stringify(payload),
     }
   );
 }

--- a/lib/friendlyErrors.ts
+++ b/lib/friendlyErrors.ts
@@ -1,4 +1,5 @@
 import { sendBotMessage } from "@/lib/chatwootBot";
+import type { SendBotMessageOptions } from "@/lib/chatwootBot";
 
 // Text shown to users when the assistant cannot send a regular message
 // response. Exported for tests to assert route-specific fallbacks.
@@ -14,7 +15,7 @@ export const HANDOFF_FALLBACK_TEXT =
 export async function notifyMessageIssue(
   accountId: number,
   conversationId: number,
-  options?: { private?: boolean }
+  options?: SendBotMessageOptions
 ) {
   return sendBotMessage(accountId, conversationId, MESSAGE_FALLBACK_TEXT, options);
 }
@@ -22,7 +23,7 @@ export async function notifyMessageIssue(
 export async function notifyHandoffIssue(
   accountId: number,
   conversationId: number,
-  options?: { private?: boolean }
+  options?: SendBotMessageOptions
 ) {
   return sendBotMessage(accountId, conversationId, HANDOFF_FALLBACK_TEXT, options);
 }

--- a/tests/chatwootWebhook.test.js
+++ b/tests/chatwootWebhook.test.js
@@ -519,6 +519,10 @@ test('chatwoot webhook escalates when agent available', async () => {
   assert.strictEqual(setConversationLabelsMock.mock.calls.length, 1);
   assert.deepStrictEqual(setConversationLabelsMock.mock.calls[0].arguments[2], [CONVO_LABELS.assigned]);
   assert.strictEqual(sendBotMessageMock.mock.calls[0].arguments[2], 'A human agent will join shortly.');
+  assert.deepStrictEqual(sendBotMessageMock.mock.calls[0].arguments[3], {
+    private: false,
+    inReplyTo: 1,
+  });
   assert.strictEqual(getProviderMock.mock.calls.length, 0);
   resetMocks();
 });
@@ -552,6 +556,10 @@ test('chatwoot webhook queues request when no agent available', async () => {
   assert.strictEqual(setConversationLabelsMock.mock.calls.length, 1);
   assert.deepStrictEqual(setConversationLabelsMock.mock.calls[0].arguments[2], [CONVO_LABELS.waiting]);
   assert.strictEqual(sendBotMessageMock.mock.calls[0].arguments[2], 'All human agents are currently busy. Please wait for the next available agent.');
+  assert.deepStrictEqual(sendBotMessageMock.mock.calls[0].arguments[3], {
+    private: false,
+    inReplyTo: 2,
+  });
   assert.strictEqual(getProviderMock.mock.calls.length, 0);
   resetMocks();
 });
@@ -583,6 +591,10 @@ test('chatwoot webhook sends fallback when enqueueRequest fails', async () => {
   assert.strictEqual(handOffMock.mock.calls.length, 0);
   assert.strictEqual(sendBotMessageMock.mock.calls.length, 1);
   assert.strictEqual(sendBotMessageMock.mock.calls[0].arguments[2], HANDOFF_FALLBACK_TEXT);
+  assert.deepStrictEqual(sendBotMessageMock.mock.calls[0].arguments[3], {
+    private: false,
+    inReplyTo: 1,
+  });
   resetMocks();
 });
 
@@ -614,6 +626,10 @@ test('chatwoot webhook sends fallback when updateRequest fails', async () => {
   assert.strictEqual(updateRequestMock.mock.calls.length, 1);
   assert.strictEqual(sendBotMessageMock.mock.calls.length, 1);
   assert.strictEqual(sendBotMessageMock.mock.calls[0].arguments[2], HANDOFF_FALLBACK_TEXT);
+  assert.deepStrictEqual(sendBotMessageMock.mock.calls[0].arguments[3], {
+    private: false,
+    inReplyTo: 1,
+  });
   assert.strictEqual(setConversationLabelsMock.mock.calls.length, 0);
   resetMocks();
 });
@@ -730,6 +746,7 @@ test('chatwoot webhook processes incoming message', async () => {
     data: {
       event: 'message_created',
       message: {
+        id: 700,
         message_type: 0,
         content: 'Hello',
         account: { id: 7 },
@@ -759,6 +776,7 @@ test('chatwoot webhook processes incoming message', async () => {
   assert.strictEqual(call[0], 7);
   assert.strictEqual(call[1], 7);
   assert.strictEqual(call[2], 'hi');
+  assert.deepStrictEqual(call[3], { private: false, inReplyTo: 700 });
   resetMocks();
 });
 
@@ -871,6 +889,7 @@ test('chatwoot webhook sends fallback when relevance guardrail triggers', async 
     data: {
       event: 'message_created',
       message: {
+        id: 901,
         message_type: 0,
         content: 'off topic',
         account: { id: 9 },
@@ -886,6 +905,10 @@ test('chatwoot webhook sends fallback when relevance guardrail triggers', async 
   const body = await res.json();
   assert.strictEqual(body.status, 'guardrail');
   assert.strictEqual(sendBotMessageMock.mock.calls[0].arguments[2], "I can't assist with that request.");
+  assert.deepStrictEqual(sendBotMessageMock.mock.calls[0].arguments[3], {
+    private: false,
+    inReplyTo: 901,
+  });
   assert.strictEqual(getProviderMock.mock.calls.length, 0);
   resetMocks();
 });
@@ -899,6 +922,7 @@ test('chatwoot webhook sends fallback when jailbreak guardrail triggers', async 
     data: {
       event: 'message_created',
       message: {
+        id: 902,
         message_type: 0,
         content: 'jailbreak attempt',
         account: { id: 10 },
@@ -914,6 +938,10 @@ test('chatwoot webhook sends fallback when jailbreak guardrail triggers', async 
   const body = await res.json();
   assert.strictEqual(body.status, 'guardrail');
   assert.strictEqual(sendBotMessageMock.mock.calls[0].arguments[2], "I can't assist with that request.");
+  assert.deepStrictEqual(sendBotMessageMock.mock.calls[0].arguments[3], {
+    private: false,
+    inReplyTo: 902,
+  });
   assert.strictEqual(getProviderMock.mock.calls.length, 0);
   resetMocks();
 });
@@ -927,6 +955,7 @@ test('chatwoot webhook sends fallback when sendBotMessage fails', async () => {
     data: {
       event: 'message_created',
       message: {
+        id: 800,
         message_type: 0,
         content: 'Hello',
         account: { id: 8 },
@@ -943,9 +972,17 @@ test('chatwoot webhook sends fallback when sendBotMessage fails', async () => {
   assert.strictEqual(res.status, 200);
   assert.strictEqual(body.status, 'fallback');
   assert.strictEqual(sendBotMessageMock.mock.calls.length, 2);
+  assert.deepStrictEqual(sendBotMessageMock.mock.calls[0].arguments[3], {
+    private: false,
+    inReplyTo: 800,
+  });
   assert.strictEqual(
     sendBotMessageMock.mock.calls[1].arguments[2],
     MESSAGE_FALLBACK_TEXT
   );
+  assert.deepStrictEqual(sendBotMessageMock.mock.calls[1].arguments[3], {
+    private: false,
+    inReplyTo: 800,
+  });
   resetMocks();
 });


### PR DESCRIPTION
## Summary
- add typed options for Chatwoot bot messages so quoted replies include content_attributes
- update the webhook flow to pass in-reply-to metadata on automated and fallback messages
- extend friendly error helpers and webhook tests to cover the new reply behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca91801f9c83339d6d7b191a498093