### PR TITLE
Handle relevance guardrail follow-ups

### DIFF
--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -22,6 +22,10 @@ import { enqueueRequest, updateRequest } from "@/lib/handoffQueue";
 import { handoffStrategy } from "@/config/handoffStrategy";
 import { releaseAgent } from "@/lib/conversationResolution";
 import { CHATWOOT_SYSTEM_PROMPT, MODEL } from "@/config/constants";
+import {
+  RELEVANCE_FOLLOW_UP_MESSAGE,
+  RELEVANCE_REJECTION_MESSAGE,
+} from "@/config/guardrailMessages";
 import { getConversationKey } from "@/lib/getConversationKey";
 import { getConversationHistory } from "@/lib/getConversationHistory";
 import { getConversationSynopsis } from "@/lib/getConversationSynopsis";
@@ -49,6 +53,28 @@ const QUOTE_TRANSCRIPT_ASSISTANT_LIMIT = 2;
 const MAX_DEVELOPER_QUOTE_LINES = 6;
 const SYNOPSIS_HISTORY_LIMIT = 50;
 const PROMPT_HISTORY_LIMIT = 20;
+
+function extractResponseMessageText(message: any): string {
+  if (!message) {
+    return "";
+  }
+  const { content } = message as { content?: unknown };
+  if (typeof content === "string") {
+    return content;
+  }
+  if (Array.isArray(content)) {
+    return content
+      .map((item) => {
+        if (!item) return "";
+        if (typeof item === "string") return item;
+        if (typeof (item as any)?.text === "string") return (item as any).text;
+        return "";
+      })
+      .join(" ")
+      .trim();
+  }
+  return "";
+}
 
 function formatQuoteTimestamp(date?: Date): string {
   if (!date || !(date instanceof Date) || Number.isNaN(date.getTime())) {
@@ -1106,17 +1132,52 @@ export async function POST(request: Request) {
         input: relevanceInput,
       });
       const jailbreak = await runJailbreakGuardrail({ input: guardrailUserInput });
-      if (relevance.tripwireTriggered || jailbreak.tripwireTriggered) {
+
+      if (jailbreak.tripwireTriggered) {
+        console.log("Guardrail triggered via Chatwoot: jailbreak", {
+          guardrailUserInput,
+          jailbreakOutput: jailbreak.outputInfo,
+          relevanceOutput: relevance.outputInfo,
+        });
         const guardrailResponse = await sendBotMessage(
           accountId,
           conversationId,
-          "I can't assist with that request.",
+          RELEVANCE_REJECTION_MESSAGE,
           buildReplyOptions(defaultReplyOverride, normalizedReferencedReplyToId)
         );
-        await logAssistantResponse(
-          guardrailResponse,
-          "I can't assist with that request."
+        await logAssistantResponse(guardrailResponse, RELEVANCE_REJECTION_MESSAGE);
+        return NextResponse.json({ status: "guardrail" });
+      }
+
+      if (relevance.tripwireTriggered) {
+        const lastAssistantMessage = Array.isArray(fullHistory)
+          ? [...fullHistory].reverse().find((entry) => entry?.role === "assistant")
+          : undefined;
+        const previousAssistantText = extractResponseMessageText(
+          lastAssistantMessage
         );
+        const clarificationRequestedPreviously =
+          previousAssistantText === RELEVANCE_FOLLOW_UP_MESSAGE;
+        const outgoingMessage = clarificationRequestedPreviously
+          ? RELEVANCE_REJECTION_MESSAGE
+          : RELEVANCE_FOLLOW_UP_MESSAGE;
+        console.log(
+          clarificationRequestedPreviously
+            ? "Guardrail rejection after clarification via Chatwoot"
+            : "Guardrail follow-up requested via Chatwoot",
+          {
+            guardrailUserInput,
+            relevanceOutput: relevance.outputInfo,
+            conversationId,
+          }
+        );
+        const guardrailResponse = await sendBotMessage(
+          accountId,
+          conversationId,
+          outgoingMessage,
+          buildReplyOptions(defaultReplyOverride, normalizedReferencedReplyToId)
+        );
+        await logAssistantResponse(guardrailResponse, outgoingMessage);
         return NextResponse.json({ status: "guardrail" });
       }
     } catch (err) {

--- a/app/api/turn_response/route.ts
+++ b/app/api/turn_response/route.ts
@@ -4,6 +4,32 @@ import { getProvider } from "@/lib/providers";
 import { saveSessionMessages } from "@/lib/server/saveSessionMessages";
 import { toResponseMessage } from "@/lib/utils/toResponseMessage";
 import { randomUUID } from "crypto";
+import {
+  RELEVANCE_FOLLOW_UP_MESSAGE,
+  RELEVANCE_REJECTION_MESSAGE,
+} from "@/config/guardrailMessages";
+
+function extractMessageText(message: any): string {
+  if (!message) {
+    return "";
+  }
+  const { content } = message;
+  if (typeof content === "string") {
+    return content;
+  }
+  if (Array.isArray(content)) {
+    return content
+      .map((item) => {
+        if (!item) return "";
+        if (typeof item === "string") return item;
+        if (typeof item?.text === "string") return item.text;
+        return "";
+      })
+      .join(" ")
+      .trim();
+  }
+  return "";
+}
 
 /**
  * Handle a single conversation turn and stream the model response.
@@ -69,16 +95,57 @@ export async function POST(request: Request) {
     jailbreak = await runJailbreakGuardrail({ input: userInput });
     console.log("Jailbreak guardrail result:", jailbreak);
 
-    if (relevance.tripwireTriggered || jailbreak.tripwireTriggered) {
-      console.log("Guardrail triggered", {
-        relevanceTriggered: relevance.tripwireTriggered,
-        jailbreakTriggered: jailbreak.tripwireTriggered,
+    const lastMessageIndex = normalizedMessages.lastIndexOf(lastMessage);
+    let previousAssistantText = "";
+    if (
+      typeof lastMessageIndex === "number" &&
+      lastMessageIndex > 0 &&
+      lastMessage?.role === "user"
+    ) {
+      for (let index = lastMessageIndex - 1; index >= 0; index -= 1) {
+        const candidate = normalizedMessages[index];
+        if (candidate?.role === "assistant") {
+          previousAssistantText = extractMessageText(candidate);
+          break;
+        }
+      }
+    }
+
+    if (jailbreak.tripwireTriggered) {
+      console.log("Guardrail triggered: jailbreak", {
+        userInput,
+        jailbreakOutput: jailbreak.outputInfo,
+        relevanceOutput: relevance.outputInfo,
       });
       return NextResponse.json(
-        {
-          guardrail: true,
-          message: "Sorry, I can't help with that request.",
-        },
+        { guardrail: true, message: RELEVANCE_REJECTION_MESSAGE },
+        { status: 200 }
+      );
+    }
+
+    if (relevance.tripwireTriggered) {
+      const clarificationRequestedPreviously =
+        previousAssistantText === RELEVANCE_FOLLOW_UP_MESSAGE;
+
+      if (!clarificationRequestedPreviously) {
+        console.log("Guardrail follow-up requested", {
+          userInput,
+          guardrailInput,
+          relevanceOutput: relevance.outputInfo,
+        });
+        return NextResponse.json(
+          { guardrail: true, message: RELEVANCE_FOLLOW_UP_MESSAGE },
+          { status: 200 }
+        );
+      }
+
+      console.log("Guardrail rejection after clarification", {
+        userInput,
+        guardrailInput,
+        relevanceOutput: relevance.outputInfo,
+      });
+      return NextResponse.json(
+        { guardrail: true, message: RELEVANCE_REJECTION_MESSAGE },
         { status: 200 }
       );
     }

--- a/config/guardrailMessages.ts
+++ b/config/guardrailMessages.ts
@@ -1,0 +1,5 @@
+export const RELEVANCE_FOLLOW_UP_MESSAGE =
+  "I'm here to help with Automation Ghana support questions. Could you clarify or narrow your request so I can assist you better?";
+
+export const RELEVANCE_REJECTION_MESSAGE =
+  "Sorry, I can't help with that request.";

--- a/tests/chatwootWebhook.test.js
+++ b/tests/chatwootWebhook.test.js
@@ -63,6 +63,10 @@ const getConversationTranscriptMock = mock.method(
 );
 
 const { toResponseMessage } = require('../lib/utils/toResponseMessage.ts');
+const {
+  RELEVANCE_FOLLOW_UP_MESSAGE,
+  RELEVANCE_REJECTION_MESSAGE,
+} = require('../config/guardrailMessages.ts');
 
 const agentRotation = require('../lib/agentRotation.ts');
 const getNextAgentMock = mock.method(agentRotation, 'getNextAgent', async () => null);
@@ -1316,10 +1320,53 @@ test('chatwoot webhook sends fallback when relevance guardrail triggers', async 
   const res = await webhookPost(req);
   const body = await res.json();
   assert.strictEqual(body.status, 'guardrail');
-  assert.strictEqual(sendBotMessageMock.mock.calls[0].arguments[2], "I can't assist with that request.");
+  assert.strictEqual(
+    sendBotMessageMock.mock.calls[0].arguments[2],
+    RELEVANCE_FOLLOW_UP_MESSAGE
+  );
   assert.deepStrictEqual(sendBotMessageMock.mock.calls[0].arguments[3], {
     private: false,
     inReplyTo: 901,
+  });
+  assert.strictEqual(getProviderMock.mock.calls.length, 0);
+  assertLoggedIds(1);
+  resetMocks();
+});
+
+test('chatwoot webhook rejects after clarification when relevance guardrail triggers again', async () => {
+  runRelevanceGuardrailMock.mock.mockImplementation(async () => ({
+    tripwireTriggered: true,
+  }));
+  getConversationHistoryMock.mock.mockImplementationOnce(async () => [
+    toResponseMessage('assistant', RELEVANCE_FOLLOW_UP_MESSAGE),
+  ]);
+  const payload = {
+    event: 'message_created',
+    data: {
+      event: 'message_created',
+      message: {
+        id: 905,
+        message_type: 0,
+        content: 'still off topic',
+        account: { id: 9 },
+        conversation: { id: 9, inbox_id: 1, status: 'resolved', account_id: 9 },
+      },
+    },
+  };
+  const req = new Request('http://localhost', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+  const res = await webhookPost(req);
+  const body = await res.json();
+  assert.strictEqual(body.status, 'guardrail');
+  assert.strictEqual(
+    sendBotMessageMock.mock.calls[0].arguments[2],
+    RELEVANCE_REJECTION_MESSAGE
+  );
+  assert.deepStrictEqual(sendBotMessageMock.mock.calls[0].arguments[3], {
+    private: false,
+    inReplyTo: 905,
   });
   assert.strictEqual(getProviderMock.mock.calls.length, 0);
   assertLoggedIds(1);
@@ -1350,7 +1397,10 @@ test('chatwoot webhook sends fallback when jailbreak guardrail triggers', async 
   const res = await webhookPost(req);
   const body = await res.json();
   assert.strictEqual(body.status, 'guardrail');
-  assert.strictEqual(sendBotMessageMock.mock.calls[0].arguments[2], "I can't assist with that request.");
+  assert.strictEqual(
+    sendBotMessageMock.mock.calls[0].arguments[2],
+    RELEVANCE_REJECTION_MESSAGE
+  );
   assert.deepStrictEqual(sendBotMessageMock.mock.calls[0].arguments[3], {
     private: false,
     inReplyTo: 902,


### PR DESCRIPTION
## Summary
- add shared guardrail messaging constants for relevance guardrail responses
- update the turn response API to request clarification before rejecting irrelevant requests and log outcomes
- adjust the Chatwoot webhook guardrail flow and tests to cover clarification follow-ups and eventual rejection

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbc37ca0a083339311a6e59dd0cf28