### PR TITLE
Initialize guardrail defaults for turn response guardrails

### DIFF
--- a/app/api/turn_response/route.ts
+++ b/app/api/turn_response/route.ts
@@ -66,8 +66,14 @@ export async function POST(request: Request) {
 
     let userInput = "";
     let guardrailInput = "";
-    let relevance = { tripwireTriggered: false };
-    let jailbreak = { tripwireTriggered: false };
+    let relevance: Awaited<ReturnType<typeof runRelevanceGuardrail>> = {
+      tripwireTriggered: false,
+      outputInfo: {},
+    };
+    let jailbreak: Awaited<ReturnType<typeof runJailbreakGuardrail>> = {
+      tripwireTriggered: false,
+      outputInfo: {},
+    };
 
     if (Array.isArray(normalizedMessages)) {
       const relevant = normalizedMessages


### PR DESCRIPTION
## Summary
- initialize relevance and jailbreak guardrail defaults with output information
- annotate guardrail placeholders with their return types for safer logging

## Testing
- npx tsc

------
https://chatgpt.com/codex/tasks/task_e_68dbd40cd3388333afea8995a1421486