### PR TITLE
Clarify quote candidate developer guidance

### DIFF
--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -70,7 +70,7 @@ function buildQuoteDeveloperPrompt(
     const timestamp = formatQuoteTimestamp(entry.createdAt);
     return `${prefix} · ${timestamp} · ${snippet}`;
   });
-  return `Quote candidates (newest first):\n${lines.join("\n")}`;
+  return `Quote candidates available for set_reply_reference (newest first):\n${lines.join("\n")}`;
 }
 
 function normalizeHistoryTurnFromMessage(message: any): HistoryTurn | undefined {

--- a/tests/chatwootWebhook.test.js
+++ b/tests/chatwootWebhook.test.js
@@ -978,7 +978,11 @@ test('chatwoot webhook includes developer quote guidance when transcript exists'
   assert.strictEqual(messages[1].content[0].text, 'Quote summary');
   assert.strictEqual(messages[2].role, 'developer');
   const developerText = messages[2].content[0].text;
-  assert.ok(developerText.includes('Quote candidates (newest first):'));
+  assert.ok(
+    developerText.includes(
+      'Quote candidates available for set_reply_reference (newest first):'
+    )
+  );
   assert.ok(developerText.includes('user#4324'));
   assert.ok(developerText.includes('Official WhatsApp order update'));
   assert.ok(developerText.includes('user#4321'));


### PR DESCRIPTION
## Summary
- update the developer prompt injected into the Chatwoot webhook so it explicitly frames quote candidates as message IDs for `set_reply_reference`
- adjust the webhook test to match the clarified guidance text

## Testing
- npm test -- tests/chatwootWebhook.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d8ffaccb808333b18dc704770652d0