### PR TITLE
Add agent availability summary to rotation and update fallbacks

### DIFF
--- a/app/api/chatwoot-webhook/route.ts
+++ b/app/api/chatwoot-webhook/route.ts
@@ -2,7 +2,11 @@ import { NextResponse } from "next/server";
 import { parse } from "partial-json";
 import type { ChatwootWebhookPayload, Conversation } from "@/types/chatwoot";
 import prisma from "@/lib/prisma";
-import { getNextAgent, setActiveConversation } from "@/lib/agentRotation";
+import {
+  getNextAgent,
+  setActiveConversation,
+  type AgentAvailabilitySummary,
+} from "@/lib/agentRotation";
 import { sendBotMessage } from "@/lib/chatwootBot";
 import redis from "@/lib/redis";
 import { storeBotMessage } from "@/lib/storeBotMessage";
@@ -53,6 +57,20 @@ const QUOTE_TRANSCRIPT_ASSISTANT_LIMIT = 2;
 const MAX_DEVELOPER_QUOTE_LINES = 6;
 const SYNOPSIS_HISTORY_LIMIT = 50;
 const PROMPT_HISTORY_LIMIT = 20;
+
+const BUSY_AGENT_MESSAGE =
+  "All human agents are currently busy. Please wait for the next available agent.";
+const OFFLINE_AGENT_MESSAGE =
+  "No human agents are currently available. Please try again later.";
+
+function getAgentUnavailableMessage(
+  summary: AgentAvailabilitySummary
+): string {
+  if (summary.online > 0 || summary.busy > 0) {
+    return BUSY_AGENT_MESSAGE;
+  }
+  return OFFLINE_AGENT_MESSAGE;
+}
 
 function extractResponseMessageText(message: any): string {
   if (!message) {
@@ -697,7 +715,7 @@ export async function POST(request: Request) {
       const confirmPattern = /\b(yes|y|sure|confirm|ok)\b/i;
       if (confirmPattern.test(content)) {
         try {
-            const agent = await getNextAgent(accountId);
+            const { agent } = await getNextAgent(accountId);
             if (agent) {
               const role =
                 agent.role === "administrator" ? "administrator" : "agent";
@@ -889,7 +907,7 @@ export async function POST(request: Request) {
       }
 
       try {
-        const agent = await getNextAgent(accountId);
+        const { agent, availabilitySummary } = await getNextAgent(accountId);
         if (agent) {
           console.info("handoff", {
             step: "enqueue",
@@ -1018,16 +1036,14 @@ export async function POST(request: Request) {
               accountId,
               conversationId,
             });
+          const unavailableMessage = getAgentUnavailableMessage(availabilitySummary);
           const botResponse = await sendBotMessage(
             accountId,
             conversationId,
-            "All human agents are currently busy. Please wait for the next available agent.",
+            unavailableMessage,
             buildReplyOptions(defaultReplyOverride, normalizedReferencedReplyToId)
           );
-          await logAssistantResponse(
-            botResponse,
-            "All human agents are currently busy. Please wait for the next available agent."
-          );
+          await logAssistantResponse(botResponse, unavailableMessage);
           console.info("handoff", "message sent");
         }
       } catch (err) {

--- a/lib/agentRotation.ts
+++ b/lib/agentRotation.ts
@@ -8,20 +8,60 @@ export interface AgentRecord {
   [key: string]: any;
 }
 
+export interface AgentAvailabilitySummary {
+  online: number;
+  busy: number;
+  offline: number;
+}
+
+export interface AgentSelectionResult {
+  agent: AgentRecord | null;
+  availabilitySummary: AgentAvailabilitySummary;
+}
+
 export async function getNextAgent(
   accountId: number
-): Promise<AgentRecord | null> {
-  const agents: AgentRecord[] = await listAgents(accountId, "online");
-  // Double-check the API response to ensure only online agents are considered
+): Promise<AgentSelectionResult> {
+  const agents: AgentRecord[] = await listAgents(accountId);
+
+  const availabilitySummary: AgentAvailabilitySummary = {
+    online: 0,
+    busy: 0,
+    offline: 0,
+  };
+
+  for (const agent of agents) {
+    switch (agent.availability_status) {
+      case "online":
+        availabilitySummary.online += 1;
+        break;
+      case "busy":
+        availabilitySummary.busy += 1;
+        break;
+      case "offline":
+        availabilitySummary.offline += 1;
+        break;
+      default:
+        break;
+    }
+  }
+
   const onlineAgents = agents.filter(
     (a) => a.availability_status === "online"
   );
   console.info(
     "[agentRotation] fetched agents",
-    { accountId, agents: onlineAgents.map((a) => ({ id: a.id, availability_status: a.availability_status })) }
+    {
+      accountId,
+      availabilitySummary,
+      agents: onlineAgents.map((a) => ({
+        id: a.id,
+        availability_status: a.availability_status,
+      })),
+    }
   );
   if (onlineAgents.length === 0) {
-    return null;
+    return { agent: null, availabilitySummary };
   }
 
   const existing = await prisma.agentAssignment.findMany({
@@ -58,14 +98,14 @@ export async function getNextAgent(
     orderBy: { lastAssignedAt: "asc" },
   });
   if (!nextAssignment) {
-    return null;
+    return { agent: null, availabilitySummary };
   }
 
   const nextAgent = onlineAgents.find(
     (a) => a.id === nextAssignment.agentId
   );
   if (!nextAgent) {
-    return null;
+    return { agent: null, availabilitySummary };
   }
 
   await prisma.agentAssignment.update({
@@ -78,7 +118,7 @@ export async function getNextAgent(
     data: { lastAssignedAt: new Date() },
   });
 
-  return nextAgent;
+  return { agent: nextAgent, availabilitySummary };
 }
 
 export async function setActiveConversation(

--- a/tests/chatwootWebhook.test.js
+++ b/tests/chatwootWebhook.test.js
@@ -69,7 +69,14 @@ const {
 } = require('../config/guardrailMessages.ts');
 
 const agentRotation = require('../lib/agentRotation.ts');
-const getNextAgentMock = mock.method(agentRotation, 'getNextAgent', async () => null);
+const getNextAgentMock = mock.method(
+  agentRotation,
+  'getNextAgent',
+  async () => ({
+    agent: null,
+    availabilitySummary: { online: 0, busy: 0, offline: 0 },
+  })
+);
 const setActiveConversationMock = mock.method(agentRotation, 'setActiveConversation', async () => {});
 
 const handoff = require('../lib/handoff.ts');
@@ -148,6 +155,10 @@ function resetMocks() {
   getProviderMock.mock.resetCalls();
   providerFnMock.mock.resetCalls();
   getNextAgentMock.mock.resetCalls();
+  getNextAgentMock.mock.mockImplementation(async () => ({
+    agent: null,
+    availabilitySummary: { online: 0, busy: 0, offline: 0 },
+  }));
   setActiveConversationMock.mock.resetCalls();
   handOffMock.mock.resetCalls();
   enqueueRequestMock.mock.resetCalls();
@@ -570,7 +581,10 @@ test('chatwoot status webhook skips release when no assignee', async () => {
 });
 
 test('chatwoot webhook escalates when agent available', async () => {
-  getNextAgentMock.mock.mockImplementationOnce(async () => ({ id: 10, role: 'agent' }));
+  getNextAgentMock.mock.mockImplementationOnce(async () => ({
+    agent: { id: 10, role: 'agent', availability_status: 'online' },
+    availabilitySummary: { online: 1, busy: 0, offline: 0 },
+  }));
   getConversationMock.mock.mockImplementationOnce(async () => ({ id: 1, status: 'resolved', inbox_id: 1 }));
   const payload = {
     event: 'message_created',
@@ -607,8 +621,11 @@ test('chatwoot webhook escalates when agent available', async () => {
   resetMocks();
 });
 
-test('chatwoot webhook queues request when no agent available', async () => {
-  getNextAgentMock.mock.mockImplementationOnce(async () => null);
+test('chatwoot webhook queues request when agents busy', async () => {
+  getNextAgentMock.mock.mockImplementationOnce(async () => ({
+    agent: null,
+    availabilitySummary: { online: 0, busy: 3, offline: 1 },
+  }));
   getConversationMock.mock.mockImplementationOnce(async () => ({ id: 2, status: 'resolved', inbox_id: 1 }));
   const payload = {
     event: 'message_created',
@@ -635,7 +652,10 @@ test('chatwoot webhook queues request when no agent available', async () => {
   assert.deepStrictEqual(enqueueRequestMock.mock.calls[0].arguments, [2, 2, undefined, undefined, 1]);
   assert.strictEqual(setConversationLabelsMock.mock.calls.length, 1);
   assert.deepStrictEqual(setConversationLabelsMock.mock.calls[0].arguments[2], [CONVO_LABELS.waiting]);
-  assert.strictEqual(sendBotMessageMock.mock.calls[0].arguments[2], 'All human agents are currently busy. Please wait for the next available agent.');
+  assert.strictEqual(
+    sendBotMessageMock.mock.calls[0].arguments[2],
+    'All human agents are currently busy. Please wait for the next available agent.'
+  );
   assert.deepStrictEqual(sendBotMessageMock.mock.calls[0].arguments[3], {
     private: false,
     inReplyTo: 2,
@@ -645,8 +665,59 @@ test('chatwoot webhook queues request when no agent available', async () => {
   resetMocks();
 });
 
+test('chatwoot webhook queues request when agents offline', async () => {
+  getNextAgentMock.mock.mockImplementationOnce(async () => ({
+    agent: null,
+    availabilitySummary: { online: 0, busy: 0, offline: 4 },
+  }));
+  getConversationMock.mock.mockImplementationOnce(async () => ({
+    id: 3,
+    status: 'resolved',
+    inbox_id: 1,
+  }));
+  const payload = {
+    event: 'message_created',
+    data: {
+      event: 'message_created',
+      message: {
+        id: 3,
+        message_type: 0,
+        content: 'Is a human available?',
+        account: { id: 3 },
+        conversation: { id: 3, inbox_id: 1, status: 'resolved', account_id: 3 },
+      },
+    },
+  };
+  const req = new Request('http://localhost', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+  const res = await webhookPost(req);
+  const body = await res.json();
+  assert.strictEqual(body.status, 'handoff');
+  assert.strictEqual(handOffMock.mock.calls.length, 0);
+  assert.strictEqual(enqueueRequestMock.mock.calls.length, 1);
+  assert.deepStrictEqual(enqueueRequestMock.mock.calls[0].arguments, [3, 3, undefined, undefined, 1]);
+  assert.strictEqual(setConversationLabelsMock.mock.calls.length, 1);
+  assert.deepStrictEqual(setConversationLabelsMock.mock.calls[0].arguments[2], [CONVO_LABELS.waiting]);
+  assert.strictEqual(
+    sendBotMessageMock.mock.calls[0].arguments[2],
+    'No human agents are currently available. Please try again later.'
+  );
+  assert.deepStrictEqual(sendBotMessageMock.mock.calls[0].arguments[3], {
+    private: false,
+    inReplyTo: 3,
+  });
+  assert.strictEqual(getProviderMock.mock.calls.length, 0);
+  assertLoggedIds(1);
+  resetMocks();
+});
+
 test('chatwoot webhook sends fallback when enqueueRequest fails', async () => {
-  getNextAgentMock.mock.mockImplementationOnce(async () => ({ id: 10, role: 'agent' }));
+  getNextAgentMock.mock.mockImplementationOnce(async () => ({
+    agent: { id: 10, role: 'agent', availability_status: 'online' },
+    availabilitySummary: { online: 1, busy: 0, offline: 0 },
+  }));
   getConversationMock.mock.mockImplementationOnce(async () => ({ id: 1, status: 'resolved', inbox_id: 1 }));
   enqueueRequestMock.mock.mockImplementationOnce(async () => { throw new Error('fail'); });
   const payload = {
@@ -681,7 +752,10 @@ test('chatwoot webhook sends fallback when enqueueRequest fails', async () => {
 });
 
 test('chatwoot webhook sends fallback when updateRequest fails', async () => {
-  getNextAgentMock.mock.mockImplementationOnce(async () => ({ id: 10, role: 'agent' }));
+  getNextAgentMock.mock.mockImplementationOnce(async () => ({
+    agent: { id: 10, role: 'agent', availability_status: 'online' },
+    availabilitySummary: { online: 1, busy: 0, offline: 0 },
+  }));
   getConversationMock.mock.mockImplementationOnce(async () => ({ id: 1, status: 'resolved', inbox_id: 1 }));
   handOffMock.mock.mockImplementationOnce(async () => false);
   updateRequestMock.mock.mockImplementationOnce(async () => { throw new Error('fail'); });


### PR DESCRIPTION
## Summary
- fetch full agent list, compute availability counts, and return them alongside the selected agent
- use the availability summary in the Chatwoot webhook to pick online, busy, or offline messaging for escalations
- adjust webhook tests and mocks to cover both busy and offline fallbacks with the new return shape

## Testing
- npm test -- tests/chatwootWebhook.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dc2fae94b083338d893e972f6d63be