### PR TITLE
Handle streaming reply reference overrides

### DIFF
--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -532,22 +532,31 @@ export async function POST(request: Request) {
     const mode = INBOX_MODE[inboxId] ?? "auto";
 
     const buildReplyOptions = (
-      overrides?: { quoteMessageId?: number | null; forcePrivate?: boolean }
+      overrides?: { quoteMessageId?: number | null; private?: boolean }
     ) => {
       const options: { private?: boolean; inReplyTo?: number } = {};
-      const forcePrivate = overrides?.forcePrivate;
-      const quoteMessageId = overrides?.quoteMessageId;
-      const privateValue =
-        typeof forcePrivate === "boolean" ? forcePrivate : mode !== "auto";
-      options.private = privateValue;
 
       const hasOverrides = overrides !== undefined;
+      const hasPrivateProp =
+        hasOverrides &&
+        Object.prototype.hasOwnProperty.call(
+          overrides as Record<string, unknown>,
+          "private"
+        );
+      const privateOverride =
+        hasPrivateProp && typeof overrides?.private === "boolean"
+          ? overrides.private
+          : undefined;
+      options.private =
+        privateOverride !== undefined ? privateOverride : mode !== "auto";
+
       const hasQuoteProp =
         hasOverrides &&
         Object.prototype.hasOwnProperty.call(
           overrides as Record<string, unknown>,
           "quoteMessageId"
         );
+      const quoteMessageId = overrides?.quoteMessageId;
 
       if (quoteMessageId === null) {
         return options;
@@ -1179,7 +1188,7 @@ export async function POST(request: Request) {
     let pendingReplyReferenceId: string | undefined;
     let pendingReplyReferenceArgs = "";
     let replyReferenceOverride:
-      | { quoteMessageId?: number | null; forcePrivate?: boolean }
+      | { quoteMessageId?: number | null; private?: boolean }
       | undefined;
     try {
       const systemMessage = toResponseMessage("system", CHATWOOT_SYSTEM_PROMPT);
@@ -1316,14 +1325,38 @@ export async function POST(request: Request) {
                     parsedArgs?.messageId ??
                     parsedArgs?.messageID
                 );
+                const parsedPrivate =
+                  typeof parsedArgs?.private === "boolean"
+                    ? parsedArgs.private
+                    : typeof parsedArgs?.is_private === "boolean"
+                      ? parsedArgs.is_private
+                      : typeof parsedArgs?.send_private === "boolean"
+                        ? parsedArgs.send_private
+                        : undefined;
+
+                const nextOverride: {
+                  quoteMessageId?: number | null;
+                  private?: boolean;
+                } = {};
+                let hasOverride = false;
+
                 if (parsedUseQuotes === false) {
-                  replyReferenceOverride = { quoteMessageId: null };
+                  nextOverride.quoteMessageId = null;
+                  hasOverride = true;
                 } else if (typeof parsedMessageId === "number") {
-                  replyReferenceOverride = {
-                    quoteMessageId: parsedMessageId,
-                  };
+                  nextOverride.quoteMessageId = parsedMessageId;
+                  hasOverride = true;
                 } else if (parsedUseQuotes === true) {
-                  replyReferenceOverride = {};
+                  hasOverride = true;
+                }
+
+                if (typeof parsedPrivate === "boolean") {
+                  nextOverride.private = parsedPrivate;
+                  hasOverride = true;
+                }
+
+                if (hasOverride) {
+                  replyReferenceOverride = nextOverride;
                 }
               } catch (err) {
                 console.warn("set_reply_reference parse error", err);
@@ -1350,7 +1383,13 @@ export async function POST(request: Request) {
       : [];
 
     let finalReplyReference = replyReferenceOverride;
-    if (finalReplyReference === undefined) {
+    const hasQuoteOverride =
+      finalReplyReference !== undefined &&
+      Object.prototype.hasOwnProperty.call(
+        finalReplyReference as Record<string, unknown>,
+        "quoteMessageId"
+      );
+    if (!hasQuoteOverride) {
       const shouldQuote = shouldQuoteInboundMessage({
         messageText: userInput,
         referencedMessageId,
@@ -1367,7 +1406,10 @@ export async function POST(request: Request) {
               ? defaultReplyToId
               : undefined;
         if (typeof preferredQuoteId === "number") {
-          finalReplyReference = { quoteMessageId: preferredQuoteId };
+          finalReplyReference = {
+            ...(finalReplyReference ?? {}),
+            quoteMessageId: preferredQuoteId,
+          };
         }
       }
     }

--- a/tests/chatwootWebhook.test.js
+++ b/tests/chatwootWebhook.test.js
@@ -1449,6 +1449,124 @@ test('chatwoot webhook uses set_reply_reference message override', async () => {
   resetMocks();
 });
 
+test('chatwoot webhook set_reply_reference streaming controls quoting content attributes', async () => {
+  const scenarios = [
+    {
+      name: 'applies quoting override with private flag',
+      callId: 'call-private-quote',
+      arguments: { message_id: 654321, private: true, use_quotes: true },
+      expected: { private: true, inReplyTo: 654321 },
+      accountId: 19,
+      conversationId: 919,
+      messageId: 919,
+      content: 'Here are the latest order details for review.',
+      replyText: 'Sharing the requested details now.',
+    },
+    {
+      name: 'omits content attributes when quoting is disabled',
+      callId: 'call-private-skip',
+      arguments: { private: true, use_quotes: false },
+      expected: { private: true },
+      accountId: 20,
+      conversationId: 920,
+      messageId: 920,
+      content: 'Please send a private note without quoting anything.',
+      replyText: 'Absolutely, sending a private update.',
+    },
+  ];
+
+  for (const scenario of scenarios) {
+    providerFnMock.mock.mockImplementationOnce(() =>
+      (async function* () {
+        yield {
+          event: 'response.output_item.added',
+          data: {
+            item: {
+              type: 'function_call',
+              name: 'set_reply_reference',
+              id: scenario.callId,
+              call_id: scenario.callId,
+              arguments: '',
+            },
+          },
+        };
+        const argumentString = JSON.stringify(scenario.arguments);
+        const splitIndex = Math.max(1, Math.floor(argumentString.length / 2));
+        const fragments = [
+          argumentString.slice(0, splitIndex),
+          argumentString.slice(splitIndex),
+        ].filter((fragment) => fragment.length > 0);
+        for (const fragment of fragments) {
+          yield {
+            event: 'response.function_call_arguments.delta',
+            data: { item_id: scenario.callId, delta: fragment },
+          };
+        }
+        yield {
+          event: 'response.function_call_arguments.done',
+          data: { item_id: scenario.callId, arguments: argumentString },
+        };
+        yield {
+          event: 'response.output_text.delta',
+          data: { delta: scenario.replyText },
+        };
+      })()
+    );
+
+    const payload = {
+      event: 'message_created',
+      data: {
+        event: 'message_created',
+        message: {
+          id: scenario.messageId,
+          message_type: 0,
+          content: scenario.content,
+          account: { id: scenario.accountId },
+          conversation: {
+            id: scenario.conversationId,
+            inbox_id: 1,
+            status: 'resolved',
+            account_id: scenario.accountId,
+          },
+        },
+      },
+    };
+
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+    const res = await webhookPost(req);
+    await res.json();
+
+    assert.strictEqual(
+      sendBotMessageMock.mock.calls.length,
+      1,
+      `${scenario.name} send count`
+    );
+    const options = sendBotMessageMock.mock.calls[0].arguments[3];
+    assert.strictEqual(
+      options.private,
+      scenario.expected.private,
+      `${scenario.name} private flag`
+    );
+    if (Object.prototype.hasOwnProperty.call(scenario.expected, 'inReplyTo')) {
+      assert.strictEqual(
+        options.inReplyTo,
+        scenario.expected.inReplyTo,
+        `${scenario.name} quoting override`
+      );
+    } else {
+      assert.ok(
+        !Object.prototype.hasOwnProperty.call(options, 'inReplyTo'),
+        `${scenario.name} should not include inReplyTo`
+      );
+    }
+
+    resetMocks();
+  }
+});
+
 test('chatwoot webhook fallback keeps quoting inbound when set_reply_reference skips quotes', async () => {
   sendBotMessageMock.mock.mockImplementationOnce(async () => {
     throw new Error('initial send failure');


### PR DESCRIPTION
## Summary
- parse streaming set_reply_reference arguments to capture message IDs and private overrides before finalizing a reply
- allow chat reply option builder to honor quote/opt-out directives while merging with heuristics
- cover quoting and opt-out flows with a new chatwoot webhook streaming fixture

## Testing
- npm test -- tests/chatwootWebhook.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d3e6837f8083338fe6e37b3619af63