### PR TITLE
Add quote candidate helper and expose selection tool

### DIFF
--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -28,10 +28,7 @@ import { CHATWOOT_SYSTEM_PROMPT, MODEL } from "@/config/constants";
 import { getConversationKey } from "@/lib/getConversationKey";
 import { getConversationHistory } from "@/lib/getConversationHistory";
 import { getConversationSynopsis } from "@/lib/getConversationSynopsis";
-import {
-  getConversationTranscript,
-  type ConversationTranscriptEntry,
-} from "@/lib/getConversationTranscript";
+import { getQuoteCandidates, type QuoteCandidate } from "@/lib/getQuoteCandidates";
 import {
   runRelevanceGuardrail,
   runJailbreakGuardrail,
@@ -64,29 +61,14 @@ function formatQuoteTimestamp(date?: Date): string {
 }
 
 function buildQuoteDeveloperPrompt(
-  entries: ConversationTranscriptEntry[]
+  candidates: QuoteCandidate[]
 ): string | undefined {
-  if (!Array.isArray(entries) || !entries.length) {
+  if (!Array.isArray(candidates) || !candidates.length) {
     return undefined;
   }
-  const eligible = entries.filter((entry) => {
-    if (!entry?.quoteEligible) {
-      return false;
-    }
-    if (typeof entry.messageId !== "number" || !Number.isFinite(entry.messageId)) {
-      return false;
-    }
-    if (typeof entry.contentSnippet !== "string") {
-      return false;
-    }
-    return entry.contentSnippet.trim().length > 0;
-  });
-  if (!eligible.length) {
-    return undefined;
-  }
-  const limited = eligible.slice(0, MAX_DEVELOPER_QUOTE_LINES);
+  const limited = candidates.slice(0, MAX_DEVELOPER_QUOTE_LINES);
   const lines = limited.map((entry) => {
-    const snippet = entry.contentSnippet.trim();
+    const snippet = entry.snippet.trim();
     const prefix = `${entry.sender}#${entry.messageId}`;
     const timestamp = formatQuoteTimestamp(entry.createdAt);
     return `${prefix} · ${timestamp} · ${snippet}`;
@@ -1149,16 +1131,25 @@ export async function POST(request: Request) {
       return NextResponse.json({ status: "fallback" });
     }
 
-    let transcriptEntries: ConversationTranscriptEntry[] = [];
+    let quoteCandidates: QuoteCandidate[] = [];
     try {
-      transcriptEntries = await getConversationTranscript(conversationKey, {
+      quoteCandidates = await getQuoteCandidates(conversationKey, {
+        conversation,
+        message: message as any,
         userLimit: QUOTE_TRANSCRIPT_USER_LIMIT,
         assistantLimit: QUOTE_TRANSCRIPT_ASSISTANT_LIMIT,
+        maxCandidates: MAX_DEVELOPER_QUOTE_LINES,
       });
     } catch (err) {
-      console.error("conversation transcript error", err);
+      console.error("quote candidates error", err);
     }
-    const developerPrompt = buildQuoteDeveloperPrompt(transcriptEntries);
+    const developerPrompt = buildQuoteDeveloperPrompt(quoteCandidates);
+    if (developerPrompt) {
+      promptHistory = [
+        toResponseMessage("developer", developerPrompt),
+        ...promptHistory,
+      ];
+    }
 
     let conversationSynopsis: string | undefined;
     try {
@@ -1195,14 +1186,9 @@ export async function POST(request: Request) {
       const synopsisMessages = conversationSynopsis
         ? [toResponseMessage("developer", conversationSynopsis)]
         : [];
-      const developerMessages = developerPrompt
-        ? [toResponseMessage("developer", developerPrompt)]
-        : [];
-
       const buildProviderMessages = (historyEntries: ResponseMessage[]) => [
         systemMessage,
         ...synopsisMessages,
-        ...developerMessages,
         ...historyEntries,
       ];
 
@@ -1213,8 +1199,23 @@ export async function POST(request: Request) {
         MODEL as TiktokenModel
       );
 
+      const stickyDeveloperEntry =
+        trimmedHistory.length && trimmedHistory[0]?.role === "developer"
+          ? trimmedHistory[0]
+          : undefined;
+
       while (trimmedHistory.length && tokenEstimate > TOKEN_THRESHOLD) {
-        trimmedHistory = trimmedHistory.slice(1);
+        if (stickyDeveloperEntry) {
+          if (trimmedHistory.length <= 1) {
+            break;
+          }
+          trimmedHistory = [
+            stickyDeveloperEntry,
+            ...trimmedHistory.slice(2),
+          ];
+        } else {
+          trimmedHistory = trimmedHistory.slice(1);
+        }
         providerMessages = buildProviderMessages(trimmedHistory);
         tokenEstimate = estimateMessageTokens(
           providerMessages,

--- a/lib/getQuoteCandidates.ts
+++ b/lib/getQuoteCandidates.ts
@@ -1,0 +1,171 @@
+import type { Conversation, Message } from "@/types/chatwoot";
+import {
+  getConversationTranscript,
+  type ConversationTranscriptEntry,
+} from "@/lib/getConversationTranscript";
+
+export type QuoteCandidate = {
+  messageId: number;
+  sender: "user" | "assistant";
+  snippet: string;
+  createdAt?: Date;
+};
+
+export type GetQuoteCandidatesOptions = {
+  conversation?: Conversation | null;
+  message?: Message | Record<string, unknown> | null;
+  userLimit?: number;
+  assistantLimit?: number;
+  maxCandidates?: number;
+};
+
+const DEFAULT_MAX_CANDIDATES = 6;
+
+const CHANNEL_KEYS = [
+  "channel",
+  "inbox_channel",
+  "inboxChannel",
+  "source_channel",
+  "sourceChannel",
+  "provider_channel",
+  "providerChannel",
+  "conversation_channel",
+  "conversationChannel",
+  "message_channel",
+  "messageChannel",
+  "medium",
+];
+
+const NESTED_CHANNEL_CARRIERS = [
+  "additional_attributes",
+  "additionalAttributes",
+  "content_attributes",
+  "contentAttributes",
+  "meta",
+  "conversation",
+  "message",
+  "sender",
+  "inbox",
+  "data",
+  "payload",
+  "source",
+];
+
+function collectChannelHints(...sources: Array<unknown>): string[] {
+  const hints: string[] = [];
+  const queue: Array<unknown> = sources.filter(
+    (source) => source && typeof source === "object"
+  );
+  const visited = new Set<object>();
+
+  while (queue.length) {
+    const current = queue.shift();
+    if (!current || typeof current !== "object") {
+      continue;
+    }
+    if (visited.has(current as object)) {
+      continue;
+    }
+    visited.add(current as object);
+    const record = current as Record<string, unknown>;
+
+    for (const key of CHANNEL_KEYS) {
+      const value = record[key];
+      if (typeof value === "string") {
+        const trimmed = value.trim();
+        if (trimmed) {
+          hints.push(trimmed);
+        }
+      }
+    }
+
+    for (const key of NESTED_CHANNEL_CARRIERS) {
+      const nested = record[key];
+      if (nested && typeof nested === "object") {
+        queue.push(nested);
+      }
+    }
+  }
+
+  return hints;
+}
+
+function isUnsupportedChannel(channel: string): boolean {
+  const normalized = channel.toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  if (normalized.includes("sms")) {
+    return true;
+  }
+  if (normalized.includes("twilio") && normalized.includes("whatsapp")) {
+    return true;
+  }
+  return false;
+}
+
+function filterQuoteableEntries(
+  entries: ConversationTranscriptEntry[],
+  maxCandidates: number
+): QuoteCandidate[] {
+  const eligible = entries.filter((entry) => {
+    if (!entry?.quoteEligible) {
+      return false;
+    }
+    if (entry.sender !== "assistant" && entry.sender !== "user") {
+      return false;
+    }
+    if (typeof entry.messageId !== "number" || !Number.isFinite(entry.messageId)) {
+      return false;
+    }
+    if (typeof entry.contentSnippet !== "string") {
+      return false;
+    }
+    const snippet = entry.contentSnippet.trim();
+    if (!snippet) {
+      return false;
+    }
+    return true;
+  });
+
+  const limited =
+    maxCandidates >= 0 ? eligible.slice(0, maxCandidates) : eligible.slice();
+
+  return limited.map((entry) => ({
+    messageId: entry.messageId!,
+    sender: entry.sender,
+    snippet: entry.contentSnippet.trim(),
+    createdAt: entry.createdAt,
+  }));
+}
+
+export async function getQuoteCandidates(
+  conversationKey: string,
+  options: GetQuoteCandidatesOptions = {}
+): Promise<QuoteCandidate[]> {
+  const {
+    conversation,
+    message,
+    userLimit,
+    assistantLimit,
+    maxCandidates = DEFAULT_MAX_CANDIDATES,
+  } = options;
+
+  const channelHints = collectChannelHints(conversation, message);
+  if (channelHints.some((hint) => isUnsupportedChannel(hint))) {
+    return [];
+  }
+
+  const transcriptEntries = await getConversationTranscript(conversationKey, {
+    userLimit,
+    assistantLimit,
+  });
+
+  if (!Array.isArray(transcriptEntries) || transcriptEntries.length === 0) {
+    return [];
+  }
+
+  return filterQuoteableEntries(transcriptEntries, maxCandidates);
+}
+
+export default getQuoteCandidates;

--- a/tests/getQuoteCandidates.test.js
+++ b/tests/getQuoteCandidates.test.js
@@ -1,0 +1,102 @@
+const assert = require('assert');
+const { test, mock } = require('node:test');
+
+require('ts-node/register/transpile-only');
+require('tsconfig-paths/register');
+
+const { getQuoteCandidates } = require('../lib/getQuoteCandidates.ts');
+const conversationTranscript = require('../lib/getConversationTranscript.ts');
+
+const getConversationTranscriptMock = mock.method(
+  conversationTranscript,
+  'getConversationTranscript',
+  async () => []
+);
+
+test.beforeEach(() => {
+  getConversationTranscriptMock.mock.resetCalls();
+  getConversationTranscriptMock.mock.mockImplementation(async () => []);
+});
+
+test('getQuoteCandidates returns most recent snippets', async () => {
+  const createdAtUser = new Date('2024-05-15T10:00:00Z');
+  const createdAtAssistant = new Date('2024-05-15T10:05:00Z');
+
+  getConversationTranscriptMock.mock.mockImplementationOnce(async () => [
+    {
+      messageId: 4002,
+      sender: 'assistant',
+      contentSnippet: 'Sure, I can take a look at that for you',
+      quoteEligible: true,
+      createdAt: createdAtAssistant,
+    },
+    {
+      messageId: 4001,
+      sender: 'user',
+      contentSnippet: 'Need help with an installation',
+      quoteEligible: true,
+      createdAt: createdAtUser,
+    },
+    {
+      messageId: 4000,
+      sender: 'user',
+      contentSnippet: '   ',
+      quoteEligible: true,
+      createdAt: createdAtUser,
+    },
+    {
+      messageId: 3999,
+      sender: 'assistant',
+      contentSnippet: 'Private note content',
+      quoteEligible: false,
+      createdAt: createdAtAssistant,
+    },
+  ]);
+
+  const result = await getQuoteCandidates('chatwoot:70:1:70', {
+    conversation: { id: 70, inbox_id: 1 },
+    message: { content_attributes: { channel: 'web_widget' } },
+    userLimit: 4,
+    assistantLimit: 2,
+    maxCandidates: 3,
+  });
+
+  assert.deepStrictEqual(result, [
+    {
+      messageId: 4002,
+      sender: 'assistant',
+      snippet: 'Sure, I can take a look at that for you',
+      createdAt: createdAtAssistant,
+    },
+    {
+      messageId: 4001,
+      sender: 'user',
+      snippet: 'Need help with an installation',
+      createdAt: createdAtUser,
+    },
+  ]);
+
+  assert.strictEqual(getConversationTranscriptMock.mock.calls.length, 1);
+  const [, options] = getConversationTranscriptMock.mock.calls[0].arguments;
+  assert.deepStrictEqual(options, { userLimit: 4, assistantLimit: 2 });
+});
+
+test('getQuoteCandidates skips unsupported conversation channels', async () => {
+  const result = await getQuoteCandidates('chatwoot:70:1:70', {
+    conversation: { additional_attributes: { channel: 'sms' } },
+    message: { content_attributes: { channel: 'web_widget' } },
+  });
+
+  assert.deepStrictEqual(result, []);
+  assert.strictEqual(getConversationTranscriptMock.mock.calls.length, 0);
+});
+
+test('getQuoteCandidates skips unsupported message channels', async () => {
+  const result = await getQuoteCandidates('chatwoot:70:1:70', {
+    conversation: { id: 70, inbox_id: 1 },
+    message: { channel: 'twilio_whatsapp' },
+  });
+
+  assert.deepStrictEqual(result, []);
+  assert.strictEqual(getConversationTranscriptMock.mock.calls.length, 0);
+});


### PR DESCRIPTION
## Summary
- add a `getQuoteCandidates` helper that filters the latest quoteable Chatwoot messages and ignores unsupported channels
- inject the quote candidate developer prompt into the Chatwoot webhook flow before provider selection and keep it during token trimming
- cover the new helper with unit tests alongside the existing webhook integration tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2684ffe388333ae6b43e96a65146d