### PR TITLE
Add quote heuristics and update webhook quoting

### DIFF
--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -40,6 +40,7 @@ import {
   clearReleaseAttempts,
 } from "@/lib/releaseAttempts";
 import { notifyMessageIssue, notifyHandoffIssue } from "@/lib/friendlyErrors";
+import { shouldQuoteInboundMessage } from "@/lib/quoteHeuristics";
 
 type HistoryTurn = { role: string; content: string };
 
@@ -541,31 +542,42 @@ export async function POST(request: Request) {
     const mode = INBOX_MODE[inboxId] ?? "auto";
 
     const buildReplyOptions = (
-      overrides: { quoteMessageId?: number | null; forcePrivate?: boolean } = {}
+      overrides?: { quoteMessageId?: number | null; forcePrivate?: boolean }
     ) => {
-      const { quoteMessageId, forcePrivate } = overrides;
       const options: { private?: boolean; inReplyTo?: number } = {};
+      const forcePrivate = overrides?.forcePrivate;
+      const quoteMessageId = overrides?.quoteMessageId;
       const privateValue =
         typeof forcePrivate === "boolean" ? forcePrivate : mode !== "auto";
       options.private = privateValue;
 
-      let resolvedQuoteId: number | undefined;
+      const hasOverrides = overrides !== undefined;
+      const hasQuoteProp =
+        hasOverrides &&
+        Object.prototype.hasOwnProperty.call(
+          overrides as Record<string, unknown>,
+          "quoteMessageId"
+        );
+
       if (quoteMessageId === null) {
-        resolvedQuoteId = undefined;
-      } else if (
+        return options;
+      }
+
+      if (
         typeof quoteMessageId === "number" &&
         Number.isFinite(quoteMessageId)
       ) {
-        resolvedQuoteId = quoteMessageId;
-      } else if (
+        options.inReplyTo = quoteMessageId;
+        return options;
+      }
+
+      if (
+        hasOverrides &&
+        !hasQuoteProp &&
         typeof defaultReplyToId === "number" &&
         Number.isFinite(defaultReplyToId)
       ) {
-        resolvedQuoteId = defaultReplyToId;
-      }
-
-      if (resolvedQuoteId !== undefined) {
-        options.inReplyTo = resolvedQuoteId;
+        options.inReplyTo = defaultReplyToId;
       }
 
       return options;
@@ -1269,12 +1281,44 @@ export async function POST(request: Request) {
       return NextResponse.json({ status: "fallback" });
     }
 
+    const quoteHistoryTurns: HistoryTurn[] = Array.isArray(history)
+      ? history
+          .filter((m: { role: string }) => m.role !== "developer")
+          .map((m: { role: string; content: any[] }) => ({
+            role: m.role,
+            content: m.content.map((c: { text: any }) => c.text).join(" "),
+          }))
+      : [];
+
+    let finalReplyReference = replyReferenceOverride;
+    if (finalReplyReference === undefined) {
+      const shouldQuote = shouldQuoteInboundMessage({
+        messageText: userInput,
+        referencedMessageId,
+        referencedMessageContent: referencedTurn?.content,
+        history: quoteHistoryTurns,
+      });
+      if (shouldQuote) {
+        const preferredQuoteId =
+          typeof referencedMessageId === "number" &&
+          Number.isFinite(referencedMessageId)
+            ? referencedMessageId
+            : typeof defaultReplyToId === "number" &&
+                Number.isFinite(defaultReplyToId)
+              ? defaultReplyToId
+              : undefined;
+        if (typeof preferredQuoteId === "number") {
+          finalReplyReference = { quoteMessageId: preferredQuoteId };
+        }
+      }
+    }
+
     try {
       const finalResponse = await sendBotMessage(
         accountId,
         conversationId,
         replyText,
-        buildReplyOptions(replyReferenceOverride)
+        buildReplyOptions(finalReplyReference)
       );
       await logAssistantResponse(finalResponse, replyText);
     } catch (err) {

--- a/lib/quoteHeuristics.ts
+++ b/lib/quoteHeuristics.ts
@@ -1,0 +1,103 @@
+type QuoteHeuristicsTurn = { role: string; content: string };
+
+const SHORT_ACKNOWLEDGEMENT_PATTERNS = [
+  /^(yes|yep|yeah|ya)$/i,
+  /^(same question|same issue|same problem)$/i,
+  /^(same here|me too)$/i,
+  /^following$/i,
+];
+
+const PRONOUN_PHRASES = [
+  "this issue",
+  "this problem",
+  "this question",
+  "this request",
+  "this one",
+  "that issue",
+  "that problem",
+  "that question",
+  "that one",
+  "same issue",
+  "same problem",
+  "same question",
+];
+
+const PRONOUN_WORDS = ["this", "that", "it", "those", "these"];
+
+function normalizeText(value: unknown): string {
+  if (typeof value !== "string") {
+    return "";
+  }
+  return value.trim().replace(/\s+/g, " ");
+}
+
+function hasShortAcknowledgement(message: string): boolean {
+  return SHORT_ACKNOWLEDGEMENT_PATTERNS.some((pattern) => pattern.test(message));
+}
+
+function hasPronounIndicator(message: string): boolean {
+  const lower = message.toLowerCase();
+  if (PRONOUN_PHRASES.some((phrase) => lower.includes(phrase))) {
+    return true;
+  }
+
+  const words = lower.split(/\s+/).filter(Boolean);
+  if (!words.length || words.length > 6) {
+    return false;
+  }
+  const pronounMatches = words.filter((word) => PRONOUN_WORDS.includes(word)).length;
+  return pronounMatches >= 1;
+}
+
+function isDuplicateOfTurn(message: string, history: QuoteHeuristicsTurn[]): boolean {
+  if (!message) {
+    return false;
+  }
+  const normalizedMessage = message.toLowerCase();
+  return history.some((turn) => {
+    if (!turn || turn.role !== "user") {
+      return false;
+    }
+    const normalizedTurn = normalizeText(turn.content).toLowerCase();
+    return normalizedTurn.length > 0 && normalizedTurn === normalizedMessage;
+  });
+}
+
+export type QuoteHeuristicsInput = {
+  messageText?: string | null;
+  referencedMessageId?: number;
+  referencedMessageContent?: string | null;
+  history?: QuoteHeuristicsTurn[];
+};
+
+export function shouldQuoteInboundMessage({
+  messageText,
+  referencedMessageContent,
+  history = [],
+}: QuoteHeuristicsInput): boolean {
+  const normalizedMessage = normalizeText(messageText);
+  if (!normalizedMessage) {
+    return false;
+  }
+
+  if (hasShortAcknowledgement(normalizedMessage)) {
+    return true;
+  }
+
+  if (hasPronounIndicator(normalizedMessage)) {
+    return true;
+  }
+
+  const normalizedReference = normalizeText(referencedMessageContent);
+  if (normalizedReference && normalizedReference.toLowerCase() === normalizedMessage.toLowerCase()) {
+    return true;
+  }
+
+  if (Array.isArray(history) && isDuplicateOfTurn(normalizedMessage, history)) {
+    return true;
+  }
+
+  return false;
+}
+
+export type { QuoteHeuristicsTurn };

--- a/tests/chatwootWebhook.test.js
+++ b/tests/chatwootWebhook.test.js
@@ -175,7 +175,13 @@ function resetMocks() {
   redisPipelineMock.expire.mock.resetCalls();
   redisPipelineMock.exec.mock.resetCalls();
   runRelevanceGuardrailMock.mock.resetCalls();
+  runRelevanceGuardrailMock.mock.mockImplementation(async () => ({
+    tripwireTriggered: false,
+  }));
   runJailbreakGuardrailMock.mock.resetCalls();
+  runJailbreakGuardrailMock.mock.mockImplementation(async () => ({
+    tripwireTriggered: false,
+  }));
 }
 
 function assertLoggedIds(...expectedIds) {
@@ -1115,14 +1121,13 @@ test('chatwoot webhook replies to referenced message when available', async () =
   assert.strictEqual(sendBotMessageMock.mock.calls.length, 1);
   assert.deepStrictEqual(sendBotMessageMock.mock.calls[0].arguments[3], {
     private: false,
-    inReplyTo: referencedMessageId,
   });
   assertLoggedIds(1);
   resetMocks();
 });
 
 test('chatwoot webhook sends fallback when relevance guardrail triggers', async () => {
-  runRelevanceGuardrailMock.mock.mockImplementationOnce(async () => ({
+  runRelevanceGuardrailMock.mock.mockImplementation(async () => ({
     tripwireTriggered: true,
   }));
   const payload = {
@@ -1156,7 +1161,7 @@ test('chatwoot webhook sends fallback when relevance guardrail triggers', async 
 });
 
 test('chatwoot webhook sends fallback when jailbreak guardrail triggers', async () => {
-  runJailbreakGuardrailMock.mock.mockImplementationOnce(async () => ({
+  runJailbreakGuardrailMock.mock.mockImplementation(async () => ({
     tripwireTriggered: true,
   }));
   const payload = {
@@ -1215,10 +1220,9 @@ test('chatwoot webhook sends fallback when sendBotMessage fails', async () => {
   assert.strictEqual(res.status, 200);
   assert.strictEqual(body.status, 'fallback');
   assert.strictEqual(sendBotMessageMock.mock.calls.length, 2);
-  assert.deepStrictEqual(sendBotMessageMock.mock.calls[0].arguments[3], {
-    private: false,
-    inReplyTo: 800,
-  });
+  const initialOptions = sendBotMessageMock.mock.calls[0].arguments[3];
+  assert.strictEqual(initialOptions.private, false);
+  assert.ok(!Object.prototype.hasOwnProperty.call(initialOptions, 'inReplyTo'));
   assert.strictEqual(
     sendBotMessageMock.mock.calls[1].arguments[2],
     MESSAGE_FALLBACK_TEXT
@@ -1227,6 +1231,73 @@ test('chatwoot webhook sends fallback when sendBotMessage fails', async () => {
     private: false,
     inReplyTo: 800,
   });
+  assertLoggedIds(1);
+  resetMocks();
+});
+
+test('chatwoot webhook auto quotes acknowledgement when heuristic triggers', async () => {
+  const referencedMessageId = 4123;
+  const payload = {
+    event: 'message_created',
+    data: {
+      event: 'message_created',
+      message: {
+        id: 905,
+        message_type: 0,
+        content: 'Yes',
+        account: { id: 17 },
+        conversation: {
+          id: 905,
+          inbox_id: 1,
+          status: 'resolved',
+          account_id: 17,
+        },
+        content_attributes: { in_reply_to: referencedMessageId },
+      },
+    },
+  };
+  const req = new Request('http://localhost', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+  const res = await webhookPost(req);
+  await res.json();
+  assert.strictEqual(sendBotMessageMock.mock.calls.length, 1);
+  const options = sendBotMessageMock.mock.calls[0].arguments[3];
+  assert.deepStrictEqual(options, { private: false, inReplyTo: referencedMessageId });
+  assertLoggedIds(1);
+  resetMocks();
+});
+
+test('chatwoot webhook leaves inReplyTo unset when heuristic does not trigger', async () => {
+  const payload = {
+    event: 'message_created',
+    data: {
+      event: 'message_created',
+      message: {
+        id: 906,
+        message_type: 0,
+        content: 'Thanks for the help earlier, here are the details.',
+        account: { id: 18 },
+        conversation: {
+          id: 906,
+          inbox_id: 1,
+          status: 'resolved',
+          account_id: 18,
+        },
+      },
+    },
+  };
+  const req = new Request('http://localhost', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+  const res = await webhookPost(req);
+  await res.json();
+  assert.strictEqual(sendBotMessageMock.mock.calls.length, 1);
+  const options = sendBotMessageMock.mock.calls[0].arguments[3];
+  assert.strictEqual(options.private, false);
+  assert.ok(!Object.prototype.hasOwnProperty.call(options, 'inReplyTo'));
   assertLoggedIds(1);
   resetMocks();
 });

--- a/tests/quoteHeuristics.test.js
+++ b/tests/quoteHeuristics.test.js
@@ -1,0 +1,48 @@
+const assert = require('assert');
+const { test } = require('node:test');
+
+const { shouldQuoteInboundMessage } = require('../lib/quoteHeuristics.ts');
+
+test('shouldQuoteInboundMessage flags short acknowledgements', () => {
+  assert.strictEqual(
+    shouldQuoteInboundMessage({ messageText: 'Yes', referencedMessageId: 123 }),
+    true
+  );
+  assert.strictEqual(
+    shouldQuoteInboundMessage({ messageText: 'Same question' }),
+    true
+  );
+});
+
+test('shouldQuoteInboundMessage detects pronoun heavy replies', () => {
+  assert.strictEqual(
+    shouldQuoteInboundMessage({ messageText: 'This issue', referencedMessageId: 5 }),
+    true
+  );
+  assert.strictEqual(
+    shouldQuoteInboundMessage({ messageText: 'That one is broken' }),
+    true
+  );
+});
+
+test('shouldQuoteInboundMessage matches duplicates', () => {
+  const history = [
+    { role: 'assistant', content: 'How can I help?' },
+    { role: 'user', content: 'My login fails' },
+  ];
+  assert.strictEqual(
+    shouldQuoteInboundMessage({ messageText: 'My login fails', history }),
+    true
+  );
+  assert.strictEqual(
+    shouldQuoteInboundMessage({ messageText: 'Different question', history }),
+    false
+  );
+});
+
+test('shouldQuoteInboundMessage stays false for unrelated messages', () => {
+  assert.strictEqual(
+    shouldQuoteInboundMessage({ messageText: 'Here are the details you requested earlier.' }),
+    false
+  );
+});


### PR DESCRIPTION
## Summary
- add a quote heuristics helper that flags acknowledgements, pronoun-heavy replies, and repeated questions so we can decide when to auto quote
- update the chatwoot webhook to honor the heuristics when set_reply_reference is absent and adjust reply option handling accordingly
- extend the webhook tests and add dedicated heuristics unit tests to cover the new behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd8aa90e548333b728523242349f6c