### PR TITLE
Fix Chatwoot webhook quoting fallback logic

### DIFF
--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -1383,14 +1383,27 @@ export async function POST(request: Request) {
         history: quoteHistoryTurns,
       });
       if (shouldQuote) {
+        const fallbackQuoteId = (() => {
+          const overrideInReply = defaultReplyOverride?.inReplyTo;
+          if (
+            typeof overrideInReply === "number" &&
+            Number.isFinite(overrideInReply)
+          ) {
+            return overrideInReply;
+          }
+          if (
+            typeof normalizedDefaultReplyToId === "number" &&
+            Number.isFinite(normalizedDefaultReplyToId)
+          ) {
+            return normalizedDefaultReplyToId;
+          }
+          return undefined;
+        })();
         const preferredQuoteId =
           typeof referencedMessageId === "number" &&
           Number.isFinite(referencedMessageId)
             ? referencedMessageId
-            : typeof defaultReplyToId === "number" &&
-                Number.isFinite(defaultReplyToId)
-              ? defaultReplyToId
-              : undefined;
+            : fallbackQuoteId;
         if (typeof preferredQuoteId === "number") {
           finalReplyReference = {
             ...(finalReplyReference ?? {}),


### PR DESCRIPTION
## Summary
- ensure the Chatwoot webhook's quoting heuristic falls back to the normalized reply target when no override is set
- keep the referenced message ID preferred whenever the heuristic detects it should quote

## Testing
- npm test -- tests/chatwootWebhook.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d93e9dc4a883338ee5605d1f5b32dc