### PR TITLE
Stub Prisma client in getQuoteCandidates test

### DIFF
--- a/tests/getQuoteCandidates.test.js
+++ b/tests/getQuoteCandidates.test.js
@@ -1,8 +1,28 @@
 const assert = require('assert');
 const { test, mock } = require('node:test');
+const Module = require('module');
+const path = require('path');
 
 require('ts-node/register/transpile-only');
 require('tsconfig-paths/register');
+
+const prismaModulePath = require.resolve('../lib/prisma.ts');
+const originalPrismaModule = require.cache[prismaModulePath];
+
+const prisma = {
+  $disconnect: mock.fn(async () => {}),
+  conversationMessage: {
+    findMany: mock.fn(async () => []),
+  },
+};
+
+const prismaStub = new Module(prismaModulePath, module);
+prismaStub.filename = prismaModulePath;
+prismaStub.paths = Module._nodeModulePaths(path.dirname(prismaModulePath));
+prismaStub.loaded = true;
+prismaStub.exports = { __esModule: true, default: prisma };
+
+require.cache[prismaModulePath] = prismaStub;
 
 const { getQuoteCandidates } = require('../lib/getQuoteCandidates.ts');
 const conversationTranscript = require('../lib/getConversationTranscript.ts');
@@ -12,6 +32,15 @@ const getConversationTranscriptMock = mock.method(
   'getConversationTranscript',
   async () => []
 );
+
+test.after(async () => {
+  await prisma.$disconnect();
+  if (originalPrismaModule) {
+    require.cache[prismaModulePath] = originalPrismaModule;
+  } else {
+    delete require.cache[prismaModulePath];
+  }
+});
 
 test.beforeEach(() => {
   getConversationTranscriptMock.mock.resetCalls();


### PR DESCRIPTION
## Summary
- stub the Prisma client module in the getQuoteCandidates tests so the engine never starts during the suite
- restore the original module after the tests and keep the disconnect hook to cleanly tear down resources

## Testing
- `npm test tests/getQuoteCandidates.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68d3d42ab8d48333824c97f8696c8f7e