### PR TITLE
Log Chatwoot bot responses to conversation storage

### DIFF
--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -4,6 +4,7 @@ import prisma from "@/lib/prisma";
 import { getNextAgent, setActiveConversation } from "@/lib/agentRotation";
 import { sendBotMessage } from "@/lib/chatwootBot";
 import redis from "@/lib/redis";
+import { storeAssistantMessage } from "@/lib/storeConversationMessage";
 import handOff from "@/lib/handoff";
 import {
   getConversation,
@@ -496,6 +497,65 @@ export async function POST(request: Request) {
       return options;
     };
 
+    const logAssistantResponse = async (
+      response: unknown,
+      fallbackContent: string
+    ) => {
+      if (!response || typeof response !== "object") {
+        console.warn("sendBotMessage response missing payload", {
+          accountId,
+          conversationId,
+        });
+        return;
+      }
+
+      const messageId =
+        parseMessageId((response as any)?.id) ??
+        parseMessageId((response as any)?.message_id) ??
+        parseMessageId((response as any)?.source_id);
+      const responseInboxId =
+        parseMessageId((response as any)?.inbox_id) ??
+        parseMessageId((response as any)?.conversation?.inbox_id) ??
+        parseMessageId((response as any)?.inboxId);
+      const resolvedInboxId =
+        typeof responseInboxId === "number"
+          ? responseInboxId
+          : typeof inboxId === "number"
+            ? inboxId
+            : undefined;
+
+      if (typeof messageId !== "number" || typeof resolvedInboxId !== "number") {
+        console.warn("sendBotMessage response missing identifiers", {
+          hasMessageId: typeof messageId === "number",
+          hasInboxId: typeof resolvedInboxId === "number",
+          accountId,
+          conversationId,
+        });
+        return;
+      }
+
+      const resolvedContent =
+        typeof (response as any)?.content === "string"
+          ? (response as any).content
+          : fallbackContent;
+      const createdAt =
+        (response as any)?.created_at ?? (response as any)?.createdAt ?? undefined;
+      const resolvedConversationKey =
+        typeof inboxId === "number" && inboxId === resolvedInboxId
+          ? conversationKey
+          : getConversationKey(accountId, conversationId, resolvedInboxId);
+
+      await storeAssistantMessage({
+        accountId,
+        conversationId,
+        inboxId: resolvedInboxId,
+        conversationKey: resolvedConversationKey,
+        messageId,
+        content: resolvedContent,
+        createdAt,
+      });
+    };
+
     // Reuse conversation data from the payload when possible.
     // Only fetch from Chatwoot if we are missing critical fields like `status`.
     let status = conversation?.status;
@@ -586,11 +646,15 @@ export async function POST(request: Request) {
               accountId,
               conversationId,
             });
-            await sendBotMessage(
+            const botResponse = await sendBotMessage(
               accountId,
               conversationId,
               "A human agent will join shortly.",
               buildReplyOptions()
+            );
+            await logAssistantResponse(
+              botResponse,
+              "A human agent will join shortly."
             );
             console.info("handoff", "message sent");
               let labels = [CONVO_LABELS.assigned];
@@ -795,11 +859,15 @@ export async function POST(request: Request) {
             accountId,
             conversationId,
           });
-          await sendBotMessage(
+          const confirmationResponse = await sendBotMessage(
             accountId,
             conversationId,
             "A human agent will join shortly.",
             buildReplyOptions()
+          );
+          await logAssistantResponse(
+            confirmationResponse,
+            "A human agent will join shortly."
           );
           console.info("handoff", "message sent");
             const labels = [CONVO_LABELS.assigned];
@@ -855,11 +923,15 @@ export async function POST(request: Request) {
               accountId,
               conversationId,
             });
-          await sendBotMessage(
+          const botResponse = await sendBotMessage(
             accountId,
             conversationId,
             "All human agents are currently busy. Please wait for the next available agent.",
             buildReplyOptions()
+          );
+          await logAssistantResponse(
+            botResponse,
+            "All human agents are currently busy. Please wait for the next available agent."
           );
           console.info("handoff", "message sent");
         }
@@ -959,11 +1031,15 @@ export async function POST(request: Request) {
       });
       const jailbreak = await runJailbreakGuardrail({ input: guardrailUserInput });
       if (relevance.tripwireTriggered || jailbreak.tripwireTriggered) {
-        await sendBotMessage(
+        const guardrailResponse = await sendBotMessage(
           accountId,
           conversationId,
           "I can't assist with that request.",
           buildReplyOptions()
+        );
+        await logAssistantResponse(
+          guardrailResponse,
+          "I can't assist with that request."
         );
         return NextResponse.json({ status: "guardrail" });
       }
@@ -1004,12 +1080,13 @@ export async function POST(request: Request) {
     }
 
     try {
-      await sendBotMessage(
+      const finalResponse = await sendBotMessage(
         accountId,
         conversationId,
         replyText,
         buildReplyOptions()
       );
+      await logAssistantResponse(finalResponse, replyText);
     } catch (err) {
       console.error("sendBotMessage error", err);
       await sendFallback();

--- a/lib/conversationResolution.ts
+++ b/lib/conversationResolution.ts
@@ -15,6 +15,10 @@ import { CONVO_LABELS } from "@/lib/constants";
 import { dequeueRequest, updateRequest } from "@/lib/handoffQueue";
 import { notifyHandoffIssue } from "@/lib/friendlyErrors";
 import type { Conversation } from "@/types/chatwoot";
+import {
+  getNumericId,
+  storeAssistantMessage,
+} from "@/lib/storeConversationMessage";
 
 /**
  * Clear the active conversation for the freed agent and assign the next request in queue.
@@ -139,11 +143,44 @@ export async function releaseAgent(
           outcome = "error";
           return;
         }
-        await sendBotMessage(
+        const confirmationMessage = await sendBotMessage(
           accountId,
           request.conversationId,
           "A human agent will join shortly."
         );
+        const confirmationMessageId =
+          getNumericId((confirmationMessage as any)?.id) ??
+          getNumericId((confirmationMessage as any)?.message_id) ??
+          getNumericId((confirmationMessage as any)?.source_id);
+        const confirmationInboxId =
+          getNumericId((confirmationMessage as any)?.inbox_id) ??
+          getNumericId((confirmationMessage as any)?.conversation?.inbox_id) ??
+          getNumericId((confirmationMessage as any)?.inboxId);
+        if (
+          typeof confirmationMessageId === "number" &&
+          typeof confirmationInboxId === "number"
+        ) {
+          await storeAssistantMessage({
+            accountId,
+            conversationId: request.conversationId,
+            inboxId: confirmationInboxId,
+            messageId: confirmationMessageId,
+            content:
+              typeof (confirmationMessage as any)?.content === "string"
+                ? (confirmationMessage as any).content
+                : "A human agent will join shortly.",
+            createdAt:
+              (confirmationMessage as any)?.created_at ??
+              (confirmationMessage as any)?.createdAt,
+          });
+        } else {
+          console.warn("handoff confirmation missing identifiers", {
+            hasMessageId: typeof confirmationMessageId === "number",
+            hasInboxId: typeof confirmationInboxId === "number",
+            accountId,
+            conversationId: request.conversationId,
+          });
+        }
         outcome = "assigned";
       } else {
         outcome = "released";

--- a/lib/friendlyErrors.ts
+++ b/lib/friendlyErrors.ts
@@ -1,5 +1,9 @@
 import { sendBotMessage } from "@/lib/chatwootBot";
 import type { SendBotMessageOptions } from "@/lib/chatwootBot";
+import {
+  getNumericId,
+  storeAssistantMessage,
+} from "@/lib/storeConversationMessage";
 
 // Text shown to users when the assistant cannot send a regular message
 // response. Exported for tests to assert route-specific fallbacks.
@@ -17,7 +21,19 @@ export async function notifyMessageIssue(
   conversationId: number,
   options?: SendBotMessageOptions
 ) {
-  return sendBotMessage(accountId, conversationId, MESSAGE_FALLBACK_TEXT, options);
+  const response = await sendBotMessage(
+    accountId,
+    conversationId,
+    MESSAGE_FALLBACK_TEXT,
+    options
+  );
+  await logAssistantFallback(
+    accountId,
+    conversationId,
+    MESSAGE_FALLBACK_TEXT,
+    response
+  );
+  return response;
 }
 
 export async function notifyHandoffIssue(
@@ -25,6 +41,64 @@ export async function notifyHandoffIssue(
   conversationId: number,
   options?: SendBotMessageOptions
 ) {
-  return sendBotMessage(accountId, conversationId, HANDOFF_FALLBACK_TEXT, options);
+  const response = await sendBotMessage(
+    accountId,
+    conversationId,
+    HANDOFF_FALLBACK_TEXT,
+    options
+  );
+  await logAssistantFallback(
+    accountId,
+    conversationId,
+    HANDOFF_FALLBACK_TEXT,
+    response
+  );
+  return response;
+}
+
+async function logAssistantFallback(
+  accountId: number,
+  conversationId: number,
+  fallbackContent: string,
+  response: unknown
+) {
+  if (!response || typeof response !== "object") {
+    console.warn("fallback sendBotMessage response missing payload", {
+      accountId,
+      conversationId,
+    });
+    return;
+  }
+
+  const messageId =
+    getNumericId((response as any)?.id) ??
+    getNumericId((response as any)?.message_id) ??
+    getNumericId((response as any)?.source_id);
+  const inboxId =
+    getNumericId((response as any)?.inbox_id) ??
+    getNumericId((response as any)?.conversation?.inbox_id) ??
+    getNumericId((response as any)?.inboxId);
+
+  if (typeof messageId !== "number" || typeof inboxId !== "number") {
+    console.warn("fallback sendBotMessage missing identifiers", {
+      hasMessageId: typeof messageId === "number",
+      hasInboxId: typeof inboxId === "number",
+      accountId,
+      conversationId,
+    });
+    return;
+  }
+
+  await storeAssistantMessage({
+    accountId,
+    conversationId,
+    inboxId,
+    messageId,
+    content:
+      typeof (response as any)?.content === "string"
+        ? (response as any).content
+        : fallbackContent,
+    createdAt: (response as any)?.created_at ?? (response as any)?.createdAt,
+  });
 }
 

--- a/lib/handoff.ts
+++ b/lib/handoff.ts
@@ -4,6 +4,10 @@ import {
   sendBotMessage,
 } from "@/lib/chatwootBot";
 import { setAgentAvailability, updateConversation } from "@/lib/chatwoot";
+import {
+  getNumericId,
+  storeAssistantMessage,
+} from "@/lib/storeConversationMessage";
 
 export async function handOff(
   accountId: number,
@@ -33,11 +37,42 @@ export async function handOff(
       console.error("rollback conversation error", error);
     }
     try {
-      await sendBotMessage(
+      const fallbackContent =
+        "We're unable to connect you to a human agent right now. Please try again later.";
+      const response = await sendBotMessage(
         accountId,
         conversationId,
-        "We're unable to connect you to a human agent right now. Please try again later."
+        fallbackContent
       );
+      const messageId =
+        getNumericId((response as any)?.id) ??
+        getNumericId((response as any)?.message_id) ??
+        getNumericId((response as any)?.source_id);
+      const inboxId =
+        getNumericId((response as any)?.inbox_id) ??
+        getNumericId((response as any)?.conversation?.inbox_id) ??
+        getNumericId((response as any)?.inboxId);
+      if (typeof messageId === "number" && typeof inboxId === "number") {
+        await storeAssistantMessage({
+          accountId,
+          conversationId,
+          inboxId,
+          messageId,
+          content:
+            typeof (response as any)?.content === "string"
+              ? (response as any).content
+              : fallbackContent,
+          createdAt:
+            (response as any)?.created_at ?? (response as any)?.createdAt,
+        });
+      } else {
+        console.warn("handoff fallback message missing identifiers", {
+          hasMessageId: typeof messageId === "number",
+          hasInboxId: typeof inboxId === "number",
+          accountId,
+          conversationId,
+        });
+      }
     } catch (error) {
       console.error("send fallback message error", error);
     }

--- a/lib/storeConversationMessage.ts
+++ b/lib/storeConversationMessage.ts
@@ -1,0 +1,157 @@
+import prisma from "@/lib/prisma";
+import redis from "@/lib/redis";
+import { getConversationKey } from "@/lib/getConversationKey";
+
+export type StoreAssistantMessageParams = {
+  accountId: number;
+  conversationId: number;
+  inboxId: number;
+  messageId: number;
+  content: string;
+  conversationKey?: string;
+  createdAt?: Date | string | number | null;
+};
+
+export function getNumericId(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+    const parsed = Number.parseInt(trimmed, 10);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+  return undefined;
+}
+
+function toDate(value: Date | string | number | null | undefined): Date | undefined {
+  if (!value) {
+    return undefined;
+  }
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? undefined : value;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    const ms = value > 1_000_000_000_000 ? value : value * 1000;
+    const date = new Date(ms);
+    return Number.isNaN(date.getTime()) ? undefined : date;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+    const date = new Date(trimmed);
+    return Number.isNaN(date.getTime()) ? undefined : date;
+  }
+  return undefined;
+}
+
+export async function storeAssistantMessage({
+  accountId,
+  conversationId,
+  inboxId,
+  messageId,
+  content,
+  conversationKey: providedKey,
+  createdAt: rawCreatedAt,
+}: StoreAssistantMessageParams) {
+  if (!Number.isFinite(accountId) || !Number.isFinite(conversationId)) {
+    return;
+  }
+  if (!Number.isFinite(inboxId) || !Number.isFinite(messageId)) {
+    return;
+  }
+
+  const conversationKey =
+    providedKey ?? getConversationKey(accountId, conversationId, inboxId);
+
+  const normalizedContent =
+    typeof content === "string"
+      ? content
+      : typeof content === "object"
+        ? JSON.stringify(content)
+        : String(content ?? "");
+
+  const messageData: Parameters<typeof prisma.conversationMessage.upsert>[0]["create"] = {
+    messageId,
+    conversationId,
+    inboxId,
+    conversationKey,
+    sender: "bot",
+    content: normalizedContent,
+  };
+
+  const createdAt = toDate(rawCreatedAt ?? undefined);
+  if (createdAt) {
+    messageData.createdAt = createdAt;
+  }
+
+  try {
+    await prisma.conversationMessage.upsert({
+      where: { conversationKey_messageId: { conversationKey, messageId } },
+      update: {},
+      create: messageData,
+    });
+  } catch (err) {
+    console.error("assistant message log error", err);
+    return;
+  }
+
+  try {
+    const redisClient = redis as unknown as {
+      exists?: (key: string) => Promise<number>;
+      pipeline?: () => {
+        rpush: (key: string, value: string) => unknown;
+        expire: (key: string, seconds: number) => unknown;
+        exec: () => Promise<unknown>;
+      };
+    };
+
+    if (
+      typeof redisClient?.exists === "function" &&
+      typeof redisClient?.pipeline === "function"
+    ) {
+      const key = conversationKey;
+      const keyExists = await redisClient.exists(key);
+      if (!keyExists) {
+        const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
+        const recent = await prisma.conversationMessage.findMany({
+          where: { conversationKey, createdAt: { gte: since } },
+          orderBy: { messageId: "asc" },
+        });
+        if (recent.length) {
+          const pipeline = redisClient.pipeline();
+          for (const record of recent) {
+            pipeline.rpush(key, JSON.stringify(record));
+          }
+          pipeline.expire(key, 86400);
+          await pipeline.exec();
+        }
+      } else {
+        const pipeline = redisClient.pipeline();
+        const redisPayload = {
+          messageId,
+          conversationId,
+          inboxId,
+          conversationKey,
+          sender: "bot",
+          content: normalizedContent,
+          createdAt: createdAt ?? undefined,
+        };
+        pipeline.rpush(key, JSON.stringify(redisPayload));
+        pipeline.expire(key, 86400);
+        await pipeline.exec();
+      }
+    }
+  } catch (err) {
+    console.error("assistant message redis log error", err);
+  }
+}
+
+export default storeAssistantMessage;

--- a/tests/chatwootWebhook.test.js
+++ b/tests/chatwootWebhook.test.js
@@ -10,7 +10,26 @@ const conversationResolution = require('../lib/conversationResolution.ts');
 const releaseAgentMock = mock.method(conversationResolution, 'releaseAgent', async () => {});
 
 const chatwootBot = require('../lib/chatwootBot.ts');
-const sendBotMessageMock = mock.method(chatwootBot, 'sendBotMessage', async () => {});
+let nextMessageId = 0;
+const sendBotMessageMock = mock.method(
+  chatwootBot,
+  'sendBotMessage',
+  async (accountId, conversationId, content) => ({
+    id: ++nextMessageId,
+    inbox_id: 1,
+    content,
+    conversation_id: conversationId,
+    account_id: accountId,
+    created_at: Math.floor(Date.now() / 1000),
+  })
+);
+
+const storeConversationMessage = require('../lib/storeConversationMessage.ts');
+const storeAssistantMessageMock = mock.method(
+  storeConversationMessage,
+  'storeAssistantMessage',
+  async () => {}
+);
 
 const {
   MESSAGE_FALLBACK_TEXT,
@@ -105,6 +124,8 @@ function resetMocks() {
   releaseAgentMock.mock.resetCalls();
   releaseAgentMock.mock.mockImplementation(async () => {});
   sendBotMessageMock.mock.resetCalls();
+  nextMessageId = 0;
+  storeAssistantMessageMock.mock.resetCalls();
   getProviderMock.mock.resetCalls();
   providerFnMock.mock.resetCalls();
   getNextAgentMock.mock.resetCalls();
@@ -131,6 +152,14 @@ function resetMocks() {
   runJailbreakGuardrailMock.mock.resetCalls();
 }
 
+function assertLoggedIds(...expectedIds) {
+  assert.strictEqual(storeAssistantMessageMock.mock.calls.length, expectedIds.length);
+  expectedIds.forEach((id, index) => {
+    const call = storeAssistantMessageMock.mock.calls[index];
+    assert.strictEqual(call.arguments[0].messageId, id);
+  });
+}
+
 test('chatwoot status webhook releases agent on conversation_status_changed', async () => {
   const payload = {
     event: 'conversation_status_changed',
@@ -152,6 +181,7 @@ test('chatwoot status webhook releases agent on conversation_status_changed', as
   assert.strictEqual(releaseAgentMock.mock.calls.length, 1);
   assert.strictEqual(sendBotMessageMock.mock.calls.length, 0);
   assert.strictEqual(getProviderMock.mock.calls.length, 0);
+  assertLoggedIds();
   resetMocks();
 });
 
@@ -182,6 +212,7 @@ test('chatwoot status webhook returns error when releaseAgent fails', async () =
     sendBotMessageMock.mock.calls[0].arguments[2],
     HANDOFF_FALLBACK_TEXT
   );
+  assertLoggedIds(1);
   resetMocks();
 });
 
@@ -224,6 +255,7 @@ test('chatwoot status webhook stops returning 500 after retry limit', async () =
     sendBotMessageMock.mock.calls[1].arguments[2],
     HANDOFF_FALLBACK_TEXT
   );
+  assertLoggedIds(1, 2);
   resetMocks();
 });
 
@@ -253,6 +285,7 @@ test('chatwoot status webhook skips release on label removal', async () => {
   const data = await res.json();
   assert.strictEqual(data.status, 'handled');
   assert.strictEqual(releaseAgentMock.mock.calls.length, 0);
+  assertLoggedIds();
   resetMocks();
 });
 
@@ -280,6 +313,7 @@ test('chatwoot status webhook releases agent on status-only update with top-leve
   const data = await res.json();
   assert.strictEqual(data.status, 'handled');
   assert.strictEqual(releaseAgentMock.mock.calls.length, 1);
+  assertLoggedIds();
   resetMocks();
 });
 
@@ -307,6 +341,7 @@ test('chatwoot status webhook releases agent on status update', async () => {
   const data = await res.json();
   assert.strictEqual(data.status, 'handled');
   assert.strictEqual(releaseAgentMock.mock.calls.length, 1);
+  assertLoggedIds();
   resetMocks();
 });
 
@@ -333,6 +368,7 @@ test('chatwoot status webhook releases agent when label present without change',
   const data = await res.json();
   assert.strictEqual(data.status, 'handled');
   assert.strictEqual(releaseAgentMock.mock.calls.length, 1);
+  assertLoggedIds();
   resetMocks();
 });
 
@@ -369,6 +405,7 @@ test('chatwoot status webhook skips release when status changes without label', 
   assert.strictEqual(resolvedFieldsCall.arguments[1].labels_current, undefined);
   assert.strictEqual(resolvedFieldsCall.arguments[1].labels_previous, undefined);
   consoleInfoMock.mock.restore();
+  assertLoggedIds();
   resetMocks();
 });
 
@@ -413,6 +450,7 @@ test('chatwoot status webhook skips release when label removed but status open',
   ]);
   assert.deepStrictEqual(resolvedFieldsCall.arguments[1].labels_current, []);
   consoleInfoMock.mock.restore();
+  assertLoggedIds();
   resetMocks();
 });
 
@@ -459,6 +497,7 @@ test('chatwoot status webhook releases agent when status changes with label', as
     CONVO_LABELS.assigned,
   ]);
   consoleInfoMock.mock.restore();
+  assertLoggedIds();
   resetMocks();
 });
 
@@ -487,6 +526,7 @@ test('chatwoot status webhook skips release when no assignee', async () => {
   const data = await res.json();
   assert.strictEqual(data.status, 'handled');
   assert.strictEqual(releaseAgentMock.mock.calls.length, 0);
+  assertLoggedIds();
   resetMocks();
 });
 
@@ -524,6 +564,7 @@ test('chatwoot webhook escalates when agent available', async () => {
     inReplyTo: 1,
   });
   assert.strictEqual(getProviderMock.mock.calls.length, 0);
+  assertLoggedIds(1);
   resetMocks();
 });
 
@@ -561,6 +602,7 @@ test('chatwoot webhook queues request when no agent available', async () => {
     inReplyTo: 2,
   });
   assert.strictEqual(getProviderMock.mock.calls.length, 0);
+  assertLoggedIds(1);
   resetMocks();
 });
 
@@ -595,6 +637,7 @@ test('chatwoot webhook sends fallback when enqueueRequest fails', async () => {
     private: false,
     inReplyTo: 1,
   });
+  assertLoggedIds(1);
   resetMocks();
 });
 
@@ -631,6 +674,7 @@ test('chatwoot webhook sends fallback when updateRequest fails', async () => {
     inReplyTo: 1,
   });
   assert.strictEqual(setConversationLabelsMock.mock.calls.length, 0);
+  assertLoggedIds(1);
   resetMocks();
 });
 
@@ -683,6 +727,7 @@ test('chatwoot webhook releases agent on resolution with assigned label', async 
   const data = await res.json();
   assert.strictEqual(data.status, 'handled');
   assert.strictEqual(releaseAgentMock.mock.calls.length, 1);
+  assertLoggedIds();
   resetMocks();
 });
 
@@ -711,6 +756,7 @@ test('chatwoot webhook skips release when assigned label missing', async () => {
   const data = await res.json();
   assert.strictEqual(data.status, 'handled');
   assert.strictEqual(releaseAgentMock.mock.calls.length, 0);
+  assertLoggedIds();
   resetMocks();
 });
 
@@ -737,6 +783,7 @@ test('chatwoot webhook ignores request for missing IDs', async () => {
   assert.strictEqual(body.status, 'ignored');
   assert.strictEqual(sendBotMessageMock.mock.calls.length, 0);
   assert.strictEqual(getProviderMock.mock.calls.length, 0);
+  assertLoggedIds();
   resetMocks();
 });
 
@@ -777,6 +824,7 @@ test('chatwoot webhook processes incoming message', async () => {
   assert.strictEqual(call[1], 7);
   assert.strictEqual(call[2], 'hi');
   assert.deepStrictEqual(call[3], { private: false, inReplyTo: 700 });
+  assertLoggedIds(1);
   resetMocks();
 });
 
@@ -807,6 +855,7 @@ test('chatwoot webhook treats lone greeting as relevant', async () => {
   assert.strictEqual(runRelevanceGuardrailMock.mock.calls.length, 1);
   assert.ok(guardrailOutput);
   assert.strictEqual(guardrailOutput.outputInfo.relevant, true);
+  assertLoggedIds(1);
   resetMocks();
 });
 
@@ -877,6 +926,7 @@ test('chatwoot webhook includes referenced message in guardrail input', async ()
     redisPipelineMock.rpush.mock.calls[0].arguments[1]
   );
   assert.strictEqual(storedRedisEntry.content, expectedEnrichedText);
+  assertLoggedIds(1);
   resetMocks();
 });
 
@@ -922,6 +972,7 @@ test('chatwoot webhook replies to referenced message when available', async () =
     private: false,
     inReplyTo: referencedMessageId,
   });
+  assertLoggedIds(1);
   resetMocks();
 });
 
@@ -955,6 +1006,7 @@ test('chatwoot webhook sends fallback when relevance guardrail triggers', async 
     inReplyTo: 901,
   });
   assert.strictEqual(getProviderMock.mock.calls.length, 0);
+  assertLoggedIds(1);
   resetMocks();
 });
 
@@ -988,6 +1040,7 @@ test('chatwoot webhook sends fallback when jailbreak guardrail triggers', async 
     inReplyTo: 902,
   });
   assert.strictEqual(getProviderMock.mock.calls.length, 0);
+  assertLoggedIds(1);
   resetMocks();
 });
 
@@ -1029,5 +1082,6 @@ test('chatwoot webhook sends fallback when sendBotMessage fails', async () => {
     private: false,
     inReplyTo: 800,
   });
+  assertLoggedIds(1);
   resetMocks();
 });

--- a/tests/releaseAgent.test.js
+++ b/tests/releaseAgent.test.js
@@ -6,6 +6,7 @@ require('tsconfig-paths/register');
 const conversationResolution = require('../lib/conversationResolution.ts');
 const chatwoot = require('../lib/chatwoot.ts');
 const chatwootBot = require('../lib/chatwootBot.ts');
+const storeConversationMessage = require('../lib/storeConversationMessage.ts');
 const agentRotation = require('../lib/agentRotation.ts');
 const handoffQueue = require('../lib/handoffQueue.ts');
 const friendlyErrors = require('../lib/friendlyErrors.ts');
@@ -39,16 +40,47 @@ test.after(async () => {
 
 let status = 'resolved';
 
+let nextMessageId = 0;
+
 const dequeueRequestMock = mock.method(handoffQueue, 'dequeueRequest', async () => ({ conversationId: queuedConversationId, conversationKey: `chatwoot:${accountId}:${queuedConversationId}` }));
 const toggleMock = mock.method(chatwootBot, 'toggleConversationStatus', async () => {
   status = 'open';
 });
 const assignMock = mock.method(chatwootBot, 'assignConversation', async () => {});
-const sendMock = mock.method(chatwootBot, 'sendBotMessage', async () => {
-  assert.strictEqual(status, 'open');
-});
+const sendMock = mock.method(
+  chatwootBot,
+  'sendBotMessage',
+  async (accountIdArg, conversationIdArg, content) => {
+    assert.strictEqual(status, 'open');
+    return {
+      id: ++nextMessageId,
+      inbox_id: 1,
+      content,
+      conversation_id: conversationIdArg,
+      account_id: accountIdArg,
+      created_at: Math.floor(Date.now() / 1000),
+    };
+  }
+);
+
+const storeAssistantMessageMock = mock.method(
+  storeConversationMessage,
+  'storeAssistantMessage',
+  async () => {}
+);
+
+function assertLoggedIds(...expectedIds) {
+  assert.strictEqual(storeAssistantMessageMock.mock.calls.length, expectedIds.length);
+  expectedIds.forEach((id, index) => {
+    const call = storeAssistantMessageMock.mock.calls[index];
+    assert.strictEqual(call.arguments[0].messageId, id);
+  });
+}
 
 test('releaseAgent opens and assigns conversation before notifying', async () => {
+  nextMessageId = 0;
+  storeAssistantMessageMock.mock.resetCalls();
+  sendMock.mock.resetCalls();
   await conversationResolution.releaseAgent(accountId, releasedConversationId, { assignee_id: freedAgentId });
 
   assert.strictEqual(dequeueRequestMock.mock.calls.length, 1);
@@ -57,19 +89,26 @@ test('releaseAgent opens and assigns conversation before notifying', async () =>
   assert.strictEqual(assignMock.mock.calls.length, 1);
   assert.deepStrictEqual(assignMock.mock.calls[0].arguments, [accountId, queuedConversationId, freedAgentId]);
   assert.strictEqual(sendMock.mock.calls.length, 1);
+  assertLoggedIds(1);
 });
 
 test('releaseAgent sends fallback when updateRequest fails', async () => {
+  nextMessageId = 0;
+  storeAssistantMessageMock.mock.resetCalls();
   sendMock.mock.resetCalls();
   handoffQueue.updateRequest.mock.mockImplementationOnce(async () => { throw new Error('fail'); });
   const notifyMock = mock.method(friendlyErrors, 'notifyHandoffIssue', async () => {});
   await conversationResolution.releaseAgent(accountId, releasedConversationId, { assignee_id: freedAgentId });
   assert.strictEqual(notifyMock.mock.calls.length, 1);
   assert.strictEqual(sendMock.mock.calls.length, 0);
+  assertLoggedIds();
   notifyMock.mock.restore();
 });
 
 test('releaseAgent throws when freed agent cannot be resolved', async () => {
+  nextMessageId = 0;
+  storeAssistantMessageMock.mock.resetCalls();
+  sendMock.mock.resetCalls();
   const fetchErr = new Error('fetch failed');
   getConversationMock.mock.mockImplementationOnce(async () => {
     throw fetchErr;
@@ -86,9 +125,13 @@ test('releaseAgent throws when freed agent cannot be resolved', async () => {
       return true;
     }
   );
+  assertLoggedIds();
 });
 
 test('status change without label skips releaseAgent call', async () => {
+  nextMessageId = 0;
+  storeAssistantMessageMock.mock.resetCalls();
+  sendMock.mock.resetCalls();
   const consoleInfoMock = mock.method(console, 'info', () => {});
   const releaseAgentMock = mock.method(
     conversationResolution,
@@ -127,9 +170,13 @@ test('status change without label skips releaseAgent call', async () => {
   assert.strictEqual(resolvedFieldsCall.arguments[1].labels_previous, undefined);
   consoleInfoMock.mock.restore();
   releaseAgentMock.mock.restore();
+  assertLoggedIds();
 });
 
 test('label removed with status open skips releaseAgent call', async () => {
+  nextMessageId = 0;
+  storeAssistantMessageMock.mock.resetCalls();
+  sendMock.mock.resetCalls();
   const consoleInfoMock = mock.method(console, 'info', () => {});
   const releaseAgentMock = mock.method(
     conversationResolution,
@@ -176,9 +223,13 @@ test('label removed with status open skips releaseAgent call', async () => {
   assert.deepStrictEqual(resolvedFieldsCall.arguments[1].labels_current, []);
   consoleInfoMock.mock.restore();
   releaseAgentMock.mock.restore();
+  assertLoggedIds();
 });
 
 test('status change with label triggers releaseAgent', async () => {
+  nextMessageId = 0;
+  storeAssistantMessageMock.mock.resetCalls();
+  sendMock.mock.resetCalls();
   const consoleInfoMock = mock.method(console, 'info', () => {});
   const releaseAgentMock = mock.method(
     conversationResolution,
@@ -227,4 +278,5 @@ test('status change with label triggers releaseAgent', async () => {
   ]);
   consoleInfoMock.mock.restore();
   releaseAgentMock.mock.restore();
+  assertLoggedIds();
 });


### PR DESCRIPTION
## Summary
- add a reusable helper to persist assistant messages to Prisma and Redis and expose numeric parsing utilities
- capture Chatwoot bot responses across the webhook, handoff, conversation resolution, and friendly error flows and guard against missing metadata
- update Chatwoot webhook and release agent tests to verify the logging helper receives the created message IDs

## Testing
- npm test -- tests/chatwootWebhook.test.js tests/releaseAgent.test.js

------
https://chatgpt.com/codex/tasks/task_e_68caa5ea8abc83338e6ac01aade6bae4