### PR TITLE
Add set_reply_reference tool to catalog

### DIFF
--- a/config/functions.ts
+++ b/config/functions.ts
@@ -401,6 +401,14 @@ export const start_chat_session = async ({
   }
 };
 
+export const set_reply_reference = async (args: {
+  message_id?: number;
+  use_quotes?: boolean;
+  reason?: string;
+}) => {
+  return { ...args };
+};
+
 export const search_knowledge_base = async ({
   query,
   queries,
@@ -504,6 +512,7 @@ export const functionsMap = {
   get_user_profile: get_user_profile,
   create_user_profile: create_user_profile,
   start_chat_session: start_chat_session,
+  set_reply_reference: set_reply_reference,
   search_knowledge_base: search_knowledge_base,
   // add more functions as needed
 };

--- a/config/tools-list.ts
+++ b/config/tools-list.ts
@@ -341,6 +341,34 @@ export const toolsList = [
       },
     },
   },
+  {
+    type: "function",
+    function: {
+      name: "set_reply_reference",
+      description:
+        "Control whether the next reply quotes a specific customer message. When use_quotes is false and no message_id is provided, quoting is skipped entirely.",
+      parameters: {
+        type: "object",
+        properties: {
+          message_id: {
+            type: "number",
+            description:
+              "ID of the customer message to quote. Omit to clear any existing reference.",
+          },
+          use_quotes: {
+            type: "boolean",
+            description:
+              "Set to false to disable quoting. When false and message_id is omitted, the assistant will not quote any message.",
+          },
+          reason: {
+            type: "string",
+            description: "Optional explanation for updating the reply reference.",
+          },
+        },
+        additionalProperties: false,
+      },
+    },
+  },
   // add more tools as needed
 ];
 

--- a/lib/tools/tools.ts
+++ b/lib/tools/tools.ts
@@ -7,7 +7,11 @@ import { VECTOR_STORE_ID } from "@/config/constants";
  * Ollama provider only needs the function tools defined in `toolsList`.
  */
 
-const functionTools = toolsList;
+export const functionTools = toolsList;
+
+export const functionToolNames = functionTools
+  .map((tool) => (tool.type === "function" ? tool.function?.name : null))
+  .filter((name): name is string => typeof name === "string");
 
 // Tools for the OpenAI provider (includes built-in file search)
 export const tools = [

--- a/tests/tools.test.js
+++ b/tests/tools.test.js
@@ -1,0 +1,58 @@
+const assert = require('assert');
+const test = require('node:test');
+
+require('ts-node/register/transpile-only');
+require('tsconfig-paths/register');
+
+test('tool catalog includes set_reply_reference', () => {
+  const { toolsList } = require('../config/tools-list.ts');
+  const { tools, ollamaTools, functionToolNames } = require('../lib/tools/tools.ts');
+  const { functionsMap, set_reply_reference } = require('../config/functions.ts');
+
+  assert.ok(
+    toolsList.some(
+      (tool) => tool?.function?.name === 'set_reply_reference'
+    ),
+    'toolsList should include set_reply_reference'
+  );
+
+  assert.ok(
+    functionToolNames.includes('set_reply_reference'),
+    'functionToolNames should include set_reply_reference'
+  );
+
+  const openaiHasTool = tools.some(
+    (tool) =>
+      tool?.type === 'function' && tool.function?.name === 'set_reply_reference'
+  );
+  assert.ok(openaiHasTool, 'tools should include set_reply_reference');
+
+  const ollamaHasTool = ollamaTools.some(
+    (tool) => tool?.function?.name === 'set_reply_reference'
+  );
+  assert.ok(ollamaHasTool, 'ollamaTools should include set_reply_reference');
+
+  assert.strictEqual(
+    typeof functionsMap.set_reply_reference,
+    'function',
+    'functionsMap should expose set_reply_reference'
+  );
+
+  assert.strictEqual(
+    typeof set_reply_reference,
+    'function',
+    'set_reply_reference export should be a function'
+  );
+});
+
+test('set_reply_reference returns provided arguments', async () => {
+  const { set_reply_reference } = require('../config/functions.ts');
+
+  const input = { message_id: 123, use_quotes: false, reason: 'duplicate thread' };
+  const result = await set_reply_reference(input);
+  assert.deepStrictEqual(result, input);
+
+  const skipQuotingInput = { use_quotes: false };
+  const skipQuotingResult = await set_reply_reference(skipQuotingInput);
+  assert.deepStrictEqual(skipQuotingResult, skipQuotingInput);
+});


### PR DESCRIPTION
## Summary
- add the `set_reply_reference` function tool with documentation for skipping quotes
- surface a stub implementation and propagate the tool name through exported provider helpers
- verify the catalogs and stub behavior with new unit coverage

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc3664585c8333ac0f6b346c07aa91