### PR TITLE
Disconnect Prisma client after getQuoteCandidates tests

### DIFF
--- a/tests/getQuoteCandidates.test.js
+++ b/tests/getQuoteCandidates.test.js
@@ -6,12 +6,17 @@ require('tsconfig-paths/register');
 
 const { getQuoteCandidates } = require('../lib/getQuoteCandidates.ts');
 const conversationTranscript = require('../lib/getConversationTranscript.ts');
+const prisma = require('../lib/prisma.ts').default;
 
 const getConversationTranscriptMock = mock.method(
   conversationTranscript,
   'getConversationTranscript',
   async () => []
 );
+
+test.after(async () => {
+  await prisma.$disconnect();
+});
 
 test.beforeEach(() => {
   getConversationTranscriptMock.mock.resetCalls();


### PR DESCRIPTION
## Summary
- import the Prisma client in the getQuoteCandidates test suite
- disconnect Prisma once the tests finish running

## Testing
- `npm test tests/getQuoteCandidates.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68d3d42ab8d48333824c97f8696c8f7e