### PR TITLE
Add helper to log bot messages and update call sites

### DIFF
--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -5,7 +5,10 @@ import prisma from "@/lib/prisma";
 import { getNextAgent, setActiveConversation } from "@/lib/agentRotation";
 import { sendBotMessage } from "@/lib/chatwootBot";
 import redis from "@/lib/redis";
-import { storeAssistantMessage } from "@/lib/storeConversationMessage";
+import {
+  resolveBotMessageIdentifiers,
+  storeBotMessage,
+} from "@/lib/storeBotMessage";
 import handOff from "@/lib/handoff";
 import {
   getConversation,
@@ -580,24 +583,28 @@ export async function POST(request: Request) {
         return;
       }
 
-      const messageId =
-        parseMessageId((response as any)?.id) ??
-        parseMessageId((response as any)?.message_id) ??
-        parseMessageId((response as any)?.source_id);
-      const responseInboxId =
-        parseMessageId((response as any)?.inbox_id) ??
-        parseMessageId((response as any)?.conversation?.inbox_id) ??
-        parseMessageId((response as any)?.inboxId);
+      const { messageId: directMessageId, sourceId, inboxId: responseInboxId } =
+        resolveBotMessageIdentifiers(response);
+      const resolvedMessageId =
+        typeof directMessageId === "number"
+          ? directMessageId
+          : typeof sourceId === "number"
+            ? sourceId
+            : undefined;
+      const fallbackInboxId =
+        typeof inboxId === "number" ? inboxId : undefined;
       const resolvedInboxId =
         typeof responseInboxId === "number"
           ? responseInboxId
-          : typeof inboxId === "number"
-            ? inboxId
-            : undefined;
+          : fallbackInboxId;
 
-      if (typeof messageId !== "number" || typeof resolvedInboxId !== "number") {
+      if (
+        typeof resolvedMessageId !== "number" ||
+        typeof resolvedInboxId !== "number"
+      ) {
         console.warn("sendBotMessage response missing identifiers", {
-          hasMessageId: typeof messageId === "number",
+          hasMessageId: typeof directMessageId === "number",
+          hasSourceId: typeof sourceId === "number",
           hasInboxId: typeof resolvedInboxId === "number",
           accountId,
           conversationId,
@@ -605,25 +612,20 @@ export async function POST(request: Request) {
         return;
       }
 
-      const resolvedContent =
-        typeof (response as any)?.content === "string"
-          ? (response as any).content
-          : fallbackContent;
-      const createdAt =
-        (response as any)?.created_at ?? (response as any)?.createdAt ?? undefined;
       const resolvedConversationKey =
         typeof inboxId === "number" && inboxId === resolvedInboxId
           ? conversationKey
-          : getConversationKey(accountId, conversationId, resolvedInboxId);
+          : undefined;
 
-      await storeAssistantMessage({
+      await storeBotMessage({
         accountId,
         conversationId,
+        messageId: resolvedMessageId,
         inboxId: resolvedInboxId,
+        payload: response,
+        sourceId,
+        fallbackContent,
         conversationKey: resolvedConversationKey,
-        messageId,
-        content: resolvedContent,
-        createdAt,
       });
     };
 

--- a/lib/conversationResolution.ts
+++ b/lib/conversationResolution.ts
@@ -16,9 +16,9 @@ import { dequeueRequest, updateRequest } from "@/lib/handoffQueue";
 import { notifyHandoffIssue } from "@/lib/friendlyErrors";
 import type { Conversation } from "@/types/chatwoot";
 import {
-  getNumericId,
-  storeAssistantMessage,
-} from "@/lib/storeConversationMessage";
+  resolveBotMessageIdentifiers,
+  storeBotMessage,
+} from "@/lib/storeBotMessage";
 
 /**
  * Clear the active conversation for the freed agent and assign the next request in queue.
@@ -148,38 +148,45 @@ export async function releaseAgent(
           request.conversationId,
           "A human agent will join shortly."
         );
-        const confirmationMessageId =
-          getNumericId((confirmationMessage as any)?.id) ??
-          getNumericId((confirmationMessage as any)?.message_id) ??
-          getNumericId((confirmationMessage as any)?.source_id);
-        const confirmationInboxId =
-          getNumericId((confirmationMessage as any)?.inbox_id) ??
-          getNumericId((confirmationMessage as any)?.conversation?.inbox_id) ??
-          getNumericId((confirmationMessage as any)?.inboxId);
-        if (
-          typeof confirmationMessageId === "number" &&
-          typeof confirmationInboxId === "number"
-        ) {
-          await storeAssistantMessage({
+        if (!confirmationMessage || typeof confirmationMessage !== "object") {
+          console.warn("handoff confirmation missing payload", {
             accountId,
             conversationId: request.conversationId,
-            inboxId: confirmationInboxId,
-            messageId: confirmationMessageId,
-            content:
-              typeof (confirmationMessage as any)?.content === "string"
-                ? (confirmationMessage as any).content
-                : "A human agent will join shortly.",
-            createdAt:
-              (confirmationMessage as any)?.created_at ??
-              (confirmationMessage as any)?.createdAt,
           });
         } else {
-          console.warn("handoff confirmation missing identifiers", {
-            hasMessageId: typeof confirmationMessageId === "number",
-            hasInboxId: typeof confirmationInboxId === "number",
-            accountId,
-            conversationId: request.conversationId,
-          });
+          const {
+            messageId: directMessageId,
+            sourceId,
+            inboxId: confirmationInboxId,
+          } = resolveBotMessageIdentifiers(confirmationMessage);
+          const resolvedMessageId =
+            typeof directMessageId === "number"
+              ? directMessageId
+              : typeof sourceId === "number"
+                ? sourceId
+                : undefined;
+          if (
+            typeof resolvedMessageId === "number" &&
+            typeof confirmationInboxId === "number"
+          ) {
+            await storeBotMessage({
+              accountId,
+              conversationId: request.conversationId,
+              messageId: resolvedMessageId,
+              inboxId: confirmationInboxId,
+              payload: confirmationMessage,
+              sourceId,
+              fallbackContent: "A human agent will join shortly.",
+            });
+          } else {
+            console.warn("handoff confirmation missing identifiers", {
+              hasMessageId: typeof directMessageId === "number",
+              hasSourceId: typeof sourceId === "number",
+              hasInboxId: typeof confirmationInboxId === "number",
+              accountId,
+              conversationId: request.conversationId,
+            });
+          }
         }
         outcome = "assigned";
       } else {

--- a/lib/friendlyErrors.ts
+++ b/lib/friendlyErrors.ts
@@ -1,9 +1,9 @@
 import { sendBotMessage } from "@/lib/chatwootBot";
 import type { SendBotMessageOptions } from "@/lib/chatwootBot";
 import {
-  getNumericId,
-  storeAssistantMessage,
-} from "@/lib/storeConversationMessage";
+  resolveBotMessageIdentifiers,
+  storeBotMessage,
+} from "@/lib/storeBotMessage";
 
 // Text shown to users when the assistant cannot send a regular message
 // response. Exported for tests to assert route-specific fallbacks.
@@ -70,18 +70,19 @@ async function logAssistantFallback(
     return;
   }
 
-  const messageId =
-    getNumericId((response as any)?.id) ??
-    getNumericId((response as any)?.message_id) ??
-    getNumericId((response as any)?.source_id);
-  const inboxId =
-    getNumericId((response as any)?.inbox_id) ??
-    getNumericId((response as any)?.conversation?.inbox_id) ??
-    getNumericId((response as any)?.inboxId);
+  const { messageId: directMessageId, sourceId, inboxId } =
+    resolveBotMessageIdentifiers(response);
+  const resolvedMessageId =
+    typeof directMessageId === "number"
+      ? directMessageId
+      : typeof sourceId === "number"
+        ? sourceId
+        : undefined;
 
-  if (typeof messageId !== "number" || typeof inboxId !== "number") {
+  if (typeof resolvedMessageId !== "number" || typeof inboxId !== "number") {
     console.warn("fallback sendBotMessage missing identifiers", {
-      hasMessageId: typeof messageId === "number",
+      hasMessageId: typeof directMessageId === "number",
+      hasSourceId: typeof sourceId === "number",
       hasInboxId: typeof inboxId === "number",
       accountId,
       conversationId,
@@ -89,16 +90,14 @@ async function logAssistantFallback(
     return;
   }
 
-  await storeAssistantMessage({
+  await storeBotMessage({
     accountId,
     conversationId,
+    messageId: resolvedMessageId,
     inboxId,
-    messageId,
-    content:
-      typeof (response as any)?.content === "string"
-        ? (response as any).content
-        : fallbackContent,
-    createdAt: (response as any)?.created_at ?? (response as any)?.createdAt,
+    payload: response,
+    sourceId,
+    fallbackContent,
   });
 }
 

--- a/lib/handoff.ts
+++ b/lib/handoff.ts
@@ -5,9 +5,9 @@ import {
 } from "@/lib/chatwootBot";
 import { setAgentAvailability, updateConversation } from "@/lib/chatwoot";
 import {
-  getNumericId,
-  storeAssistantMessage,
-} from "@/lib/storeConversationMessage";
+  resolveBotMessageIdentifiers,
+  storeBotMessage,
+} from "@/lib/storeBotMessage";
 
 export async function handOff(
   accountId: number,
@@ -44,30 +44,37 @@ export async function handOff(
         conversationId,
         fallbackContent
       );
-      const messageId =
-        getNumericId((response as any)?.id) ??
-        getNumericId((response as any)?.message_id) ??
-        getNumericId((response as any)?.source_id);
-      const inboxId =
-        getNumericId((response as any)?.inbox_id) ??
-        getNumericId((response as any)?.conversation?.inbox_id) ??
-        getNumericId((response as any)?.inboxId);
-      if (typeof messageId === "number" && typeof inboxId === "number") {
-        await storeAssistantMessage({
+      if (!response || typeof response !== "object") {
+        console.warn("handoff fallback message missing payload", {
           accountId,
           conversationId,
+        });
+        return false;
+      }
+
+      const { messageId: directMessageId, sourceId, inboxId } =
+        resolveBotMessageIdentifiers(response);
+      const resolvedMessageId =
+        typeof directMessageId === "number"
+          ? directMessageId
+          : typeof sourceId === "number"
+            ? sourceId
+            : undefined;
+
+      if (typeof resolvedMessageId === "number" && typeof inboxId === "number") {
+        await storeBotMessage({
+          accountId,
+          conversationId,
+          messageId: resolvedMessageId,
           inboxId,
-          messageId,
-          content:
-            typeof (response as any)?.content === "string"
-              ? (response as any).content
-              : fallbackContent,
-          createdAt:
-            (response as any)?.created_at ?? (response as any)?.createdAt,
+          payload: response,
+          sourceId,
+          fallbackContent,
         });
       } else {
         console.warn("handoff fallback message missing identifiers", {
-          hasMessageId: typeof messageId === "number",
+          hasMessageId: typeof directMessageId === "number",
+          hasSourceId: typeof sourceId === "number",
           hasInboxId: typeof inboxId === "number",
           accountId,
           conversationId,

--- a/lib/storeBotMessage.ts
+++ b/lib/storeBotMessage.ts
@@ -1,0 +1,121 @@
+import { getConversationKey } from "@/lib/getConversationKey";
+import {
+  getNumericId,
+  storeAssistantMessage,
+  type StoreAssistantMessageParams,
+} from "@/lib/storeConversationMessage";
+
+export type BotMessageIdentifiers = {
+  messageId?: number;
+  sourceId?: number;
+  inboxId?: number;
+};
+
+export type StoreBotMessageParams = {
+  accountId: number;
+  conversationId: number;
+  messageId: number;
+  inboxId: number;
+  payload?: unknown;
+  sourceId?: number;
+  fallbackContent?: string;
+  conversationKey?: string;
+  createdAt?: StoreAssistantMessageParams["createdAt"];
+};
+
+export type StoreBotMessageResult = {
+  stored: true;
+  messageId: number;
+  inboxId: number;
+  sourceId?: number;
+  conversationKey: string;
+  content: string;
+};
+
+export function resolveBotMessageIdentifiers(payload: unknown): BotMessageIdentifiers {
+  if (!payload || typeof payload !== "object") {
+    return {};
+  }
+
+  const record = payload as Record<string, unknown>;
+
+  const messageId =
+    getNumericId((record as any)?.id) ??
+    getNumericId((record as any)?.message_id) ??
+    undefined;
+
+  const sourceId = getNumericId((record as any)?.source_id) ?? undefined;
+
+  let inboxId = getNumericId((record as any)?.inbox_id) ?? undefined;
+  if (inboxId === undefined) {
+    const conversation = (record as any)?.conversation;
+    if (conversation && typeof conversation === "object") {
+      inboxId = getNumericId((conversation as any)?.inbox_id) ?? undefined;
+    }
+  }
+  if (inboxId === undefined) {
+    inboxId = getNumericId((record as any)?.inboxId) ?? undefined;
+  }
+
+  return { messageId, sourceId, inboxId };
+}
+
+export async function storeBotMessage({
+  accountId,
+  conversationId,
+  messageId,
+  inboxId,
+  payload,
+  sourceId,
+  fallbackContent,
+  conversationKey: providedConversationKey,
+  createdAt: explicitCreatedAt,
+}: StoreBotMessageParams): Promise<StoreBotMessageResult> {
+  const record =
+    payload && typeof payload === "object"
+      ? (payload as Record<string, unknown>)
+      : undefined;
+
+  const contentValue =
+    typeof record?.content === "string"
+      ? record.content
+      : typeof fallbackContent === "string"
+        ? fallbackContent
+        : "";
+
+  const createdAtValue =
+    explicitCreatedAt ??
+    ((record?.created_at ?? record?.createdAt) as
+      | Date
+      | string
+      | number
+      | null
+      | undefined);
+
+  const resolvedSourceId =
+    sourceId ?? (record ? getNumericId((record as any)?.source_id) ?? undefined : undefined);
+
+  const conversationKey =
+    typeof providedConversationKey === "string" && providedConversationKey.trim().length > 0
+      ? providedConversationKey
+      : getConversationKey(accountId, conversationId, inboxId);
+
+  await storeAssistantMessage({
+    accountId,
+    conversationId,
+    inboxId,
+    conversationKey,
+    messageId,
+    content: contentValue,
+    createdAt: createdAtValue,
+  });
+
+  return {
+    stored: true,
+    messageId,
+    inboxId,
+    sourceId: resolvedSourceId,
+    conversationKey,
+    content: contentValue,
+  };
+}

--- a/tests/chatwootWebhook.test.js
+++ b/tests/chatwootWebhook.test.js
@@ -24,11 +24,27 @@ const sendBotMessageMock = mock.method(
   })
 );
 
-const storeConversationMessage = require('../lib/storeConversationMessage.ts');
-const storeAssistantMessageMock = mock.method(
-  storeConversationMessage,
-  'storeAssistantMessage',
-  async () => {}
+const storeBotMessage = require('../lib/storeBotMessage.ts');
+const storeBotMessageMock = mock.method(
+  storeBotMessage,
+  'storeBotMessage',
+  async (args) => ({
+    stored: true,
+    messageId: args.messageId,
+    inboxId: args.inboxId,
+    sourceId: args.sourceId,
+    conversationKey:
+      args.conversationKey ??
+      `chatwoot:${args.accountId}:${args.conversationId}:${args.inboxId}`,
+    content:
+      typeof args?.payload === 'object' &&
+      args?.payload !== null &&
+      typeof args.payload.content === 'string'
+        ? args.payload.content
+        : typeof args.fallbackContent === 'string'
+          ? args.fallbackContent
+          : '',
+  })
 );
 
 const {
@@ -133,7 +149,7 @@ function resetMocks() {
   releaseAgentMock.mock.mockImplementation(async () => {});
   sendBotMessageMock.mock.resetCalls();
   nextMessageId = 0;
-  storeAssistantMessageMock.mock.resetCalls();
+  storeBotMessageMock.mock.resetCalls();
   getProviderMock.mock.resetCalls();
   providerFnMock.mock.resetCalls();
   getNextAgentMock.mock.resetCalls();
@@ -163,9 +179,9 @@ function resetMocks() {
 }
 
 function assertLoggedIds(...expectedIds) {
-  assert.strictEqual(storeAssistantMessageMock.mock.calls.length, expectedIds.length);
+  assert.strictEqual(storeBotMessageMock.mock.calls.length, expectedIds.length);
   expectedIds.forEach((id, index) => {
-    const call = storeAssistantMessageMock.mock.calls[index];
+    const call = storeBotMessageMock.mock.calls[index];
     assert.strictEqual(call.arguments[0].messageId, id);
   });
 }

--- a/tests/releaseAgent.test.js
+++ b/tests/releaseAgent.test.js
@@ -6,7 +6,7 @@ require('tsconfig-paths/register');
 const conversationResolution = require('../lib/conversationResolution.ts');
 const chatwoot = require('../lib/chatwoot.ts');
 const chatwootBot = require('../lib/chatwootBot.ts');
-const storeConversationMessage = require('../lib/storeConversationMessage.ts');
+const storeBotMessage = require('../lib/storeBotMessage.ts');
 const agentRotation = require('../lib/agentRotation.ts');
 const handoffQueue = require('../lib/handoffQueue.ts');
 const friendlyErrors = require('../lib/friendlyErrors.ts');
@@ -63,23 +63,39 @@ const sendMock = mock.method(
   }
 );
 
-const storeAssistantMessageMock = mock.method(
-  storeConversationMessage,
-  'storeAssistantMessage',
-  async () => {}
+const storeBotMessageMock = mock.method(
+  storeBotMessage,
+  'storeBotMessage',
+  async (args) => ({
+    stored: true,
+    messageId: args.messageId,
+    inboxId: args.inboxId,
+    sourceId: args.sourceId,
+    conversationKey:
+      args.conversationKey ??
+      `chatwoot:${args.accountId}:${args.conversationId}:${args.inboxId}`,
+    content:
+      typeof args?.payload === 'object' &&
+      args?.payload !== null &&
+      typeof args.payload.content === 'string'
+        ? args.payload.content
+        : typeof args.fallbackContent === 'string'
+          ? args.fallbackContent
+          : '',
+  })
 );
 
 function assertLoggedIds(...expectedIds) {
-  assert.strictEqual(storeAssistantMessageMock.mock.calls.length, expectedIds.length);
+  assert.strictEqual(storeBotMessageMock.mock.calls.length, expectedIds.length);
   expectedIds.forEach((id, index) => {
-    const call = storeAssistantMessageMock.mock.calls[index];
+    const call = storeBotMessageMock.mock.calls[index];
     assert.strictEqual(call.arguments[0].messageId, id);
   });
 }
 
 test('releaseAgent opens and assigns conversation before notifying', async () => {
   nextMessageId = 0;
-  storeAssistantMessageMock.mock.resetCalls();
+  storeBotMessageMock.mock.resetCalls();
   sendMock.mock.resetCalls();
   await conversationResolution.releaseAgent(accountId, releasedConversationId, { assignee_id: freedAgentId });
 
@@ -94,7 +110,7 @@ test('releaseAgent opens and assigns conversation before notifying', async () =>
 
 test('releaseAgent sends fallback when updateRequest fails', async () => {
   nextMessageId = 0;
-  storeAssistantMessageMock.mock.resetCalls();
+  storeBotMessageMock.mock.resetCalls();
   sendMock.mock.resetCalls();
   handoffQueue.updateRequest.mock.mockImplementationOnce(async () => { throw new Error('fail'); });
   const notifyMock = mock.method(friendlyErrors, 'notifyHandoffIssue', async () => {});
@@ -107,7 +123,7 @@ test('releaseAgent sends fallback when updateRequest fails', async () => {
 
 test('releaseAgent throws when freed agent cannot be resolved', async () => {
   nextMessageId = 0;
-  storeAssistantMessageMock.mock.resetCalls();
+  storeBotMessageMock.mock.resetCalls();
   sendMock.mock.resetCalls();
   const fetchErr = new Error('fetch failed');
   getConversationMock.mock.mockImplementationOnce(async () => {
@@ -130,7 +146,7 @@ test('releaseAgent throws when freed agent cannot be resolved', async () => {
 
 test('status change without label skips releaseAgent call', async () => {
   nextMessageId = 0;
-  storeAssistantMessageMock.mock.resetCalls();
+  storeBotMessageMock.mock.resetCalls();
   sendMock.mock.resetCalls();
   const consoleInfoMock = mock.method(console, 'info', () => {});
   const releaseAgentMock = mock.method(
@@ -175,7 +191,7 @@ test('status change without label skips releaseAgent call', async () => {
 
 test('label removed with status open skips releaseAgent call', async () => {
   nextMessageId = 0;
-  storeAssistantMessageMock.mock.resetCalls();
+  storeBotMessageMock.mock.resetCalls();
   sendMock.mock.resetCalls();
   const consoleInfoMock = mock.method(console, 'info', () => {});
   const releaseAgentMock = mock.method(
@@ -228,7 +244,7 @@ test('label removed with status open skips releaseAgent call', async () => {
 
 test('status change with label triggers releaseAgent', async () => {
   nextMessageId = 0;
-  storeAssistantMessageMock.mock.resetCalls();
+  storeBotMessageMock.mock.resetCalls();
   sendMock.mock.resetCalls();
   const consoleInfoMock = mock.method(console, 'info', () => {});
   const releaseAgentMock = mock.method(


### PR DESCRIPTION
## Summary
- add a helper that captures bot message identifiers from Chatwoot responses and stores them via Prisma/Redis
- route all sendBotMessage call sites through the helper so outbound messages are logged consistently and guarded against missing IDs
- update webhook and release tests to mock the helper and assert outbound messages include IDs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd7aaa06348333a953c8f2ca17aaf0