### PR TITLE
Improve relevance guardrail domain detection

### DIFF
--- a/lib/guardrails.ts
+++ b/lib/guardrails.ts
@@ -11,10 +11,45 @@ export const JailbreakOutput = z.object({
   jailbreak: z.boolean(),
 });
 
+/**
+ * Domain-specific phrases that should always be treated as relevant.
+ * The list includes product categories, service offerings, and industry terms
+ * associated with Automation Ghana and its subsidiaries so future adjustments
+ * can extend or refine the coverage in a single place.
+ */
+const relevanceKeywords = [
+  'automation ghana',
+  'automation ghana group',
+  'tagg',
+  'process & plant automation',
+  'ppa',
+  'automation solutions limited',
+  'asl',
+  'electrical switchgear limited',
+  'esl',
+  'home automation',
+  'smart building',
+  'building management system',
+  'construction solutions',
+  'industrial automation',
+  'control panels',
+  'power management',
+  'energy efficiency services',
+  'installation services',
+  'maintenance services',
+  'commissioning support',
+  'instrumentation services',
+  'safety systems',
+  'renewable integration',
+  'facility upgrades',
+  'electrical consulting',
+  'site assessments',
+];
+
 const guardrail_agent = new Agent({
   name: 'Relevance guardrail',
   instructions:
-    'You will receive the full conversation so far. Decide if the latest user message is part of a customer support conversation. Consider single-word greetings like "hi", "hello", or "hey" as relevant even when they appear alone. Treat greetings, contact info, or short replies as relevant unless clearly off-topic. Treat queries about Automation Ghana\'s products and services—including items sold on the store such as ATS panels, distribution boards, relays, tools—as relevant. Treat follow-up questions referencing earlier answers about Automation Ghana and its subsidiaries Process & Plant Automation (PPA), Automation Solutions Limited (ASL), and Electrical Switchgear Limited (ESL) as relevant, even if they omit the company name or product details. Allow questions referencing The Automation Ghana Group or TAGG and its subsidiaries (PPA, ASL, and ESL), including sustainability initiatives and personnel. Treat queries mentioning potential or known employee names as relevant, even if the company name is omitted. Ticket numbers (e.g., #[0-9]+/[0-9]{4}-[0-9]{2}-[0-9]{2}) and requests to reconnect or resume a session are considered relevant. Treat customer requests for ticket creation or generation as relevant. Respond only with JSON {"relevant": true} or {"relevant": false}.',
+    'You will receive the full conversation so far. Decide if the latest user message is part of a customer support conversation. Consider single-word greetings like "hi", "hello", or "hey" as relevant even when they appear alone. Treat greetings, contact info, or short replies as relevant unless clearly off-topic. Treat queries about Automation Ghana\'s products and services—including items sold on the store such as ATS panels, distribution boards, relays, tools—as relevant. Treat follow-up questions referencing earlier answers about Automation Ghana and its subsidiaries Process & Plant Automation (PPA), Automation Solutions Limited (ASL), and Electrical Switchgear Limited (ESL) as relevant, even if they omit the company name or product details. Allow questions referencing The Automation Ghana Group or TAGG and its subsidiaries (PPA, ASL, and ESL), including sustainability initiatives, service offerings such as home automation, construction solutions, smart building systems, industrial automation, instrumentation, safety systems, and personnel. Treat queries mentioning potential or known employee names as relevant, even if the company name is omitted. Ticket numbers (e.g., #[0-9]+/[0-9]{4}-[0-9]{2}-[0-9]{2}) and requests to reconnect or resume a session are considered relevant. Treat customer requests for ticket creation or generation as relevant. Respond only with JSON {"relevant": true} or {"relevant": false}.',
   model: MODEL,
   outputType: RelevanceOutput,
 });
@@ -28,6 +63,18 @@ const jailbreak_guardrail_agent = new Agent({
 });
 
 export async function runRelevanceGuardrail({ input }: { input: string }) {
+  const normalizedInput = input.toLowerCase();
+  const matchedKeyword = relevanceKeywords.find((keyword) =>
+    normalizedInput.includes(keyword)
+  );
+
+  if (matchedKeyword) {
+    return {
+      tripwireTriggered: false,
+      outputInfo: { relevant: true, matchedKeyword },
+    };
+  }
+
   const result = await run(guardrail_agent, input);
   let parsed: any;
   try {


### PR DESCRIPTION
## Summary
- expand the relevance guardrail instructions to mention additional Automation Ghana domain offerings such as home automation, construction solutions, and industrial services
- introduce a documented keyword list for domain-specific phrases that should always be marked relevant
- add a pre-check that short-circuits the relevance guardrail when the latest user message matches a known domain keyword

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dbbf718b848333a093cc4a2014868d