### PR TITLE
Add conversation synopsis support and tests

### DIFF
--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -20,13 +20,14 @@ import { CONVO_LABELS } from "@/lib/constants";
 import { getProvider } from "@/lib/providers";
 import { INBOX_MODE } from "@/config/inboxMode";
 import { tools } from "@/lib/tools/tools";
-import { toResponseMessage } from "@/lib/utils/toResponseMessage";
+import { toResponseMessage, type ResponseMessage } from "@/lib/utils/toResponseMessage";
 import { enqueueRequest, updateRequest } from "@/lib/handoffQueue";
 import { handoffStrategy } from "@/config/handoffStrategy";
 import { releaseAgent } from "@/lib/conversationResolution";
-import { CHATWOOT_SYSTEM_PROMPT } from "@/config/constants";
+import { CHATWOOT_SYSTEM_PROMPT, MODEL } from "@/config/constants";
 import { getConversationKey } from "@/lib/getConversationKey";
 import { getConversationHistory } from "@/lib/getConversationHistory";
+import { getConversationSynopsis } from "@/lib/getConversationSynopsis";
 import {
   getConversationTranscript,
   type ConversationTranscriptEntry,
@@ -41,12 +42,19 @@ import {
 } from "@/lib/releaseAttempts";
 import { notifyMessageIssue, notifyHandoffIssue } from "@/lib/friendlyErrors";
 import { shouldQuoteInboundMessage } from "@/lib/quoteHeuristics";
+import {
+  estimateMessageTokens,
+  TOKEN_THRESHOLD,
+  type TiktokenModel,
+} from "@/lib/utils/tokenCounter";
 
 type HistoryTurn = { role: string; content: string };
 
 const QUOTE_TRANSCRIPT_USER_LIMIT = 4;
 const QUOTE_TRANSCRIPT_ASSISTANT_LIMIT = 2;
 const MAX_DEVELOPER_QUOTE_LINES = 6;
+const SYNOPSIS_HISTORY_LIMIT = 50;
+const PROMPT_HISTORY_LIMIT = 20;
 
 function formatQuoteTimestamp(date?: Date): string {
   if (!date || !(date instanceof Date) || Number.isNaN(date.getTime())) {
@@ -1041,17 +1049,20 @@ export async function POST(request: Request) {
       }
     };
 
-    let history = [] as any;
+    let fullHistory: ResponseMessage[] = [];
     try {
-      history = await getConversationHistory(conversationKey);
+      fullHistory = await getConversationHistory(
+        conversationKey,
+        SYNOPSIS_HISTORY_LIMIT
+      );
     } catch (err) {
       console.error("conversation history error", err);
       await sendFallback();
       return NextResponse.json({ status: "fallback" });
     }
 
-    if (enrichedContent && Array.isArray(history)) {
-      let updatedHistory = [...history];
+    if (enrichedContent && Array.isArray(fullHistory)) {
+      let updatedHistory = [...fullHistory];
       const hasEnrichedTurn = updatedHistory.some(
         (turn: any) =>
           turn?.role === "user" &&
@@ -1079,12 +1090,16 @@ export async function POST(request: Request) {
           ];
         }
       }
-      history = updatedHistory;
+      fullHistory = updatedHistory as ResponseMessage[];
     }
+
+    let promptHistory = Array.isArray(fullHistory)
+      ? fullHistory.slice(-PROMPT_HISTORY_LIMIT)
+      : [];
 
     try {
       const guardrailUserInput = enrichedContent ?? userInput;
-      const baseHistoryTurns: HistoryTurn[] = history
+      const baseHistoryTurns: HistoryTurn[] = promptHistory
         .filter((m: { role: string }) => m.role !== "developer")
         .map((m: { role: string; content: any[] }) => ({
           role: m.role,
@@ -1145,6 +1160,21 @@ export async function POST(request: Request) {
     }
     const developerPrompt = buildQuoteDeveloperPrompt(transcriptEntries);
 
+    let conversationSynopsis: string | undefined;
+    try {
+      const synopsisMessageId =
+        normalizedMessageId ??
+        (typeof messageId === "number" || typeof messageId === "string"
+          ? messageId
+          : undefined);
+      conversationSynopsis = await getConversationSynopsis(conversationKey, {
+        latestMessageId: synopsisMessageId,
+        history: fullHistory,
+      });
+    } catch (err) {
+      console.error("conversation synopsis error", err);
+    }
+
     let provider;
     try {
       provider = getProvider(undefined);
@@ -1161,11 +1191,39 @@ export async function POST(request: Request) {
       | { quoteMessageId?: number | null; forcePrivate?: boolean }
       | undefined;
     try {
-      const providerMessages = [
-        toResponseMessage("system", CHATWOOT_SYSTEM_PROMPT),
-        ...(developerPrompt ? [toResponseMessage("developer", developerPrompt)] : []),
-        ...history,
+      const systemMessage = toResponseMessage("system", CHATWOOT_SYSTEM_PROMPT);
+      const synopsisMessages = conversationSynopsis
+        ? [toResponseMessage("developer", conversationSynopsis)]
+        : [];
+      const developerMessages = developerPrompt
+        ? [toResponseMessage("developer", developerPrompt)]
+        : [];
+
+      const buildProviderMessages = (historyEntries: ResponseMessage[]) => [
+        systemMessage,
+        ...synopsisMessages,
+        ...developerMessages,
+        ...historyEntries,
       ];
+
+      let trimmedHistory = [...promptHistory];
+      let providerMessages = buildProviderMessages(trimmedHistory);
+      let tokenEstimate = estimateMessageTokens(
+        providerMessages,
+        MODEL as TiktokenModel
+      );
+
+      while (trimmedHistory.length && tokenEstimate > TOKEN_THRESHOLD) {
+        trimmedHistory = trimmedHistory.slice(1);
+        providerMessages = buildProviderMessages(trimmedHistory);
+        tokenEstimate = estimateMessageTokens(
+          providerMessages,
+          MODEL as TiktokenModel
+        );
+      }
+
+      promptHistory = trimmedHistory;
+
       const events = provider(providerMessages, tools, {});
       for await (const { event, data } of events) {
         if (
@@ -1281,8 +1339,8 @@ export async function POST(request: Request) {
       return NextResponse.json({ status: "fallback" });
     }
 
-    const quoteHistoryTurns: HistoryTurn[] = Array.isArray(history)
-      ? history
+    const quoteHistoryTurns: HistoryTurn[] = Array.isArray(promptHistory)
+      ? promptHistory
           .filter((m: { role: string }) => m.role !== "developer")
           .map((m: { role: string; content: any[] }) => ({
             role: m.role,

--- a/lib/assistant.ts
+++ b/lib/assistant.ts
@@ -7,7 +7,11 @@ import { Annotation } from "@/components/Annotations";
 import { functionsMap, create_ticket, start_chat_session } from "@/config/functions";
 import useDataStore from "@/stores/useDataStore";
 import { agentTools } from "@/config/tools-list";
-import { encodingForModel, getEncoding, TiktokenModel } from "js-tiktoken";
+import {
+  estimateMessageTokens,
+  TOKEN_THRESHOLD,
+  type TiktokenModel,
+} from "@/lib/utils/tokenCounter";
 
 // generateId uses browser crypto if available, otherwise Math.random
 export function generateId() {
@@ -67,61 +71,6 @@ export interface ToolCallItem {
 }
 
 export type Item = ChatMessage | ToolCallItem;
-
-const TOKEN_THRESHOLD = 25_000;
-
-const OLLAMA_MODEL_PREFIX_TO_ENCODING: Record<string, string> = {
-  llama: "cl100k_base",
-  qwen: "cl100k_base",
-  mistral: "cl100k_base",
-  phi: "cl100k_base",
-  gemma: "cl100k_base",
-};
-
-function mapModelToEncoding(modelName: string) {
-  const lower = modelName.toLowerCase();
-  for (const prefix of Object.keys(OLLAMA_MODEL_PREFIX_TO_ENCODING)) {
-    if (lower.startsWith(prefix)) {
-      return OLLAMA_MODEL_PREFIX_TO_ENCODING[prefix];
-    }
-  }
-  return modelName;
-}
-
-export function estimateMessageTokens(
-  messages: any[],
-  modelName: TiktokenModel = MODEL as TiktokenModel
-) {
-  let encoding;
-  const mapped = mapModelToEncoding(modelName);
-  try {
-    encoding = encodingForModel(mapped as TiktokenModel);
-  } catch {
-    const fallbackBase = mapped.startsWith("o") || mapped.includes("gpt-4o")
-      ? "o200k_base"
-      : "cl100k_base";
-    try {
-      encoding = encodingForModel(fallbackBase as TiktokenModel);
-    } catch {
-      encoding = getEncoding(fallbackBase);
-    }
-  }
-
-  let total = 0;
-  for (const msg of messages) {
-    const content = (msg as any).content;
-    if (Array.isArray(content)) {
-      for (const part of content) {
-        if (typeof part?.text === "string") {
-          total += encoding.encode(part.text).length;
-        }
-      }
-    } else if (typeof content === "string") {
-      total += encoding.encode(content).length;
-    }
-  }
-  return total;
-}
 
 async function trimMessagesToTokenLimit(
   allMessages: any[],
@@ -324,6 +273,8 @@ export const handleTurn = async (
     onMessage({ event: "error", data: { message } });
   }
 };
+
+export { estimateMessageTokens };
 
 export const processMessages = async () => {
   const {

--- a/lib/getConversationSynopsis.ts
+++ b/lib/getConversationSynopsis.ts
@@ -1,0 +1,215 @@
+import { getConversationHistory } from "@/lib/getConversationHistory";
+import redis from "@/lib/redis";
+import type { ResponseMessage } from "@/lib/utils/toResponseMessage";
+
+const DEFAULT_HISTORY_LIMIT = 50;
+const MAX_HISTORY_LIMIT = 100;
+const MAX_SNIPPET_LENGTH = 120;
+const HIGHLIGHT_LIMIT = 2;
+const SYNOPSIS_CACHE_TTL_SECONDS = 300;
+
+export type ConversationSynopsisOptions = {
+  latestMessageId?: number | string | null;
+  limit?: number;
+  history?: ResponseMessage[];
+};
+
+function collapseWhitespace(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+function truncate(text: string, maxLength: number): string {
+  if (text.length <= maxLength) {
+    return text;
+  }
+  const truncated = text.slice(0, Math.max(0, maxLength - 1)).trimEnd();
+  return `${truncated}…`;
+}
+
+function extractText(message: ResponseMessage): string {
+  if (!message || message.role === "system" || message.role === "developer") {
+    return "";
+  }
+  if (!Array.isArray(message.content)) {
+    return "";
+  }
+  const combined = message.content
+    .map((part) => (typeof part?.text === "string" ? part.text : ""))
+    .filter(Boolean)
+    .join(" ");
+  return collapseWhitespace(combined);
+}
+
+type TurnSnippet = {
+  role: "user" | "assistant";
+  snippet: string;
+};
+
+function gatherHighlights(
+  turns: TurnSnippet[],
+  role: TurnSnippet["role"],
+  limit: number
+): string[] {
+  const highlights: string[] = [];
+  const seen = new Set<string>();
+  for (let i = turns.length - 1; i >= 0 && highlights.length < limit; i -= 1) {
+    const turn = turns[i];
+    if (turn.role !== role) {
+      continue;
+    }
+    const normalized = turn.snippet.toLowerCase();
+    if (seen.has(normalized)) {
+      continue;
+    }
+    seen.add(normalized);
+    highlights.push(turn.snippet);
+  }
+  return highlights.reverse();
+}
+
+function formatHighlights(snippets: string[]): string {
+  return snippets.map((snippet) => `"${snippet}"`).join("; ");
+}
+
+function buildSynopsis(turns: TurnSnippet[]): string | undefined {
+  if (!turns.length) {
+    return undefined;
+  }
+
+  const totalTurns = turns.length;
+  const userTurns = turns.filter((turn) => turn.role === "user").length;
+  const assistantTurns = turns.filter((turn) => turn.role === "assistant").length;
+
+  const customerHighlights = gatherHighlights(turns, "user", HIGHLIGHT_LIMIT);
+  const assistantHighlights = gatherHighlights(
+    turns,
+    "assistant",
+    HIGHLIGHT_LIMIT
+  );
+
+  const latest = turns[turns.length - 1];
+  const latestRoleLabel = latest.role === "assistant" ? "assistant" : "customer";
+
+  const sentences: string[] = [
+    `Conversation synopsis (${totalTurns} turns: ${userTurns} customer / ${assistantTurns} assistant).`,
+  ];
+
+  if (customerHighlights.length) {
+    sentences.push(`Customer focus: ${formatHighlights(customerHighlights)}.`);
+  }
+
+  if (assistantHighlights.length) {
+    sentences.push(`Agent notes: ${formatHighlights(assistantHighlights)}.`);
+  }
+
+  if (latest?.snippet) {
+    sentences.push(`Latest turn (${latestRoleLabel}): "${latest.snippet}".`);
+  }
+
+  return sentences.join(" ");
+}
+
+async function readCachedSynopsis(cacheKey: string): Promise<string | undefined> {
+  try {
+    if (typeof (redis as any)?.get !== "function") {
+      return undefined;
+    }
+    const cached = await redis.get(cacheKey);
+    if (typeof cached !== "string" || !cached.trim()) {
+      return undefined;
+    }
+    try {
+      const parsed = JSON.parse(cached);
+      if (typeof parsed?.summary === "string") {
+        return parsed.summary;
+      }
+    } catch {
+      return cached;
+    }
+  } catch {
+    // ignore redis errors
+  }
+  return undefined;
+}
+
+async function writeCachedSynopsis(cacheKey: string, summary: string) {
+  try {
+    if (typeof (redis as any)?.set !== "function") {
+      return;
+    }
+    await redis.set(
+      cacheKey,
+      JSON.stringify({ summary, updatedAt: Date.now() }),
+      "EX",
+      SYNOPSIS_CACHE_TTL_SECONDS
+    );
+  } catch {
+    // ignore redis errors
+  }
+}
+
+export async function getConversationSynopsis(
+  conversationKey: string,
+  options?: ConversationSynopsisOptions
+): Promise<string | undefined> {
+  const normalizedKey = typeof conversationKey === "string" ? conversationKey.trim() : "";
+  if (!normalizedKey) {
+    return undefined;
+  }
+
+  const rawLimit = options?.limit;
+  const limit = Number.isFinite(rawLimit)
+    ? Math.min(Math.max(Math.trunc(rawLimit as number), 1), MAX_HISTORY_LIMIT)
+    : DEFAULT_HISTORY_LIMIT;
+
+  const latestMessageId = options?.latestMessageId;
+  const cacheKey = latestMessageId !== undefined && latestMessageId !== null
+    ? `synopsis:${normalizedKey}:${String(latestMessageId)}`
+    : `synopsis:${normalizedKey}`;
+
+  const cached = await readCachedSynopsis(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  let history = options?.history;
+  if (!history) {
+    history = await getConversationHistory(normalizedKey, limit);
+  }
+
+  if (!Array.isArray(history) || !history.length) {
+    return undefined;
+  }
+
+  const recent = history.slice(-limit);
+  const turns: TurnSnippet[] = recent
+    .map((message) => {
+      const role =
+        message.role === "assistant"
+          ? "assistant"
+          : message.role === "user"
+            ? "user"
+            : undefined;
+      if (!role) {
+        return undefined;
+      }
+      const text = extractText(message);
+      if (!text) {
+        return undefined;
+      }
+      const snippet = truncate(text, MAX_SNIPPET_LENGTH);
+      if (!snippet) {
+        return undefined;
+      }
+      return { role, snippet };
+    })
+    .filter((value): value is TurnSnippet => Boolean(value));
+
+  const summary = buildSynopsis(turns);
+  if (!summary) {
+    return undefined;
+  }
+
+  await writeCachedSynopsis(cacheKey, summary);
+  return summary;
+}

--- a/lib/utils/tokenCounter.ts
+++ b/lib/utils/tokenCounter.ts
@@ -1,0 +1,59 @@
+import { MODEL } from "@/config/constants";
+import { encodingForModel, getEncoding, TiktokenModel } from "js-tiktoken";
+
+const OLLAMA_MODEL_PREFIX_TO_ENCODING: Record<string, string> = {
+  llama: "cl100k_base",
+  qwen: "cl100k_base",
+  mistral: "cl100k_base",
+  phi: "cl100k_base",
+  gemma: "cl100k_base",
+};
+
+function mapModelToEncoding(modelName: string) {
+  const lower = modelName.toLowerCase();
+  for (const prefix of Object.keys(OLLAMA_MODEL_PREFIX_TO_ENCODING)) {
+    if (lower.startsWith(prefix)) {
+      return OLLAMA_MODEL_PREFIX_TO_ENCODING[prefix];
+    }
+  }
+  return modelName;
+}
+
+export const TOKEN_THRESHOLD = 25_000;
+
+export function estimateMessageTokens(
+  messages: any[],
+  modelName: TiktokenModel = MODEL as TiktokenModel
+) {
+  let encoding;
+  const mapped = mapModelToEncoding(modelName);
+  try {
+    encoding = encodingForModel(mapped as TiktokenModel);
+  } catch {
+    const fallbackBase = mapped.startsWith("o") || mapped.includes("gpt-4o")
+      ? "o200k_base"
+      : "cl100k_base";
+    try {
+      encoding = encodingForModel(fallbackBase as TiktokenModel);
+    } catch {
+      encoding = getEncoding(fallbackBase);
+    }
+  }
+
+  let total = 0;
+  for (const msg of messages) {
+    const content = (msg as any).content;
+    if (Array.isArray(content)) {
+      for (const part of content) {
+        if (typeof part?.text === "string") {
+          total += encoding.encode(part.text).length;
+        }
+      }
+    } else if (typeof content === "string") {
+      total += encoding.encode(content).length;
+    }
+  }
+  return total;
+}
+
+export type { TiktokenModel };

--- a/tests/chatwootWebhook.test.js
+++ b/tests/chatwootWebhook.test.js
@@ -70,6 +70,13 @@ const getConversationHistoryMock = mock.method(
   async () => []
 );
 
+const conversationSynopsis = require('../lib/getConversationSynopsis.ts');
+const getConversationSynopsisMock = mock.method(
+  conversationSynopsis,
+  'getConversationSynopsis',
+  async () => undefined
+);
+
 const conversationTranscript = require('../lib/getConversationTranscript.ts');
 const originalGetConversationTranscript = conversationTranscript.getConversationTranscript;
 const getConversationTranscriptMock = mock.method(
@@ -134,6 +141,14 @@ redis.rpush = mock.fn(async () => {});
 redis.pipeline = mock.fn(() => redisPipelineMock);
 redis.lrange = mock.fn(async () => []);
 
+const tokenCounter = require('../lib/utils/tokenCounter.ts');
+const originalEstimateMessageTokens = tokenCounter.estimateMessageTokens;
+const estimateMessageTokensMock = mock.method(
+  tokenCounter,
+  'estimateMessageTokens',
+  (...args) => originalEstimateMessageTokens(...args)
+);
+
 const { POST: webhookPost } = require('../app/api/chatwoot-webhook/route.ts');
 const { POST: statusWebhookPost } = require('../app/api/chatwoot-status-webhook/route.ts');
  
@@ -167,6 +182,8 @@ function resetMocks() {
   prisma.conversationMessage.findUnique.mock.resetCalls();
   getConversationHistoryMock.mock.resetCalls();
   getConversationTranscriptMock.mock.resetCalls();
+  getConversationSynopsisMock.mock.resetCalls();
+  getConversationSynopsisMock.mock.mockImplementation(async () => undefined);
   redis.exists.mock.resetCalls();
   redis.rpush.mock.resetCalls();
   redis.pipeline.mock.resetCalls();
@@ -174,6 +191,10 @@ function resetMocks() {
   redisPipelineMock.rpush.mock.resetCalls();
   redisPipelineMock.expire.mock.resetCalls();
   redisPipelineMock.exec.mock.resetCalls();
+  estimateMessageTokensMock.mock.resetCalls();
+  estimateMessageTokensMock.mock.mockImplementation((...args) =>
+    originalEstimateMessageTokens(...args)
+  );
   runRelevanceGuardrailMock.mock.resetCalls();
   runRelevanceGuardrailMock.mock.mockImplementation(async () => ({
     tripwireTriggered: false,
@@ -839,18 +860,24 @@ test('chatwoot webhook processes incoming message', async () => {
     toResponseMessage('user', 'Hello'),
   ];
   getConversationHistoryMock.mock.mockImplementationOnce(async () => history);
+  getConversationSynopsisMock.mock.mockImplementationOnce(async () => 'Mock synopsis');
   const req = new Request('http://localhost', {
     method: 'POST',
     body: JSON.stringify(payload),
   });
   const res = await webhookPost(req);
-  await res.json();
+  const result = await res.json();
   assert.strictEqual(sendBotMessageMock.mock.calls.length, 1);
   assert.strictEqual(getProviderMock.mock.calls.length, 1);
-  assert.deepStrictEqual(
-    providerFnMock.mock.calls[0].arguments[0],
-    [toResponseMessage('system', CHATWOOT_SYSTEM_PROMPT), ...history]
-  );
+  assert.strictEqual(getConversationSynopsisMock.mock.calls.length, 1);
+  const synopsisCall = getConversationSynopsisMock.mock.calls[0];
+  assert.strictEqual(synopsisCall.arguments[0], 'chatwoot:7:1:7');
+  const expectedMessages = [
+    toResponseMessage('system', CHATWOOT_SYSTEM_PROMPT),
+    toResponseMessage('developer', 'Mock synopsis'),
+    ...history,
+  ];
+  assert.deepStrictEqual(providerFnMock.mock.calls[0].arguments[0], expectedMessages);
   const call = sendBotMessageMock.mock.calls[0].arguments;
   assert.strictEqual(call[0], 7);
   assert.strictEqual(call[1], 7);
@@ -941,8 +968,10 @@ test('chatwoot webhook includes developer quote guidance when transcript exists'
     method: 'POST',
     body: JSON.stringify(payload),
   });
+  getConversationSynopsisMock.mock.mockImplementationOnce(async () => 'Quote summary');
   const res = await webhookPost(req);
-  await res.json();
+  const result = await res.json();
+  assert.ok(result);
   assert.strictEqual(sendBotMessageMock.mock.calls.length, 1);
   assert.strictEqual(getProviderMock.mock.calls.length, 1);
   assert.strictEqual(getConversationTranscriptMock.mock.calls.length, 1);
@@ -964,7 +993,9 @@ test('chatwoot webhook includes developer quote guidance when transcript exists'
   const messages = providerFnMock.mock.calls[0].arguments[0];
   assert.strictEqual(messages[0].role, 'system');
   assert.strictEqual(messages[1].role, 'developer');
-  const developerText = messages[1].content[0].text;
+  assert.strictEqual(messages[1].content[0].text, 'Quote summary');
+  assert.strictEqual(messages[2].role, 'developer');
+  const developerText = messages[2].content[0].text;
   assert.ok(developerText.includes('Quote candidates (newest first):'));
   assert.ok(developerText.includes('user#4324'));
   assert.ok(developerText.includes('Official WhatsApp order update'));
@@ -975,7 +1006,56 @@ test('chatwoot webhook includes developer quote guidance when transcript exists'
   assert.ok(!developerText.includes('user#4325'));
   assert.ok(!developerText.includes('SMS follow up (exclude)'));
   assert.ok(developerText.includes('2024-05-15'));
-  assert.deepStrictEqual(messages.slice(2), history);
+  assert.deepStrictEqual(messages.slice(3), history);
+  resetMocks();
+});
+
+test('chatwoot webhook trims prompt when token estimate exceeds threshold', async () => {
+  const payload = {
+    event: 'message_created',
+    data: {
+      event: 'message_created',
+      message: {
+        id: 702,
+        message_type: 0,
+        content: 'Please help again',
+        account: { id: 71 },
+        conversation: { id: 71, inbox_id: 1, status: 'resolved', account_id: 71 },
+      },
+    },
+  };
+  const history = Array.from({ length: 5 }, (_, index) =>
+    toResponseMessage(index % 2 === 0 ? 'user' : 'assistant', `turn-${index}`)
+  );
+  getConversationHistoryMock.mock.mockImplementationOnce(async () => history);
+  getConversationSynopsisMock.mock.mockImplementationOnce(async () => 'Token summary');
+  estimateMessageTokensMock.mock.mockImplementation((messages) => {
+    const arr = Array.isArray(messages) ? messages : [];
+    return arr.length * 6000;
+  });
+  const req = new Request('http://localhost', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+  const res = await webhookPost(req);
+  await res.json();
+  const tokenCalls = estimateMessageTokensMock.mock.calls;
+  assert.ok(tokenCalls.length >= 1);
+  const firstMessages = tokenCalls[0].arguments[0];
+  const finalMessages = tokenCalls[tokenCalls.length - 1].arguments[0];
+  assert.ok(Array.isArray(firstMessages));
+  assert.ok(Array.isArray(finalMessages));
+  assert.ok(finalMessages.length < firstMessages.length);
+  assert.strictEqual(finalMessages.length, 4);
+  assert.strictEqual(finalMessages[0].role, 'system');
+  assert.strictEqual(finalMessages[1].role, 'developer');
+  assert.strictEqual(finalMessages[1].content[0].text, 'Token summary');
+  const trimmedHistory = finalMessages.slice(2);
+  assert.strictEqual(trimmedHistory.length, 2);
+  assert.deepStrictEqual(
+    trimmedHistory.map((m) => m.content[0].text),
+    history.slice(-2).map((m) => m.content[0].text)
+  );
   resetMocks();
 });
 

--- a/tests/getConversationSynopsis.test.js
+++ b/tests/getConversationSynopsis.test.js
@@ -1,0 +1,62 @@
+const assert = require('assert');
+const { test, mock } = require('node:test');
+require('ts-node/register/transpile-only');
+require('tsconfig-paths/register');
+
+const { toResponseMessage } = require('../lib/utils/toResponseMessage.ts');
+const { getConversationSynopsis } = require('../lib/getConversationSynopsis.ts');
+const conversationHistory = require('../lib/getConversationHistory.ts');
+const redis = require('../lib/redis.ts').default;
+
+test('getConversationSynopsis summarizes history and caches results', async (t) => {
+  const cache = new Map();
+  const originalGet = redis.get;
+  const originalSet = redis.set;
+  redis.get = async (key) => cache.get(key) ?? null;
+  redis.set = async (key, value) => {
+    cache.set(key, value);
+    return 'OK';
+  };
+  t.after(() => {
+    redis.get = originalGet;
+    redis.set = originalSet;
+  });
+
+  const sampleHistory = [
+    toResponseMessage('user', 'First question about billing details and costs'),
+    toResponseMessage('assistant', 'Provided clarification on billing setup'),
+    toResponseMessage('user', 'Follow-up asking about delivery timeline tomorrow morning'),
+  ];
+
+  const historyMock = mock.method(
+    conversationHistory,
+    'getConversationHistory',
+    async () => sampleHistory
+  );
+  t.after(() => {
+    historyMock.mock.restore();
+  });
+
+  const summaryOne = await getConversationSynopsis('chatwoot:test', {
+    latestMessageId: 10,
+  });
+  assert.ok(summaryOne);
+  assert.ok(summaryOne.includes('Conversation synopsis'));
+  assert.ok(summaryOne.includes('Latest turn'));
+  assert.strictEqual(historyMock.mock.calls.length, 1);
+
+  const summaryTwo = await getConversationSynopsis('chatwoot:test', {
+    latestMessageId: 10,
+  });
+  assert.strictEqual(summaryTwo, summaryOne);
+  assert.strictEqual(historyMock.mock.calls.length, 1);
+
+  const cachedPayload = cache.get('synopsis:chatwoot:test:10');
+  assert.ok(typeof cachedPayload === 'string');
+
+  const summaryThree = await getConversationSynopsis('chatwoot:test', {
+    latestMessageId: 11,
+  });
+  assert.ok(summaryThree);
+  assert.strictEqual(historyMock.mock.calls.length, 2);
+});

--- a/tests/tokens.test.js
+++ b/tests/tokens.test.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 const test = require('node:test');
-const { estimateMessageTokens } = require('../lib/assistant');
+const { estimateMessageTokens } = require('../lib/utils/tokenCounter.ts');
 const { getEncoding } = require('js-tiktoken');
 
 test('estimateMessageTokens falls back to generic encoding on unknown model', () => {


### PR DESCRIPTION
## Summary
- add a deterministic conversation synopsis helper with Redis caching
- inject the synopsis into the Chatwoot webhook prompt alongside quote metadata and token trimming
- share token counting logic across the app and extend tests for synopsis generation and prompt trimming

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf9b2ac1448333b92935e953e9bb9e