### PR TITLE
Log Chatwoot bot replies via helper

### DIFF
--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -5,10 +5,7 @@ import prisma from "@/lib/prisma";
 import { getNextAgent, setActiveConversation } from "@/lib/agentRotation";
 import { sendBotMessage } from "@/lib/chatwootBot";
 import redis from "@/lib/redis";
-import {
-  resolveBotMessageIdentifiers,
-  storeBotMessage,
-} from "@/lib/storeBotMessage";
+import { storeBotMessage } from "@/lib/storeBotMessage";
 import handOff from "@/lib/handoff";
 import {
   getConversation,
@@ -586,57 +583,18 @@ export async function POST(request: Request) {
       response: unknown,
       fallbackContent: string
     ) => {
-      if (!response || typeof response !== "object") {
-        console.warn("sendBotMessage response missing payload", {
-          accountId,
-          conversationId,
-        });
-        return;
-      }
-
-      const { messageId: directMessageId, sourceId, inboxId: responseInboxId } =
-        resolveBotMessageIdentifiers(response);
-      const resolvedMessageId =
-        typeof directMessageId === "number"
-          ? directMessageId
-          : typeof sourceId === "number"
-            ? sourceId
-            : undefined;
-      const fallbackInboxId =
-        typeof inboxId === "number" ? inboxId : undefined;
-      const resolvedInboxId =
-        typeof responseInboxId === "number"
-          ? responseInboxId
-          : fallbackInboxId;
-
-      if (
-        typeof resolvedMessageId !== "number" ||
-        typeof resolvedInboxId !== "number"
-      ) {
-        console.warn("sendBotMessage response missing identifiers", {
-          hasMessageId: typeof directMessageId === "number",
-          hasSourceId: typeof sourceId === "number",
-          hasInboxId: typeof resolvedInboxId === "number",
-          accountId,
-          conversationId,
-        });
-        return;
-      }
-
-      const resolvedConversationKey =
-        typeof inboxId === "number" && inboxId === resolvedInboxId
-          ? conversationKey
+      const defaultInboxId =
+        typeof inboxId === "number" && Number.isFinite(inboxId)
+          ? inboxId
           : undefined;
 
       await storeBotMessage({
         accountId,
         conversationId,
-        messageId: resolvedMessageId,
-        inboxId: resolvedInboxId,
         payload: response,
-        sourceId,
         fallbackContent,
-        conversationKey: resolvedConversationKey,
+        conversationKey: conversationKey ?? undefined,
+        defaultInboxId,
       });
     };
 

--- a/lib/conversationResolution.ts
+++ b/lib/conversationResolution.ts
@@ -15,10 +15,7 @@ import { CONVO_LABELS } from "@/lib/constants";
 import { dequeueRequest, updateRequest } from "@/lib/handoffQueue";
 import { notifyHandoffIssue } from "@/lib/friendlyErrors";
 import type { Conversation } from "@/types/chatwoot";
-import {
-  resolveBotMessageIdentifiers,
-  storeBotMessage,
-} from "@/lib/storeBotMessage";
+import { storeBotMessage } from "@/lib/storeBotMessage";
 
 /**
  * Clear the active conversation for the freed agent and assign the next request in queue.
@@ -148,46 +145,12 @@ export async function releaseAgent(
           request.conversationId,
           "A human agent will join shortly."
         );
-        if (!confirmationMessage || typeof confirmationMessage !== "object") {
-          console.warn("handoff confirmation missing payload", {
-            accountId,
-            conversationId: request.conversationId,
-          });
-        } else {
-          const {
-            messageId: directMessageId,
-            sourceId,
-            inboxId: confirmationInboxId,
-          } = resolveBotMessageIdentifiers(confirmationMessage);
-          const resolvedMessageId =
-            typeof directMessageId === "number"
-              ? directMessageId
-              : typeof sourceId === "number"
-                ? sourceId
-                : undefined;
-          if (
-            typeof resolvedMessageId === "number" &&
-            typeof confirmationInboxId === "number"
-          ) {
-            await storeBotMessage({
-              accountId,
-              conversationId: request.conversationId,
-              messageId: resolvedMessageId,
-              inboxId: confirmationInboxId,
-              payload: confirmationMessage,
-              sourceId,
-              fallbackContent: "A human agent will join shortly.",
-            });
-          } else {
-            console.warn("handoff confirmation missing identifiers", {
-              hasMessageId: typeof directMessageId === "number",
-              hasSourceId: typeof sourceId === "number",
-              hasInboxId: typeof confirmationInboxId === "number",
-              accountId,
-              conversationId: request.conversationId,
-            });
-          }
-        }
+        await storeBotMessage({
+          accountId,
+          conversationId: request.conversationId,
+          payload: confirmationMessage,
+          fallbackContent: "A human agent will join shortly.",
+        });
         outcome = "assigned";
       } else {
         outcome = "released";

--- a/lib/friendlyErrors.ts
+++ b/lib/friendlyErrors.ts
@@ -1,9 +1,6 @@
 import { sendBotMessage } from "@/lib/chatwootBot";
 import type { SendBotMessageOptions } from "@/lib/chatwootBot";
-import {
-  resolveBotMessageIdentifiers,
-  storeBotMessage,
-} from "@/lib/storeBotMessage";
+import { storeBotMessage } from "@/lib/storeBotMessage";
 
 // Text shown to users when the assistant cannot send a regular message
 // response. Exported for tests to assert route-specific fallbacks.
@@ -62,41 +59,10 @@ async function logAssistantFallback(
   fallbackContent: string,
   response: unknown
 ) {
-  if (!response || typeof response !== "object") {
-    console.warn("fallback sendBotMessage response missing payload", {
-      accountId,
-      conversationId,
-    });
-    return;
-  }
-
-  const { messageId: directMessageId, sourceId, inboxId } =
-    resolveBotMessageIdentifiers(response);
-  const resolvedMessageId =
-    typeof directMessageId === "number"
-      ? directMessageId
-      : typeof sourceId === "number"
-        ? sourceId
-        : undefined;
-
-  if (typeof resolvedMessageId !== "number" || typeof inboxId !== "number") {
-    console.warn("fallback sendBotMessage missing identifiers", {
-      hasMessageId: typeof directMessageId === "number",
-      hasSourceId: typeof sourceId === "number",
-      hasInboxId: typeof inboxId === "number",
-      accountId,
-      conversationId,
-    });
-    return;
-  }
-
   await storeBotMessage({
     accountId,
     conversationId,
-    messageId: resolvedMessageId,
-    inboxId,
     payload: response,
-    sourceId,
     fallbackContent,
   });
 }

--- a/lib/handoff.ts
+++ b/lib/handoff.ts
@@ -4,10 +4,7 @@ import {
   sendBotMessage,
 } from "@/lib/chatwootBot";
 import { setAgentAvailability, updateConversation } from "@/lib/chatwoot";
-import {
-  resolveBotMessageIdentifiers,
-  storeBotMessage,
-} from "@/lib/storeBotMessage";
+import { storeBotMessage } from "@/lib/storeBotMessage";
 
 export async function handOff(
   accountId: number,
@@ -44,42 +41,12 @@ export async function handOff(
         conversationId,
         fallbackContent
       );
-      if (!response || typeof response !== "object") {
-        console.warn("handoff fallback message missing payload", {
-          accountId,
-          conversationId,
-        });
-        return false;
-      }
-
-      const { messageId: directMessageId, sourceId, inboxId } =
-        resolveBotMessageIdentifiers(response);
-      const resolvedMessageId =
-        typeof directMessageId === "number"
-          ? directMessageId
-          : typeof sourceId === "number"
-            ? sourceId
-            : undefined;
-
-      if (typeof resolvedMessageId === "number" && typeof inboxId === "number") {
-        await storeBotMessage({
-          accountId,
-          conversationId,
-          messageId: resolvedMessageId,
-          inboxId,
-          payload: response,
-          sourceId,
-          fallbackContent,
-        });
-      } else {
-        console.warn("handoff fallback message missing identifiers", {
-          hasMessageId: typeof directMessageId === "number",
-          hasSourceId: typeof sourceId === "number",
-          hasInboxId: typeof inboxId === "number",
-          accountId,
-          conversationId,
-        });
-      }
+      await storeBotMessage({
+        accountId,
+        conversationId,
+        payload: response,
+        fallbackContent,
+      });
     } catch (error) {
       console.error("send fallback message error", error);
     }

--- a/lib/storeBotMessage.ts
+++ b/lib/storeBotMessage.ts
@@ -14,12 +14,11 @@ export type BotMessageIdentifiers = {
 export type StoreBotMessageParams = {
   accountId: number;
   conversationId: number;
-  messageId: number;
-  inboxId: number;
-  payload?: unknown;
-  sourceId?: number;
+  payload: unknown;
   fallbackContent?: string;
   conversationKey?: string;
+  defaultMessageId?: number;
+  defaultInboxId?: number;
   createdAt?: StoreAssistantMessageParams["createdAt"];
 };
 
@@ -63,18 +62,45 @@ export function resolveBotMessageIdentifiers(payload: unknown): BotMessageIdenti
 export async function storeBotMessage({
   accountId,
   conversationId,
-  messageId,
-  inboxId,
   payload,
-  sourceId,
   fallbackContent,
   conversationKey: providedConversationKey,
+  defaultMessageId,
+  defaultInboxId,
   createdAt: explicitCreatedAt,
-}: StoreBotMessageParams): Promise<StoreBotMessageResult> {
-  const record =
-    payload && typeof payload === "object"
-      ? (payload as Record<string, unknown>)
-      : undefined;
+}: StoreBotMessageParams): Promise<StoreBotMessageResult | undefined> {
+  if (!payload || typeof payload !== "object") {
+    console.warn("storeBotMessage payload missing", {
+      accountId,
+      conversationId,
+    });
+    return undefined;
+  }
+
+  const record = payload as Record<string, unknown>;
+
+  const { messageId, sourceId, inboxId } = resolveBotMessageIdentifiers(record);
+
+  const resolvedMessageId =
+    getNumericId(messageId) ??
+    getNumericId(sourceId) ??
+    getNumericId(defaultMessageId) ??
+    undefined;
+
+  const resolvedInboxId =
+    getNumericId(inboxId) ?? getNumericId(defaultInboxId) ?? undefined;
+
+  if (typeof resolvedMessageId !== "number" || typeof resolvedInboxId !== "number") {
+    console.warn("storeBotMessage missing identifiers", {
+      hasMessageId: typeof messageId === "number",
+      hasSourceId: typeof sourceId === "number",
+      hasInboxId: typeof inboxId === "number", // inboxId maybe undefined
+      hasDefaultInboxId: typeof defaultInboxId === "number",
+      accountId,
+      conversationId,
+    });
+    return undefined;
+  }
 
   const contentValue =
     typeof record?.content === "string"
@@ -92,29 +118,31 @@ export async function storeBotMessage({
       | null
       | undefined);
 
-  const resolvedSourceId =
-    sourceId ?? (record ? getNumericId((record as any)?.source_id) ?? undefined : undefined);
+  const hasConversationKey =
+    typeof providedConversationKey === "string" &&
+    providedConversationKey.trim().length > 0;
 
-  const conversationKey =
-    typeof providedConversationKey === "string" && providedConversationKey.trim().length > 0
-      ? providedConversationKey
-      : getConversationKey(accountId, conversationId, inboxId);
+  const conversationKey = hasConversationKey
+    ? defaultInboxId === undefined || defaultInboxId === resolvedInboxId
+      ? providedConversationKey.trim()
+      : getConversationKey(accountId, conversationId, resolvedInboxId)
+    : getConversationKey(accountId, conversationId, resolvedInboxId);
 
   await storeAssistantMessage({
     accountId,
     conversationId,
-    inboxId,
+    inboxId: resolvedInboxId,
     conversationKey,
-    messageId,
+    messageId: resolvedMessageId,
     content: contentValue,
     createdAt: createdAtValue,
   });
 
   return {
     stored: true,
-    messageId,
-    inboxId,
-    sourceId: resolvedSourceId,
+    messageId: resolvedMessageId,
+    inboxId: resolvedInboxId,
+    sourceId: getNumericId(sourceId) ?? undefined,
     conversationKey,
     content: contentValue,
   };

--- a/tests/chatwootWebhook.test.js
+++ b/tests/chatwootWebhook.test.js
@@ -24,29 +24,6 @@ const sendBotMessageMock = mock.method(
   })
 );
 
-const storeBotMessage = require('../lib/storeBotMessage.ts');
-const storeBotMessageMock = mock.method(
-  storeBotMessage,
-  'storeBotMessage',
-  async (args) => ({
-    stored: true,
-    messageId: args.messageId,
-    inboxId: args.inboxId,
-    sourceId: args.sourceId,
-    conversationKey:
-      args.conversationKey ??
-      `chatwoot:${args.accountId}:${args.conversationId}:${args.inboxId}`,
-    content:
-      typeof args?.payload === 'object' &&
-      args?.payload !== null &&
-      typeof args.payload.content === 'string'
-        ? args.payload.content
-        : typeof args.fallbackContent === 'string'
-          ? args.fallbackContent
-          : '',
-  })
-);
-
 const {
   MESSAGE_FALLBACK_TEXT,
   HANDOFF_FALLBACK_TEXT,
@@ -164,7 +141,6 @@ function resetMocks() {
   releaseAgentMock.mock.mockImplementation(async () => {});
   sendBotMessageMock.mock.resetCalls();
   nextMessageId = 0;
-  storeBotMessageMock.mock.resetCalls();
   getProviderMock.mock.resetCalls();
   providerFnMock.mock.resetCalls();
   getNextAgentMock.mock.resetCalls();
@@ -205,11 +181,17 @@ function resetMocks() {
   }));
 }
 
+function getLoggedBotMessages() {
+  return prisma.conversationMessage.upsert.mock.calls
+    .map((call) => call.arguments?.[0]?.create)
+    .filter((create) => create && create.sender === 'bot');
+}
+
 function assertLoggedIds(...expectedIds) {
-  assert.strictEqual(storeBotMessageMock.mock.calls.length, expectedIds.length);
+  const botMessages = getLoggedBotMessages();
+  assert.strictEqual(botMessages.length, expectedIds.length);
   expectedIds.forEach((id, index) => {
-    const call = storeBotMessageMock.mock.calls[index];
-    assert.strictEqual(call.arguments[0].messageId, id);
+    assert.strictEqual(botMessages[index].messageId, id);
   });
 }
 

--- a/tests/releaseAgent.test.js
+++ b/tests/releaseAgent.test.js
@@ -6,7 +6,6 @@ require('tsconfig-paths/register');
 const conversationResolution = require('../lib/conversationResolution.ts');
 const chatwoot = require('../lib/chatwoot.ts');
 const chatwootBot = require('../lib/chatwootBot.ts');
-const storeBotMessage = require('../lib/storeBotMessage.ts');
 const agentRotation = require('../lib/agentRotation.ts');
 const handoffQueue = require('../lib/handoffQueue.ts');
 const friendlyErrors = require('../lib/friendlyErrors.ts');
@@ -30,6 +29,18 @@ const queuedConversationId = 2;
 const freedAgentId = 5;
 
 prisma.agentAssignment.findFirst = mock.fn(async () => ({ agentId: freedAgentId }));
+prisma.conversationMessage = {
+  upsert: mock.fn(async () => ({})),
+  findMany: mock.fn(async () => []),
+};
+
+const redisPipelineMock = {
+  rpush: mock.fn(() => {}),
+  expire: mock.fn(() => {}),
+  exec: mock.fn(async () => {}),
+};
+redis.exists = mock.fn(async () => 0);
+redis.pipeline = mock.fn(() => redisPipelineMock);
 
 test.after(async () => {
   await prisma.$disconnect();
@@ -63,39 +74,19 @@ const sendMock = mock.method(
   }
 );
 
-const storeBotMessageMock = mock.method(
-  storeBotMessage,
-  'storeBotMessage',
-  async (args) => ({
-    stored: true,
-    messageId: args.messageId,
-    inboxId: args.inboxId,
-    sourceId: args.sourceId,
-    conversationKey:
-      args.conversationKey ??
-      `chatwoot:${args.accountId}:${args.conversationId}:${args.inboxId}`,
-    content:
-      typeof args?.payload === 'object' &&
-      args?.payload !== null &&
-      typeof args.payload.content === 'string'
-        ? args.payload.content
-        : typeof args.fallbackContent === 'string'
-          ? args.fallbackContent
-          : '',
-  })
-);
-
 function assertLoggedIds(...expectedIds) {
-  assert.strictEqual(storeBotMessageMock.mock.calls.length, expectedIds.length);
+  const botMessages = prisma.conversationMessage.upsert.mock.calls
+    .map((call) => call.arguments?.[0]?.create)
+    .filter((create) => create && create.sender === 'bot');
+  assert.strictEqual(botMessages.length, expectedIds.length);
   expectedIds.forEach((id, index) => {
-    const call = storeBotMessageMock.mock.calls[index];
-    assert.strictEqual(call.arguments[0].messageId, id);
+    assert.strictEqual(botMessages[index].messageId, id);
   });
 }
 
 test('releaseAgent opens and assigns conversation before notifying', async () => {
   nextMessageId = 0;
-  storeBotMessageMock.mock.resetCalls();
+  prisma.conversationMessage.upsert.mock.resetCalls();
   sendMock.mock.resetCalls();
   await conversationResolution.releaseAgent(accountId, releasedConversationId, { assignee_id: freedAgentId });
 
@@ -110,7 +101,7 @@ test('releaseAgent opens and assigns conversation before notifying', async () =>
 
 test('releaseAgent sends fallback when updateRequest fails', async () => {
   nextMessageId = 0;
-  storeBotMessageMock.mock.resetCalls();
+  prisma.conversationMessage.upsert.mock.resetCalls();
   sendMock.mock.resetCalls();
   handoffQueue.updateRequest.mock.mockImplementationOnce(async () => { throw new Error('fail'); });
   const notifyMock = mock.method(friendlyErrors, 'notifyHandoffIssue', async () => {});
@@ -123,7 +114,7 @@ test('releaseAgent sends fallback when updateRequest fails', async () => {
 
 test('releaseAgent throws when freed agent cannot be resolved', async () => {
   nextMessageId = 0;
-  storeBotMessageMock.mock.resetCalls();
+  prisma.conversationMessage.upsert.mock.resetCalls();
   sendMock.mock.resetCalls();
   const fetchErr = new Error('fetch failed');
   getConversationMock.mock.mockImplementationOnce(async () => {
@@ -146,7 +137,7 @@ test('releaseAgent throws when freed agent cannot be resolved', async () => {
 
 test('status change without label skips releaseAgent call', async () => {
   nextMessageId = 0;
-  storeBotMessageMock.mock.resetCalls();
+  prisma.conversationMessage.upsert.mock.resetCalls();
   sendMock.mock.resetCalls();
   const consoleInfoMock = mock.method(console, 'info', () => {});
   const releaseAgentMock = mock.method(
@@ -191,7 +182,7 @@ test('status change without label skips releaseAgent call', async () => {
 
 test('label removed with status open skips releaseAgent call', async () => {
   nextMessageId = 0;
-  storeBotMessageMock.mock.resetCalls();
+  prisma.conversationMessage.upsert.mock.resetCalls();
   sendMock.mock.resetCalls();
   const consoleInfoMock = mock.method(console, 'info', () => {});
   const releaseAgentMock = mock.method(
@@ -244,7 +235,7 @@ test('label removed with status open skips releaseAgent call', async () => {
 
 test('status change with label triggers releaseAgent', async () => {
   nextMessageId = 0;
-  storeBotMessageMock.mock.resetCalls();
+  prisma.conversationMessage.upsert.mock.resetCalls();
   sendMock.mock.resetCalls();
   const consoleInfoMock = mock.method(console, 'info', () => {});
   const releaseAgentMock = mock.method(


### PR DESCRIPTION
## Summary
- add a dedicated `storeBotMessage` helper that resolves Chatwoot identifiers, stores the message in Prisma, and pushes it to Redis
- wire every `sendBotMessage` call site through the helper, including the webhook, handoff, friendly error, and release flows
- update the Chatwoot webhook and release agent test suites to assert bot messages are persisted via Prisma instead of a manual mock

## Testing
- `npm test -- tests/chatwootWebhook.test.js`
- `npm test -- tests/releaseAgent.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68d470b76924833397f18df0ab3a28d9